### PR TITLE
feat(hw): ADRV9371 ILAS+DMA fix; new ZC706/VCU118 overlay tests

### DIFF
--- a/adidt/model/board_model.py
+++ b/adidt/model/board_model.py
@@ -48,6 +48,12 @@ class JesdLinkModel:
             ``L``, ``Np``, ``S``.
         dma_clocks_str: Optional ``clocks`` cells-string for the DMA
             overlay (inserted verbatim into the emitted overlay).
+        dma_interrupts_str: Optional ``interrupts`` cells-string for
+            the DMA overlay.  When set, the renderer emits a
+            ``/delete-property/ interrupts;`` followed by an
+            ``interrupts = ...;`` re-assignment.  Use this when the
+            sdtgen-generated IRQ number does not match the IRQ wire
+            in the loaded bitstream.
         xcvr_rendered, jesd_overlay_rendered, tpl_core_rendered:
             Pre-rendered DTS strings for the three FPGA-side IP
             overlays.  Produced by :mod:`adidt.devices.fpga_ip`.
@@ -60,6 +66,7 @@ class JesdLinkModel:
     dma_label: str | None
     link_params: dict[str, int] = field(default_factory=dict)
     dma_clocks_str: str | None = None
+    dma_interrupts_str: str | None = None
     xcvr_rendered: str | None = None
     jesd_overlay_rendered: str | None = None
     tpl_core_rendered: str | None = None

--- a/adidt/model/renderer.py
+++ b/adidt/model/renderer.py
@@ -95,5 +95,8 @@ class BoardModelRenderer:
         ]
         if link.dma_clocks_str:
             lines.append(f"\t\tclocks = {link.dma_clocks_str};")
+        if link.dma_interrupts_str:
+            lines.append("\t\t/delete-property/ interrupts;")
+            lines.append(f"\t\tinterrupts = {link.dma_interrupts_str};")
         lines.append("\t};")
         return "\n".join(lines)

--- a/adidt/xsa/builders/adrv937x.py
+++ b/adidt/xsa/builders/adrv937x.py
@@ -344,19 +344,25 @@ class ADRV937xBuilder:
                 '"jesd_rx_clk", "jesd_tx_clk", '
                 '"dev_clk", "fmc_clk", "sysref_dev_clk", "sysref_fmc_clk"'
             )
-        # Match Kuiper's working topology: AD9371 → JESD cores → xcvrs
-        # → AD9528 (terminal sysref provider).  AD9371's
-        # jesd204-inputs points at the three JESD cores, not the
-        # xcvrs — the walker traverses the graph via each JESD core's
-        # own ``jesd204-inputs = <xcvr …>`` and then each xcvr's
-        # ``jesd204-inputs = <AD9528 …>``, reaching the sysref
-        # provider through the correct chain.
+        # Match Kuiper's working FSM-mode topology
+        # (``zynq-zc706-adv7511-adrv9371-jesd204-fsm.dts``):
+        # AD9371 → {RX JESD core, RX_OBS JESD core, TX TPL DAC core}
+        # → ... → xcvrs → AD9528 (terminal sysref provider).
+        # The TX side passes through the TPL DAC core
+        # (``axi_ad9371_core_tx`` upstream / ``tx_core_label`` here)
+        # before reaching the JESD-TX core, so cf_axi_dds's
+        # ``jesd204_post_running_stage`` callback runs and emits the
+        # ``cf_axi_dds_start_sync`` that arms the DAC data path —
+        # without it the JESD-TX framer transmits no valid 8b/10b
+        # symbols and the AD9371 deframer never decodes an ILAS
+        # sequence (mismatch mask 0xc7f8 + deframerStatus 0x21 with
+        # FS-lost set / valid-checksum clear).
         if rx_os_jesd_label and rx_os_xcvr_label:
             trx_link_ids_value = f"{tx_link_id} {rx_link_id} {rx_os_link_id}"
             trx_inputs_value = (
                 f"<&{rx_jesd_label} 0 {rx_link_id}>, "
                 f"<&{rx_os_jesd_label} 0 {rx_os_link_id}>, "
-                f"<&{tx_jesd_label} 0 {tx_link_id}>"
+                f"<&{tx_core_label} 0 {tx_link_id}>"
             )
         else:
             ad9528_sysref_link_id = 2
@@ -469,6 +475,27 @@ class ADRV937xBuilder:
             else None
         )
 
+        # IRQ overrides for the AXI DMACs:
+        # The sdtgen-generated DT extracts ``interrupts = <0 31 4>``
+        # (rx), ``<0 32 4>`` (tx), ``<0 33 4>`` (rx_obs) from the XSA
+        # — but the bitstream loaded from Kuiper's
+        # ``release:zynq-zc706-adv7511-adrv937x/BOOT.BIN`` actually
+        # routes those IRQ wires to SPI 57 / 56 / 55 (= GIC IRQ
+        # 89 / 88 / 87).  Confirmed on bq by reading
+        # ``GICD ICDISPR[2] = 0x02000000`` (IRQ 89 pending) while the
+        # DMAC asserted its IRQ output (``IRQ_PENDING=0x3``,
+        # ``TRANSFER_DONE=3``) but ``/proc/interrupts`` for the
+        # DT-declared IRQ stayed at 0.  Override to match Kuiper's
+        # reference DT (``zynq-zc706-adv7511-adrv9371.dts``).
+        # SPI 57/56 = GIC IRQ 89/88. ``4`` = ``IRQ_TYPE_LEVEL_HIGH``
+        # written as a literal so the overlay DTSO doesn't need the
+        # ``<dt-bindings/interrupt-controller/irq.h>`` include.
+        # (rx_obs DMA is SPI 55 / GIC IRQ 87 if/when that path is
+        # wired up — currently OBS is gated by a separate
+        # missing-#dma-cells issue at the OBS TPL ADC node.)
+        rx_dma_interrupts = "<0 57 4>"
+        tx_dma_interrupts = "<0 56 4>"
+
         jesd_links = [
             JesdLinkModel(
                 direction="rx",
@@ -477,6 +504,7 @@ class ADRV937xBuilder:
                 dma_label=rx_dma_label,
                 core_label=rx_core_label,
                 link_params={"F": rx_f, "K": rx_k},
+                dma_interrupts_str=rx_dma_interrupts,
                 jesd_overlay_rendered=rx_jesd_overlay,
             ),
             JesdLinkModel(
@@ -486,6 +514,7 @@ class ADRV937xBuilder:
                 dma_label=tx_dma_label,
                 core_label=tx_core_label,
                 link_params={"F": tx_octets_per_frame, "K": tx_k, "M": tx_m},
+                dma_interrupts_str=tx_dma_interrupts,
                 jesd_overlay_rendered=tx_jesd_overlay,
             ),
         ]
@@ -572,11 +601,20 @@ class ADRV937xBuilder:
         rx_core_second = (
             f"\t&{rx_core_label} {{\n\t\tspibus-connected = <&{phy_label}>;\n\t}};"
         )
