### PR TITLE
some hmc7044 fixes

### DIFF
--- a/adidt/parts/hmc7044.py
+++ b/adidt/parts/hmc7044.py
@@ -146,13 +146,8 @@ class hmc7044_dt(dt, clock_dt):
 
             node.set_property("adi,pll1-ref-prio-ctrl", ref_order_val)
 
-        # Set PLL frequency using one of the output clocks
-        k1 = list(clock["output_clocks"].keys())
-        c = clock["output_clocks"][k1[0]]
-        p2f = c["divider"] * c["rate"]
-        if math.trunc(p2f) != p2f:
-            raise Exception("Floats not supported")
-        node.set_property("adi,pll2-output-frequency", int(p2f))
+        # Set PLL frequency
+        node.set_property("adi,pll2-output-frequency", int(clock["vco"]))
         if not append:
             # Clear existing nodes
             nn = [sn.name for sn in node.nodes]

--- a/adidt/parts/hmc7044.py
+++ b/adidt/parts/hmc7044.py
@@ -139,8 +139,8 @@ class hmc7044_dt(dt, clock_dt):
             priority = 0
             # MSB (Fourth priority input [1:0]) .... (First priority input [1:0]) LSB
             for ref_nr in clock["reference_selection_order"]:
-                if (ref_nr > 4):
-                    raise Exception("Refernce number:" + str(ref_nr) + " invalid.")
+                if (ref_nr >= 4):
+                    raise Exception("Reference number:" + str(ref_nr) + " invalid.")
                 ref_order_val |= (ref_nr << (priority * 2))
                 priority += 1
 

--- a/test/hmc7044/test_hmc7044.py
+++ b/test/hmc7044/test_hmc7044.py
@@ -11,6 +11,7 @@ def test_hmc7044_add_nodes():
     d = dt.hmc7044_dt(dt_source="local_file", local_dt_filepath=dtb, arch="arm64")
 
     clock = {
+        "vco": 125000000 * 2,
         "reference_frequencies" : [38400000, 38400000, 38400000, 38400000],
         "reference_selection_order" : [0, 3, 2, 1],
         "n2": 24,


### PR DESCRIPTION
This PR adds some fixes to the hmc7044 part related with the input reference priorities selection and PLL2 frequency setting (when taken from pyadi-jif for example).