### PR TITLE
adidt/templates/adrv9009_zu11eg.dts: Fix tx loop-back-adc-profile

### DIFF
--- a/adidt/templates/adrv9009_zu11eg.dts
+++ b/adidt/templates/adrv9009_zu11eg.dts
@@ -202,7 +202,7 @@
 	adi,tx-profile-tx-input-rate_khz = <{{ tx['txInputRate_kHz'] }}>;
 	adi,tx-profile-tx-int5-interpolation = <{{ tx['txInt5Interpolation'] }}>;
 	adi,tx-profile-tx-fir-coefs = /bits/ 16  <{{ tx['filter']['coefs'] }}>;
-	adi,tx-profile-loop-back-adc-profile = /bits/ 16 <{{ tx['filter']['coefs'] }}>;
+	adi,tx-profile-loop-back-adc-profile = /bits/ 16 <{{ lpbk['lpbkAdcProfile']['coefs'] }}>;
 
 	adi,dig-clocks-clk-pll-hs-div = <{{ clocks['clkPllHsDiv'] }}>;
 	adi,dig-clocks-clk-pll-vco-freq_khz = <{{ clocks['clkPllVcoFreq_kHz'] }}>;


### PR DESCRIPTION
Use lpbkAdcProfile instead of FIR filter coefs