+        # FSM-mode: TPL DAC core is the AD9371's TX-link entry into
+        # the JESD204 graph.  ``jesd204-inputs`` chains it to the
+        # AXI JESD-TX core so the framework walks
+        # AD9371 → TPL DAC → JESD-TX → xcvr → AD9528.  Matches
+        # ``&axi_ad9371_core_tx`` overrides in
+        # ``zynq-zc706-adv7511-adrv9371-jesd204-fsm.dts``.
         tx_core_second = (
             f"\t&{tx_core_label} {{\n"
             f"\t\tspibus-connected = <&{phy_label}>;\n"
             f"\t\tclocks = <&{phy_label} 2>;\n"
             '\t\tclock-names = "sampl_clk";\n'
+            "\t\tjesd204-device;\n"
+            "\t\t#jesd204-cells = <2>;\n"
+            f"\t\tjesd204-inputs = <&{tx_jesd_label} 0 {tx_link_id}>;\n"
             "\t};"
         )
         # RX_OBS TPL core overlay — converts sdtgen's

--- a/test/hw/hw_helpers.py
+++ b/test/hw/hw_helpers.py
@@ -212,6 +212,20 @@ def compile_dts_to_dtb(dts_path: Path, dtb_path: Path) -> None:
         raise RuntimeError(f"dtc failed:\n{res.stderr}")
 
 
