### PR TITLE
Hmc7044 fix cmos settings

### DIFF
--- a/adidt/parts/hmc7044.py
+++ b/adidt/parts/hmc7044.py
@@ -38,6 +38,23 @@ class hmc7044_dt(dt, clock_dt):
         "VCO_CLOCK" : 4,
     }
 
+    cmos_outputs_reg_field_map = {
+        0 : {"P" : 1, "N" : 0},
+        1 : {"P" : 0, "N" : 1},
+        2 : {"P" : 0, "N" : 1},
+        3 : {"P" : 1, "N" : 0},
+        4 : {"P" : 0, "N" : 1},
+        5 : {"P" : 1, "N" : 0},
+        6 : {"P" : 1, "N" : 0},
+        7 : {"P" : 0, "N" : 1},
+        8 : {"P" : 0, "N" : 1},
+        9 : {"P" : 1, "N" : 0},
+        10 : {"P" : 1, "N" : 0},
+        11 : {"P" : 0, "N" : 1},
+        12 : {"P" : 0, "N" : 1},
+        13 : {"P" : 1, "N" : 0},
+    }
+
     def set_clock_node(self, parent, clk, name, reg):
         node = fdt.Node(f"channel@{reg}")
 
@@ -76,7 +93,8 @@ class hmc7044_dt(dt, clock_dt):
 
         # in CMOS mode, the impedance property describes the output status
         if ("CMOS" in clk):
-            prop_val = clk["CMOS"]["P"] + (clk["CMOS"]["N"] << 1)
+            prop_val = (clk["CMOS"]["P"] << self.cmos_outputs_reg_field_map[reg]["P"])
+            propval = prop_val | (clk["CMOS"]["N"] << self.cmos_outputs_reg_field_map[reg]["N"])
             node.append(fdt.PropWords("adi,driver-impedance-mode", prop_val))
 
         parent.append(node)

--- a/test/hmc7044/test_hmc7044.py
+++ b/test/hmc7044/test_hmc7044.py
@@ -26,7 +26,7 @@ def test_hmc7044_add_nodes():
             "FPGA": {"divider": 6, "rate": 500000000.0, "driver-mode": "CML",
                 "fine-delay": 16, "coarse-delay": 5},
             "SYSREF": {"divider": 384, "rate": 7812500.0, "driver-mode": "CMOS",
-                "CMOS": {"P" : 0, "N" : 1}},
+                "CMOS": {"P" : 1, "N" : 0}},
         },
         "r2": 2,
     }
@@ -136,7 +136,9 @@ def test_hmc7044_add_nodes():
 
         if "CMOS" in output_dict:
             impedance_prop_val = output_node.get_property("adi,driver-impedance-mode").value
-            impedance_prop_dict = output_dict["CMOS"]["P"] + (output_dict["CMOS"]["N"] << 1)
+            val_p = (output_dict["CMOS"]["P"] << dt.hmc7044_dt.cmos_outputs_reg_field_map[i]["P"])
+            val_n = (output_dict["CMOS"]["N"] << dt.hmc7044_dt.cmos_outputs_reg_field_map[i]["N"])
+            impedance_prop_dict = val_p | val_n
             assert impedance_prop_val == impedance_prop_dict
 
     # d.write_out_dts("test.dts")


### PR DESCRIPTION
CMOS outputs have been tested and they were enabled in the wrong way. This PR aims to fix that.

ad224e7456db - test: hmc7044: Fix CMOS checks
21abba9c64f0 - hmc7044: fix CMOS settings