### PR TITLE
Remove rustc requirement for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,14 @@ jobs:
         architecture: x64
     - run: pip install -r requirements/requirements_dev.txt
     - run: pytest -vs
+
+  kuiper-test:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:bullseye
+    steps:
+    - uses: actions/checkout@v2
+    - run: apt update
+    - run: apt install -y python3-pip python3-dev
+    - run: pip install -r requirements/requirements_dev.txt
+    - run: pytest -vs

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,6 +1,7 @@
 Click
 fdt
 fabric
+bcrypt==3.2.2
 rich
 numpy
 pytest

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     include_package_data=True,
     package_data={"adidt": ["templates/*.tmpl"]},
     py_modules=["adidt"],
-    install_requires=["Click", "fdt", "fabric", "rich", "numpy"],
+    install_requires=["Click", "fdt", "fabric", "bcrypt==3.2.2", "rich", "numpy"],
     entry_points={
         "console_scripts": [
             "adidtc = adidt.cli.main:cli",


### PR DESCRIPTION
PR fixes bcrypt to 3.2.2 as 4.0.0 requires a modern rust which isn't available on Kuiper yet