+def stage_dtb_as_devicetree(dtb: Path, staging_dir: Path) -> Path:
+    """Copy *dtb* into *staging_dir* renamed to ``devicetree.dtb``.
+
+    The Zynq-7000 ``BootFPGASoCTFTP`` driver in the ``bq`` and ``nemo``
+    labgrid environments hard-codes ``dtb_image_name: devicetree.dtb`` —
+    the file must have that exact basename when it lands in the TFTP
+    root for U-Boot's ``tftp devicetree.dtb`` to find it.
+    """
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    staged = staging_dir / "devicetree.dtb"
+    shutil.copyfile(dtb, staged)
+    return staged
+
+
 def compile_dtso_to_dtbo(dtso_path: Path, dtbo_path: Path) -> None:
     """Compile a DTS overlay to a DTBO binary.
 

--- a/test/hw/test_adrv9371_zc706_hw.py
+++ b/test/hw/test_adrv9371_zc706_hw.py
@@ -17,7 +17,6 @@ LG_ENV: lg_adrv9371_zc706_tftp.yaml
 from __future__ import annotations
 
 import os
-import shutil
 from pathlib import Path
 
 import pytest
@@ -47,24 +46,13 @@ from test.hw.hw_helpers import (  # noqa: E402
     parse_ilas_status,
     read_jesd_status,
     shell_out,
+    stage_dtb_as_devicetree,
 )
 
 
 DEFAULT_KUIPER_RELEASE = "2023_R2_P1"
 DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv937x"
 DEFAULT_VCXO_HZ = 122_880_000
-
-
-def _stage_dtb_as_devicetree(dtb: Path, staging_dir: Path) -> Path:
-    """Copy *dtb* into *staging_dir* renamed to ``devicetree.dtb``.
-
-    BootFPGASoCTFTP's YAML sets ``dtb_image_name: devicetree.dtb`` — the
-    file must have that exact basename when it lands in the TFTP root.
-    """
-    staging_dir.mkdir(parents=True, exist_ok=True)
-    staged = staging_dir / "devicetree.dtb"
-    shutil.copyfile(dtb, staged)
-    return staged
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +132,7 @@ def test_adrv9371_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
     # --- 4. Compile to DTB, stage as devicetree.dtb ---
     dtb_raw = out_dir / "adrv9371_zc706.dtb"
     compile_dts_to_dtb(merged_dts, dtb_raw)
-    dtb = _stage_dtb_as_devicetree(dtb_raw, out_dir / "tftp_staging_xsa")
+    dtb = stage_dtb_as_devicetree(dtb_raw, out_dir / "tftp_staging_xsa")
 
     # --- 5. Deploy + boot ---
     shell = deploy_and_boot(board, dtb, built_kernel_image_zynq)

--- a/test/hw/xsa/test_adrv9371_zc706_overlay.py
+++ b/test/hw/xsa/test_adrv9371_zc706_overlay.py
@@ -1,0 +1,548 @@
+"""ADRV9371 + ZC706 runtime device-tree overlay hardware test.
+
+Mirrors :mod:`test.hw.xsa.test_adrv9009_zc706_overlay` for the ZC706 +
+ADRV9371-FMC daughter card on the ``bq`` labgrid place.  Same six-test
+shape (unit, configfs, load, DMA, unload, reload), same configfs
+lifecycle, same dmesg-delta error gating.
+
+Differences from the ADRV9009 variant:
+
+1. **Profile transport** — ADRV9371 uses the Mykonos firmware
+   architecture; the per-radio configuration is baked into the DT as
+   ``adi,*-profile-*`` / ``adi,clocks-*`` properties on
+   ``ad9371-phy@1`` at probe time (see ``adrv937x_zc706.json`` and
+   :mod:`adidt.xsa.builders.adrv937x`).  There is no runtime
+   ``profile_config`` sysfs equivalent, so the DMA test does not push
+   a profile after overlay apply — the radio is already configured by
+   the merged base DTB before the overlay is applied.
+2. **DMA path** — ZC706 + ADRV9371 reference HDL has no internal
+   DAC→ADC loopback, same as ADRV9009.  Phase 1 (mandatory) asserts
+   non-zero, non-latched RX samples via :func:`assert_rx_capture_valid`.
+   Phase 2 (opportunistic) computes an FFT to look for a coherent
+   tone if a TX→RX SMA cable is wired on the FMC; absence of a peak
+   is logged but not a failure.
+
+Two distinct bring-up blockers were debugged and fixed during this
+test's development against the ``release:zynq-zc706-adv7511-adrv937x``
+bitstream that ``bq`` loads:
+
+1. **ILAS framing mismatch** (``mismatch=0xc7f8``, 9 framing fields
+   disagreeing) — the AD9371 deframer's "received-ILAS" registers
+   were stale zeros because the FPGA TX framer never emitted a valid
+   ILAS sequence.  Root cause: the TPL DAC core
+   (``axi_ad9371_core_tx`` upstream) was missing from the JESD204
+   topology graph, so ``cf_axi_dds_jesd204_post_running_stage`` /
+   ``cf_axi_dds_start_sync`` never armed the DAC data path.  Fixed
+   in ``adidt/xsa/builders/adrv937x.py`` ``tx_core_second`` block
+   (adds ``jesd204-device`` / ``#jesd204-cells`` / ``jesd204-inputs``
+   on the TPL DAC core) and the redirected ``trx_inputs_value``
+   pointing the AD9371 phy at the TPL DAC core for its TX link.
+
+2. **AXI DMAC IRQ number wrong in DT** — sdtgen extracted SPI 31/32
+   from the XSA but the loaded bitstream actually wires the DMAC IRQ
+   wires to SPI 57/56 (= GIC IRQ 89/88).  Confirmed on bq: DMAC
+   ``TRANSFER_DONE`` incremented and ``GICD ICDISPR[2]`` had bit 25
+   set (= IRQ 89 pending) while the DT-declared IRQ stayed at 0 in
+   ``/proc/interrupts``.  Manually injecting IRQ 63 via
+   ``GICD+0x204`` correctly fired the registered handler — proving
+   the kernel's IRQ machinery worked, only the DT-declared IRQ
+   number was wrong.  Fixed in the same builder by setting
+   ``dma_interrupts_str`` on the RX/TX ``JesdLinkModel``s; the
+   ``_render_dma_overlay`` then emits a ``/delete-property/
+   interrupts;`` + ``interrupts = <0 57 4>`` (RX) / ``<0 56 4>``
+   (TX) override matching the upstream Kuiper reference DT.
+
+LG_ENV: ``test/hw/env/bq.yaml``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from adidt.xsa.pipeline import XsaPipeline
+from adidt.xsa.topology import XsaParser
+from test.hw.hw_helpers import (
+    acquire_xsa,
+    assert_configfs_overlay_support,
+    assert_jesd_links_data,
+    assert_no_kernel_faults,
+    assert_no_probe_errors,
+    assert_rx_capture_valid,
+    check_jesd_framing_plausibility,
+    compile_dts_to_dtb,
+    compile_dtso_to_dtbo,
+    deploy_and_boot,
+    deploy_dtbo_via_shell,
+    load_overlay,
+    open_iio_context,
+    overlay_is_loaded,
+    shell_out,
+    stage_dtb_as_devicetree,
+    unload_overlay,
+)
+
+_HAS_LG = bool(os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV"))
+requires_lg = pytest.mark.skipif(
+    not _HAS_LG,
+    reason=(
+        "set LG_COORDINATOR or LG_ENV for ADRV9371 ZC706 overlay hardware tests"
+        " (see .env.example)"
+    ),
+)
+
+DEFAULT_KUIPER_RELEASE = "2023_R2_P1"
+DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv937x"
+DEFAULT_VCXO_HZ = 122_880_000
+
+OVERLAY_NAME = "adrv9371_zc706_xsa"
+DTBO_REMOTE_PATH = f"/tmp/{OVERLAY_NAME}.dtbo"
+FDT_MAGIC = b"\xd0\x0d\xfe\xed"
+
+DDS_TONE_HZ = 1_000_000
+DDS_SCALE = 0.5
+RX_BUFFER_SIZE = 2**14
+
+EXPECTED_IIO_NAMES_ANY = (
+    "axi-ad9371-rx-hpc",
+    "ad_ip_jesd204_tpl_adc",
+)
+EXPECTED_IIO_NAMES_ALL = ("ad9528-1", "ad9371-phy")
+
+
+def _adrv9371_cfg() -> dict[str, Any]:
+    """ADRV9371+ZC706 XSA pipeline cfg.
+
+    Lifted verbatim from :mod:`test.hw.test_adrv9371_zc706_hw` so the
+    XSA pipeline path the overlay test exercises is identical to the
+    one the full-DTB system test exercises — any framing or GPIO
+    drift between the two stays a single edit.
+
+    JESD framing matches the Kuiper reference design
+    ``zynq-zc706-adv7511-adrv937x``: RX = M=4 L=2 S=1 → F=4;
+    TX = M=4 L=4 S=1 → F=2 (per ``analogdevicesinc/hdl/projects/
+    adrv9371x/zc706/README``).  Mykonos profile properties come from
+    ``adidt/xsa/profiles/adrv937x_zc706.json`` and are not duplicated
+    here.
+    """
+    cfg: dict[str, Any] = {
+        "adrv9009_board": {
+            "misc_clk_hz": 122_880_000,
+            "spi_bus": "spi0",
+            "clk_cs": 0,
+            "trx_cs": 1,
+            "trx_reset_gpio": 106,
+            "trx_sysref_req_gpio": 112,
+            "ad9528_reset_gpio": 113,
+            "ad9528_vcxo_freq": DEFAULT_VCXO_HZ,
+            "rx_link_id": 1,
+            "tx_link_id": 0,
+        },
+        "jesd": {
+            "rx": {"F": 4, "K": 32, "M": 4, "L": 2},
+            "tx": {"F": 2, "K": 32, "M": 4, "L": 4},
+        },
+    }
+    framing_warnings = check_jesd_framing_plausibility(cfg["jesd"])
+    assert not framing_warnings, (
+        "JESD cfg is structurally inconsistent (will fail ILAS):\n  "
+        + "\n  ".join(framing_warnings)
+    )
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def pipeline_result(tmp_path_factory) -> dict:
+    """Run :class:`XsaPipeline` once per module and return its output dict."""
+    local_xsa = Path(__file__).parent / "system_top_adrv9371_zc706.xsa"
+    try:
+        xsa_path = acquire_xsa(
+            local_xsa,
+            DEFAULT_KUIPER_RELEASE,
+            DEFAULT_KUIPER_PROJECT,
+            tmp_path_factory.mktemp("xsa_dl"),
+        )
+    except Exception as exc:  # noqa: BLE001 — any download/IO failure → skip
+        pytest.skip(f"could not acquire ADRV9371+ZC706 XSA: {exc}")
+
+    topology = XsaParser().parse(xsa_path)
+    assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
+    assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
+
+    out_dir = tmp_path_factory.mktemp("overlay") / "out"
+    return XsaPipeline().run(
+        xsa_path=xsa_path,
+        cfg=_adrv9371_cfg(),
+        output_dir=out_dir,
+        profile="adrv937x_zc706",
+        sdtgen_timeout=300,
+    )
+
+
+@pytest.fixture(scope="module")
+def overlay_dtbo(pipeline_result, tmp_path_factory) -> Path:
+    """Compile the pipeline ``.dtso`` to ``.dtbo`` (module-scoped, once)."""
+    overlay_src: Path = pipeline_result["overlay"]
+    assert overlay_src.exists(), f"pipeline did not emit overlay DTSO: {overlay_src}"
+
+    dtbo_dir = tmp_path_factory.mktemp("dtbo")
+    dtbo = dtbo_dir / f"{OVERLAY_NAME}.dtbo"
+    compile_dtso_to_dtbo(overlay_src, dtbo)
+
+    assert dtbo.exists(), f"dtc -@ did not produce DTBO: {dtbo}"
+    size = dtbo.stat().st_size
+    assert size > 100, f"DTBO suspiciously small ({size} bytes): {dtbo}"
+    magic = dtbo.read_bytes()[:4]
+    assert magic == FDT_MAGIC, f"DTBO missing FDT magic (got {magic.hex()}): {dtbo}"
+    return dtbo
+
+
+@pytest.fixture(scope="module")
+def booted_board(
+    board, built_kernel_image_zynq, pipeline_result, overlay_dtbo, tmp_path_factory
+):
+    """Boot ZC706 with the pipeline's merged DTB and stage the ``.dtbo``.
+
+    Same rationale as the ADRV9009 ZC706 overlay test: the merged DTB
+    has the AD9528 + AD9371 SPI nodes already in place, so the overlay
+    exercises the configfs lifecycle on top of an already-probed tree
+    without inheriting unrelated stock-image boot issues.
+
+    The DTB is renamed to ``devicetree.dtb`` because
+    :class:`BootFPGASoCTFTP` (configured in ``test/hw/env/bq.yaml``)
+    sets ``dtb_image_name: devicetree.dtb`` — the file U-Boot's
+    ``tftp devicetree.dtb`` looks up in the TFTP root.
+    """
+    out_dir = tmp_path_factory.mktemp("merged_boot")
+    merged_dts = pipeline_result["merged"]
+    dtb_raw = out_dir / "adrv9371_zc706_xsa.dtb"
+    compile_dts_to_dtb(merged_dts, dtb_raw)
+
+    staged = stage_dtb_as_devicetree(dtb_raw, out_dir / "tftp_staging")
+
+    shell = deploy_and_boot(board, staged, built_kernel_image_zynq)
+
+    deploy_dtbo_via_shell(shell, overlay_dtbo, DTBO_REMOTE_PATH)
+
+    if overlay_is_loaded(shell, OVERLAY_NAME):
+        unload_overlay(shell, OVERLAY_NAME)
+
+    return board
+
+
+def _shell(booted):
+    return booted.target.get_driver("ADIShellDriver")
+
+
+def _ensure_unloaded(shell) -> None:
+    if overlay_is_loaded(shell, OVERLAY_NAME):
+        unload_overlay(shell, OVERLAY_NAME)
+        time.sleep(2.0)
+
+
+def _apply_and_wait(shell) -> None:
+    res = load_overlay(shell, OVERLAY_NAME, DTBO_REMOTE_PATH)
+    assert "RC=0" in res, f"overlay load failed: {res}"
+    # Mykonos re-init after overlay apply takes longer than the AD9081
+    # path; give the JESD FSM time to walk SYNC -> ILAS -> DATA before
+    # any sysfs check.
+    time.sleep(8.0)
+
+
+def _assert_iio_devices_present(ctx, *, context: str) -> None:
+    found = {d.name for d in ctx.devices if d.name}
+    suffix = f" ({context})" if context else ""
+    for required in EXPECTED_IIO_NAMES_ALL:
+        assert required in found, (
+            f"IIO device {required!r} not present{suffix}. Devices: {sorted(found)}"
+        )
+    assert any(n in found for n in EXPECTED_IIO_NAMES_ANY), (
+        f"AD9371 RX frontend not present{suffix}. "
+        f"Expected one of {EXPECTED_IIO_NAMES_ANY}; "
+        f"found: {sorted(found)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_generation_unit(pipeline_result, overlay_dtbo):
+    """No-hardware check: the pipeline's DTSO is a valid overlay + compiles."""
+    dtso: Path = pipeline_result["overlay"]
+    src = dtso.read_text()
+    assert "/plugin/;" in src, (
+        f"Pipeline overlay missing /plugin/; directive — "
+        f"dtc -@ will not treat it as an overlay: {dtso}"
+    )
+    assert "ad9371" in src.lower() or "axi-jesd204" in src, (
+        f"Pipeline overlay does not reference ADRV9371 / JESD nodes: {dtso}"
+    )
+    assert overlay_dtbo.exists() and overlay_dtbo.stat().st_size > 100
+
+
+@requires_lg
+@pytest.mark.lg_feature(["adrv9371", "zc706"])
+def test_configfs_overlay_support(booted_board):
+    """Target kernel must support runtime overlays via configfs."""
+    assert_configfs_overlay_support(_shell(booted_board))
+
+
+@requires_lg
+@pytest.mark.lg_feature(["adrv9371", "zc706"])
+def test_load_overlay(booted_board, tmp_path):
+    """Apply the overlay; verify clean probe, IIO discovery, and JESD DATA."""
+    shell = _shell(booted_board)
+    _ensure_unloaded(shell)
+
+    # dmesg before overlay-apply is the boot log — filter it out so we
+    # only flag errors caused by the overlay itself.
+    dmesg_baseline = int(shell_out(shell, "dmesg | wc -l").strip() or "0")
+
+    _apply_and_wait(shell)
+
+    dmesg_full = shell_out(shell, "dmesg")
+    (tmp_path / "dmesg_after_load.log").write_text(dmesg_full)
+    dmesg_new = "\n".join(dmesg_full.splitlines()[dmesg_baseline:])
+    (tmp_path / "dmesg_overlay_only.log").write_text(dmesg_new)
+    assert_no_kernel_faults(dmesg_new)
+    assert_no_probe_errors(dmesg_new)
+
+    ctx, _ = open_iio_context(shell)
+    _assert_iio_devices_present(ctx, context="after overlay load")
+
+    rx_status, tx_status = assert_jesd_links_data(shell, context="after overlay load")
+    print(f"$ cat .../*.axi?jesd204?rx/status\n{rx_status}")
+    print(f"$ cat .../*.axi?jesd204?tx/status\n{tx_status}")
+
+
+@requires_lg
+@pytest.mark.lg_feature(["adrv9371", "zc706"])
+def test_dma_loopback(booted_board):
+    """Verify DMA TX→RX data path.
+
+    Two verification phases:
+
+    * **Mandatory:** :func:`assert_rx_capture_valid` confirms that an
+      RX buffer arrives with non-zero, non-latched samples.
+    * **Opportunistic FFT:** drive a DDS tone on TX and look for a
+      coherent peak in the RX spectrum.  ZC706 + ADRV9371 reference
+      HDL has no internal DAC→ADC loopback, so without an external
+      TX→RX SMA cable on the FMC the noise-floor metric is logged
+      and the stage passes — TX→RX coupling is a lab-setup concern,
+      not an overlay-lifecycle concern.
+    """
+    pytest.importorskip("adi")
+    np = pytest.importorskip("numpy")
+
+    shell = _shell(booted_board)
+    if not overlay_is_loaded(shell, OVERLAY_NAME):
+        pytest.skip("overlay not loaded — test_load_overlay must run first")
+
+    ctx, ip = open_iio_context(shell)
+
+    # Probe TPL ADC version + force RSTN + chan-enable BEFORE capture.
+    # Earlier diagnostics showed reg 0x40 (RSTN) reading 0 even though
+    # cf_axi_adc.probe writes 0x3 — the core looks held in reset.
+    # If forcibly setting RSTN unblocks DMA, the issue is between
+    # cf_axi_adc.probe and the JESD post_running stage.
+    # Use AXI register access path — cf_axi_adc routes plain debugfs
+    # writes to the SPI converter (AD9371) by default; OR'ing
+    # 0x80000000 (DEBUGFS_DRA_PCORE_REG_MAGIC, cf_axi_adc.h:193)
+    # routes to the TPL ADC's MMIO registers.
+    # Phase 1: bare data-path smoke check.  AD9371 driver name is
+    # ``ad9371-phy``; pyadi-iio's ``adi.adrv9371`` looks up the
+    # buffered RX ADC by ``axi-ad9371-rx-hpc``.  The sdtgen-generated
+    # merged DTB labels the same buffered frontend
+    # ``ad_ip_jesd204_tpl_adc``; either is a valid capture target.
+    try:
+        assert_rx_capture_valid(
+            ctx,
+            (
+                "axi-ad9371-rx-hpc",
+                "ad_ip_jesd204_tpl_adc",
+            ),
+            n_samples=2**12,
+            context="adrv9371 zc706 overlay",
+        )
+    except AssertionError:
+        # Surface the canonical signature that distinguishes the
+        # documented HDL IRQ-wiring blocker from a real DT regression.
+        # If TRANSFER_DONE > 0 + IRQ_PENDING != 0 + GICD pending == 0
+        # + /proc/interrupts count == 0, the DMAC IRQ line is the
+        # culprit (HDL bitstream).  Anything else is a new bug.
+        print("=== DMAC HW progress (TRANSFER_DONE / IRQ_PENDING / IRQ_SOURCE) ===")
+        print(
+            shell_out(
+                shell,
+                "for off in 0x084 0x088 0x418 0x428 0x42c; do "
+                "  v=$(busybox devmem $((0x7c400000 + off)) 2>&1 | head -1); "
+                "  printf 'dmac+%s = %s\\n' $off \"$v\"; "
+                "done",
+            )
+        )
+        print("=== GIC distributor (IRQ 63 enable + pending) ===")
+        print(
+            shell_out(
+                shell,
+                # Zynq-7000 GICD at 0xF8F01000;
+                #   ICDISER1=+0x104 (enable for IRQs 32-63)
+                #   ICDISPR1=+0x204 (pending for IRQs 32-63)
+                # axi_dmac@7c400000 → SPI 31 → GIC IRQ 63 → bit 31 of word 1.
+                "for r in 0x104 0x204; do "
+                "  v=$(busybox devmem $((0xF8F01000 + r)) 2>&1 | head -1); "
+                "  printf 'GICD+%s = %s\\n' $r \"$v\"; "
+                "done",
+            )
+        )
+        print("=== /proc/interrupts (jesd + axi_dmac counts) ===")
+        print(
+            shell_out(
+                shell,
+                "grep -E 'jesd|axi_dmac' /proc/interrupts || true",
+            )
+        )
+        raise
+
+    # Phase 2: opportunistic spectrum check via pyadi-iio.
+    import adi
+
+    try:
+        dev = adi.adrv9371(uri=f"ip:{ip}")
+    except Exception as exc:  # noqa: BLE001 — connect failure → skip phase 2
+        print(f"adi.adrv9371 unavailable; skipping FFT phase: {exc}")
+        return
+    if getattr(dev, "_rxadc", None) is None:
+        print(
+            "adi.adrv9371 missing 'axi-ad9371-rx-hpc' IIO name "
+            "(merged DTB exposes 'ad_ip_jesd204_tpl_adc' instead) — "
+            "skipping FFT phase; Phase 1 already validated the data path."
+        )
+        return
+
+    dev.rx_enabled_channels = [0]
+    dev.rx_buffer_size = RX_BUFFER_SIZE
+    sample_rate = int(dev.rx_sample_rate)
+    print(f"ADRV9371 RX sample rate: {sample_rate} Hz, buffer: {RX_BUFFER_SIZE}")
+
+    try:
+        try:
+            dev.dds_single_tone(DDS_TONE_HZ, DDS_SCALE, channel=0)
+        except Exception as exc:  # noqa: BLE001 — log and continue without DDS
+            print(f"adrv9371 DDS setup failed; capturing anyway: {exc}")
+
+        for _ in range(3):
+            dev.rx()
+        raw = dev.rx()
+    except TimeoutError:
+        pytest.skip("DMA buffer refill timed out — JESD link may not be in DATA mode")
+    finally:
+        for cleanup in ("disable_dds", "rx_destroy_buffer"):
+            try:
+                getattr(dev, cleanup)()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+
+    samples = raw[0] if isinstance(raw, list) else raw
+    samples = np.asarray(samples)
+    if samples.size < 1024:
+        print(f"FFT phase: capture too short ({samples.size}); skipping spectrum check")
+        return
+
+    nfft = 1 << int(np.floor(np.log2(samples.size)))
+    trimmed = samples[:nfft]
+    win = np.hanning(nfft).astype(np.float64)
+    if np.iscomplexobj(trimmed):
+        spectrum = np.fft.fftshift(
+            np.fft.fft(trimmed.astype(np.complex128) * win, n=nfft)
+        )
+        freqs = np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / sample_rate))
+    else:
+        spectrum = np.fft.rfft(trimmed.astype(np.float64) * win, n=nfft)
+        freqs = np.fft.rfftfreq(nfft, d=1.0 / sample_rate)
+
+    mags = np.abs(spectrum)
+    fbin = sample_rate / nfft
+    nyquist = sample_rate / 2
+
+    dc_guard = 5
+    zero_idx = int(np.argmin(np.abs(freqs)))
+    nondc_mask = np.ones(mags.size, dtype=bool)
+    nondc_mask[
+        max(0, zero_idx - dc_guard) : min(mags.size, zero_idx + dc_guard + 1)
+    ] = False
+
+    search_mags = np.where(nondc_mask, mags, 0.0)
+    peak_idx = int(np.argmax(search_mags))
+    peak_mag = float(mags[peak_idx])
+    if peak_mag <= 0:
+        print("FFT phase: spectrum has no non-DC content (RX inert?)")
+        return
+    mags_db = 20.0 * np.log10(np.maximum(mags, 1e-9) / peak_mag)
+    signal_freq = float(abs(freqs[peak_idx]))
+    signal_mag_db = float(mags_db[peak_idx])
+
+    noise_mask = nondc_mask.copy()
+    lo = max(0, peak_idx - 5)
+    hi = min(mags.size, peak_idx + 6)
+    noise_mask[lo:hi] = False
+    noise_db = float(np.median(mags_db[noise_mask]))
+    snr_db = signal_mag_db - noise_db
+
+    print(
+        f"FFT phase: strongest non-DC bin {signal_freq:.0f} Hz "
+        f"({signal_mag_db:.1f} dB), noise floor {noise_db:.1f} dB, "
+        f"SNR {snr_db:.1f} dB, fbin {fbin:.0f} Hz, DDS req {DDS_TONE_HZ} Hz"
+    )
+
+    if snr_db < 10.0:
+        print(
+            "FFT phase: no coherent tone (SNR ≤ 10 dB) — recording noise-only "
+            "result and passing.  External TX↔RX coupling is a lab-setup "
+            "detail, not an overlay-lifecycle requirement."
+        )
+        return
+
+    assert signal_freq < nyquist - 10 * fbin, (
+        f"Loopback peak too close to Nyquist ({signal_freq:.0f} Hz > "
+        f"{nyquist - 10 * fbin:.0f} Hz)"
+    )
+    print(f"FFT phase: tone detected, SNR {snr_db:.1f} dB at {signal_freq:.0f} Hz")
+
+
+@requires_lg
+@pytest.mark.lg_feature(["adrv9371", "zc706"])
+def test_unload_overlay(booted_board):
+    """Removing the configfs entry tears down without kernel faults."""
+    shell = _shell(booted_board)
+    if not overlay_is_loaded(shell, OVERLAY_NAME):
+        _apply_and_wait(shell)
+
+    res = unload_overlay(shell, OVERLAY_NAME)
+    assert "RC=0" in res, f"overlay unload failed: {res}"
+    time.sleep(2.0)
+
+    assert not overlay_is_loaded(shell, OVERLAY_NAME), (
+        "overlay configfs entry still present after rmdir"
+    )
+
+    dmesg_txt = shell_out(shell, "dmesg")
+    assert_no_kernel_faults(dmesg_txt)
+
+
+@requires_lg
+@pytest.mark.lg_feature(["adrv9371", "zc706"])
+def test_reload_overlay(booted_board):
+    """Load → unload → load cycle; re-verify devices + JESD link."""
+    shell = _shell(booted_board)
+    _ensure_unloaded(shell)
+
+    _apply_and_wait(shell)
+    ctx, _ = open_iio_context(shell)
+    _assert_iio_devices_present(ctx, context="after overlay reload")
+    assert_jesd_links_data(shell, context="after overlay reload")

--- a/test/hw/xsa/test_fmcdaq3_vcu118_overlay.py
+++ b/test/hw/xsa/test_fmcdaq3_vcu118_overlay.py
@@ -1,0 +1,369 @@
+"""FMCDAQ3 + VCU118 runtime device-tree overlay hardware test.
+
+Mirrors :mod:`test.hw.xsa.test_ad9081_zcu102_overlay` for the VCU118 +
+FMCDAQ3 daughter card on the ``nuc`` labgrid place.  Same six-test
+shape (unit, configfs, load, DMA, unload, reload), same configfs
+lifecycle, same dmesg-delta error gating.
+
+Differences from the AD9081 / ADRV9009 variants:
+
+1. **Boot transport** — VCU118 runs a MicroBlaze soft CPU from the FPGA
+   fabric; there is no PS, U-Boot, SD card, or TFTP path.  Labgrid
+   drives the boot through :class:`BootFabric` + :class:`XilinxDeviceJTAG`
+   on the ``nuc`` exporter, which loads the bitstream and a
+   ``simpleImage.vcu118_fmcdaq3.strip`` (kernel + embedded DTB) over
+   JTAG.  The overlay is layered on top of the embedded DTB at runtime
+   via configfs — no DTB rebuild and no kernel-image fixture are
+   required.  The companion full-DTB smoke test
+   :mod:`test.hw.test_fmcdaq3_vcu118_hw` already validates that the
+   embedded DTB probes AD9528 + AD9680 + AD9152 cleanly and that the
+   AD9680 RX path delivers real samples; this test extends that
+   coverage with the configfs apply / unapply / reapply lifecycle.
+
+2. **Configfs gate** — Kuiper's MicroBlaze simpleImage is the most
+   likely place we will find ``CONFIG_OF_OVERLAY``/``CONFIG_OF_CONFIGFS``
+   missing.  The fixture probes
+   ``/sys/kernel/config/device-tree/overlays`` and skips the
+   lifecycle/DMA tests cleanly when absent;
+   :func:`test_configfs_overlay_support` retains its strict-assert
+   behavior so a configfs-less kernel is still an explicit failure of
+   *that* test.
+
+3. **XSA prerequisite** — the standard Kuiper boot-partition release
+   does not include a ``vcu118_fmcdaq3`` project (it only ships Zynq
+   family projects), so :func:`acquire_xsa` cannot download one.  The
+   FMCDAQ3+VCU118 ``system_top.xsa`` from the local HDL/PetaLinux
+   build must be committed to ``test/hw/xsa/system_top_fmcdaq3_vcu118.xsa``
+   before the test can run; the ``pipeline_result`` fixture
+   :func:`pytest.skip` s with a clear message until that file is
+   present.
+
+LG_ENV: ``test/hw/env/nuc.yaml``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from adidt.xsa.pipeline import XsaPipeline
+from adidt.xsa.topology import XsaParser
+from test.hw.hw_helpers import (
+    CONFIGFS_OVERLAYS,
+    assert_configfs_overlay_support,
+    assert_jesd_links_data,
+    assert_no_kernel_faults,
+    assert_no_probe_errors,
+    assert_rx_capture_valid,
+    check_jesd_framing_plausibility,
+    compile_dtso_to_dtbo,
+    deploy_dtbo_via_shell,
+    load_overlay,
+    open_iio_context,
+    overlay_is_loaded,
+    shell_out,
+    unload_overlay,
+)
+
+_HAS_LG = bool(os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV"))
+requires_lg = pytest.mark.skipif(
+    not _HAS_LG,
+    reason=(
+        "set LG_COORDINATOR or LG_ENV for FMCDAQ3 VCU118 overlay hardware tests"
+        " (see .env.example)"
+    ),
+)
+
+OVERLAY_NAME = "fmcdaq3_vcu118_xsa"
+DTBO_REMOTE_PATH = f"/tmp/{OVERLAY_NAME}.dtbo"
+FDT_MAGIC = b"\xd0\x0d\xfe\xed"
+
+DDS_TONE_HZ = 1_000_000
+DDS_SCALE = 0.5
+RX_BUFFER_SIZE = 2**14
+
+# IIO device names the FMCDAQ3 base DTB exposes.  The clock chip is
+# AD9528; the AD9680 RX frontend appears under several aliases
+# depending on whether the DTB is Kuiper-built or sdtgen-built.
+EXPECTED_IIO_NAMES_ALL = ("ad9528",)
+EXPECTED_IIO_NAMES_ANY = (
+    "axi-ad9680-hpc",
+    "axi-ad9680-rx-hpc",
+    "axi-ad9680-core-lpc",
+    "ad_ip_jesd204_tpl_adc",
+)
+
+
+def _fmcdaq3_vcu118_cfg() -> dict[str, Any]:
+    """FMCDAQ3+VCU118 XSA pipeline cfg.
+
+    The profile JSON ``adidt/xsa/profiles/fmcdaq3_vcu118.json`` already
+    supplies the full ``fmcdaq3_board`` defaults and the JESD framing
+    (RX & TX both M=2 L=4 F=1 Np=16 S=1, the FMCDAQ3 reference HDL
+    default).  We re-state the framing here only so
+    :func:`check_jesd_framing_plausibility` can sanity-check it before
+    the pipeline is run.
+    """
+    cfg: dict[str, Any] = {
+        "fmcdaq3_board": {},
+        "jesd": {
+            "rx": {"F": 1, "K": 32, "M": 2, "L": 4, "Np": 16, "S": 1},
+            "tx": {"F": 1, "K": 32, "M": 2, "L": 4, "Np": 16, "S": 1},
+        },
+    }
+    framing_warnings = check_jesd_framing_plausibility(cfg["jesd"])
+    assert not framing_warnings, (
+        "JESD cfg is structurally inconsistent (will fail ILAS):\n  "
+        + "\n  ".join(framing_warnings)
+    )
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def pipeline_result(tmp_path_factory) -> dict:
+    """Run :class:`XsaPipeline` once per module and return its output dict.
+
+    The XSA must be committed to the repo at one of the paths checked
+    below — :func:`acquire_xsa` cannot download a VCU118 / MicroBlaze
+    XSA from the standard Kuiper boot-partition release because that
+    release only ships Zynq family projects (``zynq*``, ``zynqmp*``,
+    ``versal*``).  The lab's ``simpleImage.vcu118_fmcdaq3.strip`` on
+    the ``nuc`` exporter is built from a separate HDL/PetaLinux flow
+    whose XSA is not part of Kuiper's release tarball.
+
+    Provide the XSA by copying the ``system_top.xsa`` from a local
+    ``hdl/projects/fmcdaq3/vcu118`` build (or the lab's archive of
+    that build) into ``test/hw/xsa/system_top_fmcdaq3_vcu118.xsa``.
+    """
+    candidates = (
+        Path(__file__).parent / "system_top_fmcdaq3_vcu118.xsa",
+        Path(__file__).parent / "ref_data" / "system_top_fmcdaq3_vcu118.xsa",
+    )
+    xsa_path = next((p for p in candidates if p.exists()), None)
+    if xsa_path is None:
+        pytest.skip(
+            "FMCDAQ3+VCU118 XSA fixture missing — commit the system_top.xsa "
+            f"from the FMCDAQ3 VCU118 HDL build to one of: "
+            f"{', '.join(str(p) for p in candidates)}"
+        )
+
+    topology = XsaParser().parse(xsa_path)
+    assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
+    assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
+
+    out_dir = tmp_path_factory.mktemp("overlay") / "out"
+    return XsaPipeline().run(
+        xsa_path=xsa_path,
+        cfg=_fmcdaq3_vcu118_cfg(),
+        output_dir=out_dir,
+        profile="fmcdaq3_vcu118",
+        sdtgen_timeout=300,
+    )
+
+
+@pytest.fixture(scope="module")
+def overlay_dtbo(pipeline_result, tmp_path_factory) -> Path:
+    """Compile the pipeline ``.dtso`` to ``.dtbo`` (module-scoped, once)."""
+    overlay_src: Path = pipeline_result["overlay"]
+    assert overlay_src.exists(), f"pipeline did not emit overlay DTSO: {overlay_src}"
+
+    dtbo_dir = tmp_path_factory.mktemp("dtbo")
+    dtbo = dtbo_dir / f"{OVERLAY_NAME}.dtbo"
+    compile_dtso_to_dtbo(overlay_src, dtbo)
+
+    assert dtbo.exists(), f"dtc -@ did not produce DTBO: {dtbo}"
+    size = dtbo.stat().st_size
+    assert size > 100, f"DTBO suspiciously small ({size} bytes): {dtbo}"
+    magic = dtbo.read_bytes()[:4]
+    assert magic == FDT_MAGIC, f"DTBO missing FDT magic (got {magic.hex()}): {dtbo}"
+    return dtbo
+
+
+@pytest.fixture(scope="module")
+def booted_board(board, overlay_dtbo):
+    """Drive ``BootFabric`` to shell, gate-skip on missing configfs, stage DTBO.
+
+    No merged DTB compile or kernel image fixture: the simpleImage on
+    the exporter already embeds the FMCDAQ3 base DTB.  The overlay is
+    layered on top of that pre-probed tree at runtime via configfs.
+    """
+    board.transition("shell")
+    shell = board.target.get_driver("ADIShellDriver")
+
+    res = shell_out(
+        shell,
+        f"test -d {CONFIGFS_OVERLAYS} && echo OK || echo MISSING",
+    )
+    if "OK" not in res:
+        pytest.skip(
+            "MicroBlaze kernel lacks CONFIG_OF_OVERLAY / CONFIG_OF_CONFIGFS "
+            "(simpleImage was not built with overlay support)"
+        )
+
+    deploy_dtbo_via_shell(shell, overlay_dtbo, DTBO_REMOTE_PATH)
+
+    if overlay_is_loaded(shell, OVERLAY_NAME):
+        unload_overlay(shell, OVERLAY_NAME)
+
+    return board
+
+
+def _shell(booted):
+    return booted.target.get_driver("ADIShellDriver")
+
+
+def _ensure_unloaded(shell) -> None:
+    if overlay_is_loaded(shell, OVERLAY_NAME):
+        unload_overlay(shell, OVERLAY_NAME)
+        time.sleep(2.0)
+
+
+def _apply_and_wait(shell) -> None:
+    res = load_overlay(shell, OVERLAY_NAME, DTBO_REMOTE_PATH)
+    assert "RC=0" in res, f"overlay load failed: {res}"
+    # FMCDAQ3 has fewer probe stages than the Talise/Mykonos paths;
+    # 5s is enough for AD9528 → AD9680 / AD9152 re-probe + JESD FSM
+    # to walk SYNC → ILAS → DATA.
+    time.sleep(5.0)
+
+
+def _assert_iio_devices_present(ctx, *, context: str) -> None:
+    found = {d.name for d in ctx.devices if d.name}
+    suffix = f" ({context})" if context else ""
+    for required in EXPECTED_IIO_NAMES_ALL:
+        assert required in found, (
+            f"IIO device {required!r} not present{suffix}. Devices: {sorted(found)}"
+        )
+    assert any(n in found for n in EXPECTED_IIO_NAMES_ANY), (
+        f"AD9680 RX frontend not present{suffix}. "
+        f"Expected one of {EXPECTED_IIO_NAMES_ANY}; "
+        f"found: {sorted(found)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_generation_unit(pipeline_result, overlay_dtbo):
+    """No-hardware check: the pipeline's DTSO is a valid overlay + compiles."""
+    dtso: Path = pipeline_result["overlay"]
+    src = dtso.read_text()
+    assert "/plugin/;" in src, (
+        f"Pipeline overlay missing /plugin/; directive — "
+        f"dtc -@ will not treat it as an overlay: {dtso}"
+    )
+    assert "ad9680" in src.lower() or "ad9152" in src.lower() or "axi-jesd204" in src, (
+        f"Pipeline overlay does not reference FMCDAQ3 / JESD nodes: {dtso}"
+    )
+    assert overlay_dtbo.exists() and overlay_dtbo.stat().st_size > 100
+
+
+@requires_lg
+@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
+def test_configfs_overlay_support(board):
+    """Target kernel must support runtime overlays via configfs.
+
+    Bypasses the ``booted_board`` fixture (which would skip rather than
+    fail on missing configfs) so a configfs-less simpleImage surfaces
+    here as an explicit test failure.
+    """
+    board.transition("shell")
+    shell = board.target.get_driver("ADIShellDriver")
+    assert_configfs_overlay_support(shell)
+
+
+@requires_lg
+@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
+def test_load_overlay(booted_board, tmp_path):
+    """Apply the overlay; verify clean probe, IIO discovery, and JESD DATA."""
+    shell = _shell(booted_board)
+    _ensure_unloaded(shell)
+
+    dmesg_baseline = int(shell_out(shell, "dmesg | wc -l").strip() or "0")
+
+    _apply_and_wait(shell)
+
+    dmesg_full = shell_out(shell, "dmesg")
+    (tmp_path / "dmesg_after_load.log").write_text(dmesg_full)
+    dmesg_new = "\n".join(dmesg_full.splitlines()[dmesg_baseline:])
+    (tmp_path / "dmesg_overlay_only.log").write_text(dmesg_new)
+    assert_no_kernel_faults(dmesg_new)
+    assert_no_probe_errors(dmesg_new)
+
+    ctx, _ = open_iio_context(shell)
+    _assert_iio_devices_present(ctx, context="after overlay load")
+
+    rx_status, tx_status = assert_jesd_links_data(shell, context="after overlay load")
+    print(f"$ cat .../*.axi?jesd204?rx/status\n{rx_status}")
+    print(f"$ cat .../*.axi?jesd204?tx/status\n{tx_status}")
+
+
+@requires_lg
+@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
+def test_dma_loopback(booted_board):
+    """Verify DMA RX data path on AD9680.
+
+    Mandatory: :func:`assert_rx_capture_valid` confirms a non-zero,
+    non-latched RX buffer arrives.  The companion smoke test
+    :mod:`test.hw.test_fmcdaq3_vcu118_hw` already validates the same
+    capture against the embedded base DTB; this run validates it after
+    the overlay has been re-applied through configfs, exercising the
+    overlay tear-down/re-apply path on the data layer.
+
+    No DDS/SNR phase: FMCDAQ3 reference HDL does not have an internal
+    DAC→ADC loopback, and the AD9680 ADC is the only buffered RX path
+    in the design.  An external SMA tone is a lab-setup concern, not
+    an overlay-lifecycle concern.
+    """
+    pytest.importorskip("adi")
+
+    shell = _shell(booted_board)
+    if not overlay_is_loaded(shell, OVERLAY_NAME):
+        pytest.skip("overlay not loaded — test_load_overlay must run first")
+
+    ctx, _ = open_iio_context(shell)
+    assert_rx_capture_valid(
+        ctx,
+        EXPECTED_IIO_NAMES_ANY,
+        n_samples=2**12,
+        context="fmcdaq3 vcu118 overlay",
+    )
+
+
+@requires_lg
+@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
+def test_unload_overlay(booted_board):
+    """Removing the configfs entry tears down without kernel faults."""
+    shell = _shell(booted_board)
+    if not overlay_is_loaded(shell, OVERLAY_NAME):
+        _apply_and_wait(shell)
+
+    res = unload_overlay(shell, OVERLAY_NAME)
+    assert "RC=0" in res, f"overlay unload failed: {res}"
+    time.sleep(2.0)
+
+    assert not overlay_is_loaded(shell, OVERLAY_NAME), (
+        "overlay configfs entry still present after rmdir"
+    )
+
+    dmesg_txt = shell_out(shell, "dmesg")
+    assert_no_kernel_faults(dmesg_txt)
+
+
+@requires_lg
+@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
+def test_reload_overlay(booted_board):
+    """Load → unload → load cycle; re-verify devices + JESD link."""
+    shell = _shell(booted_board)
+    _ensure_unloaded(shell)
+
+    _apply_and_wait(shell)
+    ctx, _ = open_iio_context(shell)
+    _assert_iio_devices_present(ctx, context="after overlay reload")
+    assert_jesd_links_data(shell, context="after overlay reload")


### PR DESCRIPTION
## Summary

- **`fix(adrv937x)`**: closes the long-standing ADRV9371+ZC706 ILAS mismatch (`mismatch=0xc7f8`) by adding the TPL DAC core to the JESD204 topology graph (so `cf_axi_dds_post_running_stage` runs and the AD9371 deframer receives a valid ILAS sequence), and the related DMA refill timeout by overriding the DMAC `interrupts` cells — sdtgen extracts SPI 31/32 from the XSA but the loaded Kuiper bitstream actually wires the IRQ outputs to SPI 57/56 (= GIC IRQ 89/88). Hardware-validated on `bq` — full overlay test 6/6 passes, RX DMA captures 4096 samples on all 4 I/Q channels with std ~6586 LSBs.
- **`feat(adidt/model)`**: new optional `JesdLinkModel.dma_interrupts_str` field + renderer support for emitting `/delete-property/ interrupts;` + `interrupts = <…>;` overrides on the DMA overlay node. Backwards-compatible: no-op when unset.
- **`test(hw)`**: two new overlay lifecycle tests modeled on the existing AD9081+ZCU102 / ADRV9009+ZC706 pattern: `test_adrv9371_zc706_overlay.py` for `bq` (full 6/6 pass on hardware) and `test_fmcdaq3_vcu118_overlay.py` for `nuc` (skips with actionable message until the FMCDAQ3+VCU118 `system_top.xsa` is committed — the standard Kuiper boot-partition release does not contain a `vcu118_fmcdaq3` project, so the XSA must come from a local HDL build). Helper `stage_dtb_as_devicetree` promoted from the system test into `hw_helpers.py` for reuse.

## Test plan

- [x] `pytest test/devices/ test/xsa/` (449 passed, 13 skipped, 4 xfailed locally)
- [x] `pytest test/hw/xsa/test_adrv9371_zc706_overlay.py::test_overlay_generation_unit` (12s, end-to-end XSA pipeline + DTBO compile)
- [x] `pytest test/hw/xsa/test_fmcdaq3_vcu118_overlay.py::test_overlay_generation_unit` (skips with prerequisite-XSA message)
- [x] `LG_COORDINATOR=… LG_ENV=test/hw/env/bq.yaml pytest -p no:genalyzer test/hw/xsa/test_adrv9371_zc706_overlay.py` on `bq` — **6/6 passed (~1m45s)**
- [x] Push CI green: Type Check, Audit ADI Bindings, Test and Build Package (612 passed across Python 3.10/3.11/3.12)
- [ ] PR-gated CI: `security.yml`, `hardware-test.yml`, `test-kuiper.yml`, `doc.yml`
- [ ] FMCDAQ3+VCU118 overlay test against `nuc` — pending commit of `test/hw/xsa/system_top_fmcdaq3_vcu118.xsa` from the local HDL build