### PR TITLE
refactor(test/hw/xsa): extract overlay test boilerplate into BoardOverlayProfile

### DIFF
--- a/test/hw/xsa/_overlay_base.py
+++ b/test/hw/xsa/_overlay_base.py
@@ -1,0 +1,394 @@
+"""Shared fixtures and test functions for the overlay-lifecycle suite.
+
+Each board's ``test_*_overlay.py`` declares a
+:class:`~test.hw.xsa._overlay_spec.BoardOverlayProfile` instance and
+exposes it via a module-scoped ``overlay_spec`` fixture, then imports
+the three fixtures (``pipeline_result``, ``overlay_dtbo``,
+``booted_board``) and the six test functions defined below.  Pytest
+collects ``test_*`` callables from the importing test module's
+namespace, so the imported tests appear under their canonical names
+in ``pytest --collect-only`` and per-file selection still works.
+
+This module's name starts with ``_`` so pytest does not collect tests
+directly from it; the canonical definition site is here, the
+collection sites are the per-board files that import these names.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil as _shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from adidt.xsa.pipeline import XsaPipeline
+from adidt.xsa.topology import XsaParser
+from test.hw.hw_helpers import (
+    CONFIGFS_OVERLAYS,
+    assert_configfs_overlay_support,
+    assert_jesd_links_data,
+    assert_no_kernel_faults,
+    assert_no_probe_errors,
+    assert_rx_capture_valid,
+    compile_dts_to_dtb,
+    compile_dtso_to_dtbo,
+    deploy_and_boot,
+    deploy_dtbo_via_shell,
+    load_overlay,
+    open_iio_context,
+    overlay_is_loaded,
+    shell_out,
+    stage_dtb_as_devicetree,
+    unload_overlay,
+)
+from test.hw.xsa._overlay_fft import fft_loopback_check, prepare_pyadi_device
+
+
+_HAS_LG = bool(os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV"))
+requires_lg = pytest.mark.skipif(
+    not _HAS_LG,
+    reason=(
+        "set LG_COORDINATOR or LG_ENV for overlay hardware tests "
+        "(see .env.example)"
+    ),
+)
+
+_FDT_MAGIC = b"\xd0\x0d\xfe\xed"
+_OVERLAY_TEARDOWN_SETTLE_S = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pipeline_result(overlay_spec, tmp_path_factory) -> dict:
+    """Run :class:`XsaPipeline` once per board module.
+
+    Resolves the XSA via ``overlay_spec.xsa_resolver`` (which may
+    ``pytest.skip`` if the fixture is unavailable), parses the topology,
+    runs the board's optional ``topology_assert``, then returns the
+    pipeline output dict.
+    """
+    spec = overlay_spec
+    xsa_path = spec.xsa_resolver(tmp_path_factory.mktemp("xsa_dl"))
+    topology = XsaParser().parse(xsa_path)
+    spec.topology_assert(topology)
+    out_dir = tmp_path_factory.mktemp("overlay") / "out"
+    return XsaPipeline().run(
+        xsa_path=xsa_path,
+        cfg=spec.cfg_builder(),
+        output_dir=out_dir,
+        profile=spec.sdtgen_profile,
+        sdtgen_timeout=spec.sdtgen_timeout,
+    )
+
+
+@pytest.fixture(scope="module")
+def overlay_dtbo(overlay_spec, pipeline_result, tmp_path_factory) -> Path:
+    """Compile the pipeline ``.dtso`` to ``.dtbo`` (module-scoped, once)."""
+    overlay_src: Path = pipeline_result["overlay"]
+    assert overlay_src.exists(), f"pipeline did not emit overlay DTSO: {overlay_src}"
+
+    dtbo_dir = tmp_path_factory.mktemp("dtbo")
+    dtbo = dtbo_dir / f"{overlay_spec.overlay_name}.dtbo"
+    compile_dtso_to_dtbo(overlay_src, dtbo)
+
+    assert dtbo.exists(), f"dtc -@ did not produce DTBO: {dtbo}"
+    size = dtbo.stat().st_size
+    assert size > 100, f"DTBO suspiciously small ({size} bytes): {dtbo}"
+    magic = dtbo.read_bytes()[:4]
+    assert magic == _FDT_MAGIC, f"DTBO missing FDT magic (got {magic.hex()}): {dtbo}"
+    return dtbo
+
+
+@pytest.fixture(scope="module")
+def booted_board(
+    request,
+    overlay_spec,
+    board,
+    pipeline_result,
+    overlay_dtbo,
+    tmp_path_factory,
+):
+    """Bring the board up to a shell ready for overlay apply.
+
+    Dispatches on ``overlay_spec.boot_mode``:
+
+    * ``"tftp"`` — compile merged DTS, stage as ``devicetree.dtb``,
+      ``deploy_and_boot`` with the kernel image fixture named in
+      ``kernel_fixture_name``.
+    * ``"sd"`` — same but stage as ``system.dtb`` for Kuiper's ZynqMP
+      U-Boot.
+    * ``"fabric_jtag"`` — no DTB rebuild, no kernel fixture; transition
+      directly to ``shell`` and ``pytest.skip`` if the kernel lacks
+      configfs overlay support (the simpleImage path on VCU118).
+
+    All three paths then transfer the DTBO via the serial shell and
+    ensure the configfs overlay slot is empty before yielding.
+    """
+    spec = overlay_spec
+
+    if spec.boot_mode == "fabric_jtag":
+        board.transition("shell")
+        shell = board.target.get_driver("ADIShellDriver")
+        res = shell_out(
+            shell,
+            f"test -d {CONFIGFS_OVERLAYS} && echo OK || echo MISSING",
+        )
+        if "OK" not in res:
+            pytest.skip(
+                "kernel lacks CONFIG_OF_OVERLAY / CONFIG_OF_CONFIGFS "
+                "(simpleImage was not built with overlay support)"
+            )
+    elif spec.boot_mode in ("tftp", "sd"):
+        kernel_image = (
+            request.getfixturevalue(spec.kernel_fixture_name)
+            if spec.kernel_fixture_name
+            else None
+        )
+        out_dir = tmp_path_factory.mktemp("merged_boot")
+        merged_dts = pipeline_result["merged"]
+        dtb_raw = out_dir / f"{spec.overlay_name}.dtb"
+        compile_dts_to_dtb(merged_dts, dtb_raw)
+
+        if spec.boot_mode == "tftp":
+            staged = stage_dtb_as_devicetree(dtb_raw, out_dir / "tftp_staging")
+        else:
+            staged_dir = out_dir / "sd_staging"
+            staged_dir.mkdir(parents=True, exist_ok=True)
+            staged = staged_dir / "system.dtb"
+            _shutil.copyfile(dtb_raw, staged)
+
+        shell = deploy_and_boot(board, staged, kernel_image)
+    else:
+        raise ValueError(f"unknown boot_mode: {spec.boot_mode!r}")
+
+    deploy_dtbo_via_shell(shell, overlay_dtbo, _dtbo_remote_path(spec))
+    if overlay_is_loaded(shell, spec.overlay_name):
+        unload_overlay(shell, spec.overlay_name)
+    return board
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dtbo_remote_path(spec) -> str:
+    return f"/tmp/{spec.overlay_name}.dtbo"
+
+
+def _shell(booted):
+    return booted.target.get_driver("ADIShellDriver")
+
+
+def _ensure_unloaded(shell, name: str) -> None:
+    if overlay_is_loaded(shell, name):
+        unload_overlay(shell, name)
+        time.sleep(_OVERLAY_TEARDOWN_SETTLE_S)
+
+
+def _apply_and_wait(shell, spec) -> None:
+    res = load_overlay(shell, spec.overlay_name, _dtbo_remote_path(spec))
+    assert "RC=0" in res, f"overlay load failed: {res}"
+    time.sleep(spec.settle_after_apply_s)
+
+
+def _assert_iio_devices_present(spec, ctx, *, context: str) -> None:
+    found = {d.name for d in ctx.devices if d.name}
+    suffix = f" ({context})" if context else ""
+    for required in spec.iio_required_all:
+        assert required in found, (
+            f"IIO device {required!r} not present{suffix}. Devices: {sorted(found)}"
+        )
+    if spec.iio_required_any:
+        assert any(n in found for n in spec.iio_required_any), (
+            f"{spec.iio_frontend_label} not present{suffix}. "
+            f"Expected one of {spec.iio_required_any}; "
+            f"found: {sorted(found)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_generation_unit(overlay_spec, pipeline_result, overlay_dtbo):
+    """No-hardware check: the pipeline's DTSO is a valid overlay + compiles."""
+    dtso: Path = pipeline_result["overlay"]
+    src = dtso.read_text()
+    assert "/plugin/;" in src, (
+        f"Pipeline overlay missing /plugin/; directive — "
+        f"dtc -@ will not treat it as an overlay: {dtso}"
+    )
+    src_lower = src.lower()
+    for needle in overlay_spec.dtso_must_contain_all:
+        assert needle.lower() in src_lower, (
+            f"Pipeline overlay does not contain expected substring "
+            f"{needle!r}: {dtso}"
+        )
+    if overlay_spec.dtso_must_contain_any:
+        assert any(
+            n.lower() in src_lower for n in overlay_spec.dtso_must_contain_any
+        ), (
+            f"Pipeline overlay does not contain any of "
+            f"{overlay_spec.dtso_must_contain_any}: {dtso}"
+        )
+    assert overlay_dtbo.exists() and overlay_dtbo.stat().st_size > 100
+
+
+@requires_lg
+def test_configfs_overlay_support(overlay_spec, board, request):
+    """Target kernel must support runtime overlays via configfs.
+
+    For ``fabric_jtag`` boards this bypasses ``booted_board`` (which
+    would skip rather than fail on missing configfs) so a configfs-less
+    kernel surfaces here as an explicit failure.  For other boards, the
+    fixture path is the normal one.
+    """
+    if overlay_spec.boot_mode == "fabric_jtag":
+        board.transition("shell")
+        shell = board.target.get_driver("ADIShellDriver")
+    else:
+        booted = request.getfixturevalue("booted_board")
+        shell = _shell(booted)
+    assert_configfs_overlay_support(shell)
+
+
+@requires_lg
+def test_load_overlay(overlay_spec, booted_board, tmp_path):
+    """Apply the overlay; verify clean probe, IIO discovery, and JESD DATA."""
+    spec = overlay_spec
+    shell = _shell(booted_board)
+    _ensure_unloaded(shell, spec.overlay_name)
+
+    # dmesg before overlay-apply is the boot log — filter it out so we
+    # only flag errors caused by the overlay itself.
+    dmesg_baseline = int(shell_out(shell, "dmesg | wc -l").strip() or "0")
+
+    _apply_and_wait(shell, spec)
+
+    dmesg_full = shell_out(shell, "dmesg")
+    (tmp_path / "dmesg_after_load.log").write_text(dmesg_full)
+    dmesg_new = "\n".join(dmesg_full.splitlines()[dmesg_baseline:])
+    (tmp_path / "dmesg_overlay_only.log").write_text(dmesg_new)
+    assert_no_kernel_faults(dmesg_new)
+    assert_no_probe_errors(spec.dmesg_filter(dmesg_new))
+
+    ctx, _ = open_iio_context(shell)
+    _assert_iio_devices_present(spec, ctx, context="after overlay load")
+
+    rx_status, tx_status = assert_jesd_links_data(shell, context="after overlay load")
+    print(f"$ cat .../*.axi?jesd204?rx/status\n{rx_status}")
+    print(f"$ cat .../*.axi?jesd204?tx/status\n{tx_status}")
+
+
+@requires_lg
+def test_dma_loopback(overlay_spec, booted_board, tmp_path):
+    """Verify the DMA RX data path; optionally check the FFT spectrum.
+
+    Phase 1 — :func:`assert_rx_capture_valid` confirms a non-zero,
+    non-latched RX buffer arrives.  Per-board hooks let the test push
+    a Talise profile, disambiguate duplicate IIO names, and run extra
+    diagnostics on capture failure.
+
+    Phase 2 — when ``spec.fft_mode != "skip"``, drive a DDS tone and
+    analyse the loopback spectrum (see :mod:`._overlay_fft`).
+    """
+    spec = overlay_spec
+    if spec.fft_mode != "skip":
+        pytest.importorskip("adi")
+
+    shell = _shell(booted_board)
+    if not overlay_is_loaded(shell, spec.overlay_name):
+        pytest.skip("overlay not loaded — test_load_overlay must run first")
+
+    if spec.pre_capture_hook is not None:
+        did_something = spec.pre_capture_hook(shell, tmp_path)
+        if did_something:
+            assert_jesd_links_data(shell, context="after pre-capture hook")
+        else:
+            print(
+                f"{spec.skip_reason_label}: pre-capture hook found nothing to "
+                "do; proceeding with default state"
+            )
+
+    ctx, ip = open_iio_context(shell)
+
+    if spec.capture_targets_resolver is not None:
+        targets = tuple(spec.capture_targets_resolver(ctx))
+    else:
+        targets = spec.capture_target_names
+
+    try:
+        assert_rx_capture_valid(
+            ctx,
+            targets,
+            n_samples=2**12,
+            context=f"{spec.skip_reason_label} overlay",
+        )
+    except AssertionError:
+        if spec.fft_failure_diagnostics is not None:
+            try:
+                spec.fft_failure_diagnostics(shell)
+            except Exception as exc:  # noqa: BLE001 — diagnostics best-effort
+                print(f"fft_failure_diagnostics raised: {exc}")
+        raise
+
+    if spec.fft_mode == "skip":
+        return
+
+    dev = prepare_pyadi_device(spec, ip)
+    if dev is None:
+        return
+
+    sample_rate = int(dev.rx_sample_rate)
+    fft_loopback_check(
+        dev=dev,
+        sample_rate=sample_rate,
+        dds_tone_hz=spec.dds_tone_hz,
+        dds_scale=spec.dds_scale,
+        rx_buffer_size=spec.rx_buffer_size,
+        mode=spec.fft_mode,
+        label=spec.skip_reason_label,
+    )
+
+
+@requires_lg
+def test_unload_overlay(overlay_spec, booted_board):
+    """Removing the configfs entry tears down without kernel faults."""
+    spec = overlay_spec
+    shell = _shell(booted_board)
+    if not overlay_is_loaded(shell, spec.overlay_name):
+        # Could happen if test_load_overlay was deselected; apply + unload
+        # rather than skipping so the unload path is always exercised.
+        _apply_and_wait(shell, spec)
+
+    res = unload_overlay(shell, spec.overlay_name)
+    assert "RC=0" in res, f"overlay unload failed: {res}"
+    time.sleep(_OVERLAY_TEARDOWN_SETTLE_S)
+
+    assert not overlay_is_loaded(shell, spec.overlay_name), (
+        "overlay configfs entry still present after rmdir"
+    )
+
+    dmesg_txt = shell_out(shell, "dmesg")
+    assert_no_kernel_faults(dmesg_txt)
+
+
+@requires_lg
+def test_reload_overlay(overlay_spec, booted_board):
+    """Load → unload → load cycle; re-verify devices + JESD link."""
+    spec = overlay_spec
+    shell = _shell(booted_board)
+    _ensure_unloaded(shell, spec.overlay_name)
+
+    _apply_and_wait(shell, spec)
+    ctx, _ = open_iio_context(shell)
+    _assert_iio_devices_present(spec, ctx, context="after overlay reload")
+    assert_jesd_links_data(shell, context="after overlay reload")

--- a/test/hw/xsa/_overlay_fft.py
+++ b/test/hw/xsa/_overlay_fft.py
@@ -1,0 +1,211 @@
+"""Shared FFT loopback verification for overlay hardware tests.
+
+Lifts the ~80-LOC FFT spectrum-analysis block that was inlined in three
+overlay tests (AD9081+ZCU102 mandatory check; ADRV9009+ZC706 and
+ADRV9371+ZC706 opportunistic check) into a single helper.
+
+Two modes are supported:
+
+* ``"required"`` — drive a DDS tone, capture, FFT-analyse the spectrum,
+  and *assert* a coherent non-DC peak above the noise floor (SNR > 10 dB).
+  Used when the board's reference HDL has internal DAC→ADC loopback
+  (AD9081 ZCU102) so a tone is always expected.
+* ``"optional"`` — same capture + analysis, but a low SNR result is
+  *logged* and the test passes.  Used when the board's HDL has no
+  internal loopback (ADRV9009/ADRV9371) — without an external SMA
+  cable the noise floor is the only thing in the spectrum, and that
+  is a lab-setup concern, not an overlay-lifecycle failure.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+
+FftMode = Literal["required", "optional"]
+
+_SNR_THRESHOLD_DB = 10.0
+_DC_GUARD_BINS = 5
+_PEAK_GUARD_BINS = 5
+_PRIMING_REFILLS = 3
+
+
+def prepare_pyadi_device(
+    spec, ip: str
+) -> Any | None:
+    """Build the pyadi-iio device for the FFT phase, or return ``None``.
+
+    Uses ``spec.pyadi_factory`` when set (AD9081 needs a constructor
+    that aliases sdtgen IIO names to the production hpc names).
+    Otherwise tries ``getattr(adi, spec.pyadi_class_name)(uri=...)``.
+
+    Returns ``None`` when the device's ``_rxadc`` is unset — this is
+    the sdtgen-name fallback case where pyadi-iio's hardcoded
+    ``axi-<chip>-rx-hpc`` lookup misses; the caller treats this as
+    "skip the FFT phase, phase 1 already validated the data path".
+    """
+    if spec.pyadi_factory is not None:
+        return spec.pyadi_factory(f"ip:{ip}")
+
+    if spec.pyadi_class_name is None:
+        return None
+
+    import adi
+
+    cls = getattr(adi, spec.pyadi_class_name, None)
+    if cls is None:
+        return None
+    try:
+        dev = cls(uri=f"ip:{ip}")
+    except Exception as exc:  # noqa: BLE001 — connect failure → caller skips
+        print(f"adi.{spec.pyadi_class_name} unavailable: {exc}")
+        return None
+    if getattr(dev, "_rxadc", None) is None:
+        print(
+            f"adi.{spec.pyadi_class_name} missing buffered RX adapter "
+            "(merged DTB likely exposes sdtgen 'ad_ip_jesd204_tpl_adc' name) — "
+            "skipping FFT phase; phase 1 already validated the data path."
+        )
+        return None
+    return dev
+
+
+def fft_loopback_check(
+    *,
+    dev: Any,
+    sample_rate: int,
+    dds_tone_hz: int,
+    dds_scale: float,
+    rx_buffer_size: int,
+    mode: FftMode,
+    label: str = "",
+) -> None:
+    """Drive a DDS tone, capture, and verify the loopback spectrum.
+
+    Args:
+        dev: pyadi-iio device with ``rx_enabled_channels``,
+            ``rx_buffer_size``, ``rx_sample_rate``, ``dds_single_tone``,
+            ``rx`` methods.
+        sample_rate: integer sample rate in Hz.
+        dds_tone_hz: DDS tone frequency to drive on TX.
+        dds_scale: DDS tone amplitude (0..1).
+        rx_buffer_size: capture buffer size in samples.
+        mode: ``"required"`` asserts on low SNR; ``"optional"`` logs.
+        label: free-text tag printed alongside log lines.
+
+    Raises:
+        AssertionError: in ``"required"`` mode when no coherent peak
+            emerges (SNR ≤ 10 dB) or the peak sits within 10 fbins of
+            Nyquist.
+    """
+    np = pytest.importorskip("numpy")
+    suffix = f" [{label}]" if label else ""
+
+    dev.rx_enabled_channels = [0]
+    dev.rx_buffer_size = rx_buffer_size
+    print(f"FFT phase{suffix}: sample_rate={sample_rate} Hz, buffer={rx_buffer_size}")
+
+    try:
+        try:
+            dev.dds_single_tone(dds_tone_hz, dds_scale, channel=0)
+        except Exception as exc:  # noqa: BLE001 — DDS optional in capture-only mode
+            print(f"FFT phase{suffix}: DDS setup failed; capturing anyway: {exc}")
+
+        for _ in range(_PRIMING_REFILLS):
+            dev.rx()
+        raw = dev.rx()
+    except TimeoutError:
+        pytest.skip(
+            f"DMA buffer refill timed out{suffix} — "
+            "JESD link may not be in DATA mode"
+        )
+    finally:
+        for cleanup in ("disable_dds", "rx_destroy_buffer"):
+            try:
+                getattr(dev, cleanup)()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+
+    samples = raw[0] if isinstance(raw, list) else raw
+    samples = np.asarray(samples)
+
+    if mode == "optional" and samples.size < 1024:
+        print(
+            f"FFT phase{suffix}: capture too short ({samples.size}); "
+            "skipping spectrum check"
+        )
+        return
+    assert samples.size >= 1024, f"RX capture too short{suffix}: {samples.size}"
+    assert np.max(np.abs(samples)) > 0, (
+        f"RX data is all zeros{suffix} — DMA path or JESD link stalled"
+    )
+
+    nfft = 1 << int(np.floor(np.log2(samples.size)))
+    trimmed = samples[:nfft]
+    win = np.hanning(nfft).astype(np.float64)
+    if np.iscomplexobj(trimmed):
+        spectrum = np.fft.fftshift(
+            np.fft.fft(trimmed.astype(np.complex128) * win, n=nfft)
+        )
+        freqs = np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / sample_rate))
+    else:
+        spectrum = np.fft.rfft(trimmed.astype(np.float64) * win, n=nfft)
+        freqs = np.fft.rfftfreq(nfft, d=1.0 / sample_rate)
+
+    mags = np.abs(spectrum)
+    fbin = sample_rate / nfft
+    nyquist = sample_rate / 2
+
+    zero_idx = int(np.argmin(np.abs(freqs)))
+    nondc_mask = np.ones(mags.size, dtype=bool)
+    nondc_mask[
+        max(0, zero_idx - _DC_GUARD_BINS) : min(mags.size, zero_idx + _DC_GUARD_BINS + 1)
+    ] = False
+
+    search_mags = np.where(nondc_mask, mags, 0.0)
+    peak_idx = int(np.argmax(search_mags))
+    peak_mag = float(mags[peak_idx])
+    if peak_mag <= 0:
+        msg = f"FFT phase{suffix}: spectrum has no non-DC content (RX inert?)"
+        if mode == "required":
+            pytest.fail(msg + " — JESD/DMA path inert")
+        print(msg)
+        return
+
+    mags_db = 20.0 * np.log10(np.maximum(mags, 1e-9) / peak_mag)
+    signal_freq = float(abs(freqs[peak_idx]))
+    signal_mag_db = float(mags_db[peak_idx])
+
+    noise_mask = nondc_mask.copy()
+    lo = max(0, peak_idx - _PEAK_GUARD_BINS)
+    hi = min(mags.size, peak_idx + _PEAK_GUARD_BINS + 1)
+    noise_mask[lo:hi] = False
+    noise_db = float(np.median(mags_db[noise_mask]))
+    snr_db = signal_mag_db - noise_db
+
+    print(
+        f"FFT phase{suffix}: peak {signal_freq:.0f} Hz "
+        f"({signal_mag_db:.1f} dB), noise floor {noise_db:.1f} dB, "
+        f"SNR {snr_db:.1f} dB, fbin {fbin:.0f} Hz, DDS req {dds_tone_hz} Hz"
+    )
+
+    if snr_db < _SNR_THRESHOLD_DB:
+        msg = (
+            f"FFT phase{suffix}: no coherent tone "
+            f"(SNR {snr_db:.1f} dB ≤ {_SNR_THRESHOLD_DB} dB)"
+        )
+        if mode == "required":
+            pytest.fail(msg + " — loopback path is not delivering the DDS tone")
+        print(
+            msg + " — recording noise-only result and passing.  External "
+            "TX↔RX coupling is a lab-setup detail, not an overlay-lifecycle "
+            "requirement."
+        )
+        return
+
+    assert signal_freq < nyquist - 10 * fbin, (
+        f"Loopback peak too close to Nyquist{suffix} ({signal_freq:.0f} Hz > "
+        f"{nyquist - 10 * fbin:.0f} Hz)"
+    )
+    print(f"FFT phase{suffix}: tone detected, SNR {snr_db:.1f} dB at {signal_freq:.0f} Hz")

--- a/test/hw/xsa/_overlay_hooks.py
+++ b/test/hw/xsa/_overlay_hooks.py
@@ -1,0 +1,142 @@
+"""Reusable pre-capture hooks and capture-target resolvers.
+
+Hooks here are wired into a :class:`BoardOverlayProfile` via
+``pre_capture_hook`` / ``capture_targets_resolver`` slots when the
+generic flow needs a per-family adjustment.  Anything truly board-
+specific (single-board diagnostic prints, baked-DTB profile loads)
+stays in the board test file.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+import urllib.request
+from pathlib import Path
+
+from test.hw.hw_helpers import shell_out
+
+
+# ---------------------------------------------------------------------------
+# Talise profile push (ADRV9009 family)
+# ---------------------------------------------------------------------------
+
+# Smallest of the canonical Talise filter profiles iio-oscilloscope ships.
+# All four use ``deviceClock=245.76 MHz``, so pushing this profile re-inits
+# the Talise radio to a state where buffered RX is enabled without
+# changing the JESD lane rate.
+_TALISE_PROFILE_URL = (
+    "https://raw.githubusercontent.com/analogdevicesinc/iio-oscilloscope/"
+    "main/filters/adrv9009/"
+    "Tx_BW100_IR122p88_Rx_BW100_OR122p88_ORx_BW100_OR122p88_DC245p76.txt"
+)
+
+
+def push_talise_profile(shell, tmp_path: Path) -> bool:
+    """Push a Talise filter profile to ``adrv9009-phy.profile_config``.
+
+    On ZC706 + ADRV9009 the default post-boot Talise state leaves the
+    buffered RX path inert.  Pushing any DC-245.76 MHz profile triggers
+    a Talise re-init that brings the radio up to ``radio_on``, after
+    which DMA capture works.
+
+    Returns ``True`` if a profile was applied, ``False`` if the sysfs
+    ``profile_config`` node could not be located (e.g. driver build
+    without debugfs support).
+    """
+    profile_sysfs = shell_out(
+        shell,
+        "find /sys/kernel/debug/iio /sys/bus/iio/devices "
+        "-name profile_config 2>/dev/null | head -1",
+    ).strip()
+    if not profile_sysfs:
+        profile_sysfs = shell_out(
+            shell,
+            "find /sys -name profile_config 2>/dev/null | head -1",
+        ).strip()
+    if not profile_sysfs:
+        return False
+
+    cache_dir = tmp_path / "talise_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cached = cache_dir / "talise_default.txt"
+    if cached.exists() and cached.stat().st_size > 0:
+        body = cached.read_text()
+    else:
+        with urllib.request.urlopen(_TALISE_PROFILE_URL, timeout=30) as resp:  # noqa: S310
+            body = resp.read().decode("utf-8")
+        cached.write_text(body)
+    if not body.lstrip().startswith("<profile "):
+        raise AssertionError(
+            "Talise profile fetch returned non-XML content"
+            f" (first 80 chars: {body[:80]!r})"
+        )
+
+    b64 = base64.b64encode(body.encode()).decode()
+    shell_out(shell, f"printf '%s' '{b64}' | base64 -d > /tmp/talise.txt")
+    size_on_target = shell_out(shell, "stat -c%s /tmp/talise.txt").strip()
+    assert size_on_target == str(len(body.encode())), (
+        f"Talise profile partial push: target has {size_on_target},"
+        f" expected {len(body.encode())}"
+    )
+    shell_out(shell, f"cat /tmp/talise.txt > {profile_sysfs}")
+    # Talise re-init re-runs the JESD bring-up sequence; give the FSM
+    # time to relock both links before any sysfs check.
+    time.sleep(3.0)
+
+    # Profile push leaves the radio in ``calibrated`` (ENSM state 6) on
+    # ZC706 builds — we need ``radio_on`` (state 7) before the buffered
+    # RX path will deliver samples through DMA.
+    phy_dir = profile_sysfs.rsplit("/", 1)[0]
+    shell_out(shell, f"echo radio_on > {phy_dir}/ensm_mode")
+    time.sleep(1.0)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# RX TPL disambiguation (ADRV9009 family)
+# ---------------------------------------------------------------------------
+
+_ADRV9009_RX_TPL_REG_HINT = "44a00000"
+_ADRV9009_TPL_NAME = "ad_ip_jesd204_tpl_adc"
+
+
+def resolve_adrv9009_rx_tpl(ctx) -> tuple[str, ...]:
+    """Pick the RX TPL device when multiple TPLs share the same IIO name.
+
+    Both the RX TPL (``...@44a00000``) and the OBS TPL (``...@44a08000``)
+    probe to libiio with the same ``ad_ip_jesd204_tpl_adc`` name —
+    ``ctx.find_device`` returns whichever probed first (typically OBS),
+    but Talise's ``radio_on`` only streams framer-A (RX); a refill on
+    OBS returns all zeros even though its DMA fires.  Prefer the RX TPL
+    by reg address; fall back to the higher-numbered duplicate (cf_axi_adc
+    binds the RX TPL after ``ad_adc`` binds OBS, so the RX iio:device has
+    the larger numeric id).
+    """
+    rx_tpl_dev = None
+    for d in ctx.devices:
+        if d.name != _ADRV9009_TPL_NAME:
+            continue
+        try:
+            of_node = d.attrs["of_node"].value if "of_node" in d.attrs else ""
+        except Exception:  # noqa: BLE001 — attr read may raise on some builds
+            of_node = ""
+        if _ADRV9009_RX_TPL_REG_HINT in of_node:
+            rx_tpl_dev = d
+            break
+
+    if rx_tpl_dev is None:
+        candidates = [d for d in ctx.devices if d.name == _ADRV9009_TPL_NAME]
+        if candidates:
+            rx_tpl_dev = max(
+                candidates, key=lambda d: int(d.id.rsplit(":device", 1)[1])
+            )
+
+    if rx_tpl_dev is not None:
+        return (rx_tpl_dev.id,)
+
+    return (
+        "axi-adrv9009-rx-hpc",
+        "axi-adrv9009-rx-obs-hpc",
+        _ADRV9009_TPL_NAME,
+    )

--- a/test/hw/xsa/_overlay_spec.py
+++ b/test/hw/xsa/_overlay_spec.py
@@ -1,0 +1,175 @@
+"""Declarative spec + factories for runtime overlay hardware tests.
+
+A :class:`BoardOverlayProfile` instance fully describes how the shared
+overlay-lifecycle test suite (in :mod:`test.hw.xsa._overlay_base`)
+should run for a particular board + carrier combination: which XSA to
+use, how to derive the JESD/clock cfg, how to boot, which IIO devices
+to expect, and any board-specific hooks for the DMA loopback phase.
+
+A board test module declares a ``SPEC`` constant and exposes it as the
+module-scoped ``overlay_spec`` fixture; it then imports the shared
+fixtures + 6 test functions from :mod:`test.hw.xsa._overlay_base` and
+pytest collects them into the board file's namespace under their
+canonical names (``test_load_overlay``, ``test_dma_loopback``, etc.).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Literal, Optional, Sequence
+
+import pytest
+
+from test.hw.hw_helpers import acquire_xsa
+
+
+BootMode = Literal["tftp", "sd", "fabric_jtag"]
+FftMode = Literal["required", "optional", "skip"]
+
+
+CfgBuilder = Callable[[], dict[str, Any]]
+XsaResolver = Callable[[Path], Path]
+TopologyAssert = Callable[[Any], None]
+DmesgFilter = Callable[[str], str]
+PreCaptureHook = Callable[[Any, Path], bool]
+CaptureTargetsResolver = Callable[[Any], Sequence[str]]
+PyAdiFactory = Callable[[str], Any]
+FailureDiagnostics = Callable[[Any], None]
+
+
+def _identity(text: str) -> str:
+    return text
+
+
+def _noop_topology(_topology: Any) -> None:
+    return None
+
+
+@dataclass(frozen=True)
+class BoardOverlayProfile:
+    """Per-board configuration consumed by the shared overlay test suite.
+
+    Required fields (no default):
+
+    * ``overlay_name`` — unique configfs node name, e.g. ``"ad9081_zcu102_xsa"``.
+    * ``lg_features`` — labgrid place feature tuple, applied as
+      ``@pytest.mark.lg_feature(...)`` to every hardware test by the
+      ``xsa/conftest.py`` collection hook.
+    * ``skip_reason_label`` — short human-readable name used in skip messages.
+    * ``cfg_builder`` — zero-arg callable returning the cfg dict for
+      :meth:`adidt.xsa.pipeline.XsaPipeline.run`.
+    * ``xsa_resolver`` — single-arg callable that takes a ``tmp_path``
+      and returns a path to the XSA on disk (or calls ``pytest.skip``).
+    * ``sdtgen_profile`` — pipeline profile name (e.g. ``"adrv9009_zc706"``).
+    * ``boot_mode`` — one of ``"tftp"``, ``"sd"``, ``"fabric_jtag"``.
+
+    All other fields have safe defaults so a minimal board declaration
+    only fills those seven required slots.
+    """
+
+    overlay_name: str
+    lg_features: tuple[str, ...]
+    skip_reason_label: str
+
+    cfg_builder: CfgBuilder
+    xsa_resolver: XsaResolver
+    sdtgen_profile: str
+
+    boot_mode: BootMode
+
+    topology_assert: TopologyAssert = _noop_topology
+    sdtgen_timeout: int = 300
+
+    dtso_must_contain_all: tuple[str, ...] = ()
+    dtso_must_contain_any: tuple[str, ...] = ()
+
+    kernel_fixture_name: Optional[str] = None
+    settle_after_apply_s: float = 5.0
+
+    iio_required_all: tuple[str, ...] = ()
+    iio_required_any: tuple[str, ...] = ()
+    iio_frontend_label: str = "RX frontend"
+
+    dmesg_filter: DmesgFilter = _identity
+
+    fft_mode: FftMode = "skip"
+    pre_capture_hook: Optional[PreCaptureHook] = None
+    capture_targets_resolver: Optional[CaptureTargetsResolver] = None
+    capture_target_names: tuple[str, ...] = ()
+    pyadi_class_name: Optional[str] = None
+    pyadi_factory: Optional[PyAdiFactory] = None
+    dds_tone_hz: int = 1_000_000
+    dds_scale: float = 0.5
+    rx_buffer_size: int = 2**14
+    fft_failure_diagnostics: Optional[FailureDiagnostics] = None
+
+    extra_imports_check: tuple[str, ...] = field(default=())
+
+
+# ---------------------------------------------------------------------------
+# Resolver factories — common XSA acquisition patterns the boards reuse.
+# ---------------------------------------------------------------------------
+
+
+def local_xsa_or_skip(*candidate_filenames: str) -> XsaResolver:
+    """Return a resolver that picks the first existing local XSA fixture.
+
+    Looks under ``test/hw/xsa/`` and ``test/hw/xsa/ref_data/`` for each
+    candidate basename in order; calls :func:`pytest.skip` if none are
+    present.  Used by FMCDAQ3+VCU118 (no Kuiper download exists for the
+    MicroBlaze build) and as a fallback for AD9081+ZCU102.
+    """
+    here = Path(__file__).parent
+
+    def _resolver(_tmp_path: Path) -> Path:
+        for name in candidate_filenames:
+            for parent in (here, here / "ref_data"):
+                candidate = parent / name
+                if candidate.exists():
+                    return candidate
+        searched = ", ".join(
+            str(parent / name)
+            for name in candidate_filenames
+            for parent in (here, here / "ref_data")
+        )
+        pytest.skip(f"XSA fixture missing — looked at: {searched}")
+
+    return _resolver
+
+
+def acquire_or_local_xsa(
+    local_filename: str,
+    release: str,
+    project: str,
+    *,
+    fallback_filenames: tuple[str, ...] = (),
+) -> XsaResolver:
+    """Return a resolver that prefers a local XSA, else downloads from Kuiper.
+
+    Tries ``test/hw/xsa/<local_filename>`` (and any
+    ``fallback_filenames``) first; if none are present, hands off to
+    :func:`test.hw.hw_helpers.acquire_xsa` which downloads from the
+    given Kuiper *release* / *project*.  Skips the test on download
+    failure rather than erroring — the same behavior the original
+    inline ``pipeline_result`` fixtures had.
+    """
+    here = Path(__file__).parent
+
+    def _resolver(tmp_path: Path) -> Path:
+        for name in (local_filename, *fallback_filenames):
+            for parent in (here, here / "ref_data"):
+                candidate = parent / name
+                if candidate.exists():
+                    return candidate
+        try:
+            return acquire_xsa(
+                here / local_filename,
+                release,
+                project,
+                tmp_path,
+            )
+        except Exception as exc:  # noqa: BLE001 — any IO/download failure → skip
+            pytest.skip(f"could not acquire XSA ({project}@{release}): {exc}")
+
+    return _resolver

--- a/test/hw/xsa/conftest.py
+++ b/test/hw/xsa/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest configuration shared across the overlay-lifecycle tests.
+
+Each per-board ``test_*_overlay.py`` declares a ``SPEC`` constant
+(a :class:`~test.hw.xsa._overlay_spec.BoardOverlayProfile` instance).
+The collection hook below reads ``SPEC.lg_features`` at collection
+time and applies ``@pytest.mark.lg_feature(...)`` to every test in the
+module — so the per-board labgrid place feature gate stays a single
+declaration in the SPEC instead of a decorator on every test function.
+
+``tryfirst=True`` is critical: labgrid's pytest plugin filters tests
+by ``lg_feature`` marker during collection, so this hook must run
+*before* labgrid's filtering pass.  Without the marker, labgrid would
+either run every test against every place or skip every test
+unconditionally (depending on env), defeating the per-place isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        spec = getattr(item.module, "SPEC", None)
+        if spec is None:
+            continue
+        features = getattr(spec, "lg_features", None)
+        if not features:
+            continue
+        item.add_marker(pytest.mark.lg_feature(list(features)))
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "lg_feature(features): labgrid place feature gate"
+    )

--- a/test/hw/xsa/test_ad9081_zcu102_overlay.py
+++ b/test/hw/xsa/test_ad9081_zcu102_overlay.py
@@ -1,28 +1,22 @@
 """AD9081 + ZCU102 runtime device-tree overlay hardware test.
 
-Exercises the full overlay lifecycle against a live ZCU102 booted from a
-stock Kuiper SD image:
+Same six-test shape as the rest of the overlay suite — fixtures + tests
+live in :mod:`test.hw.xsa._overlay_base`.  Per-board specifics
+(:func:`_solve_ad9081_config`, :func:`_create_ad9081`) stay in this
+file because they are genuinely AD9081-only.
 
-1. ``XsaPipeline.run`` produces a ``.dtso`` (plugin overlay) from the
-   AD9081+ZCU102 XSA.
-2. :func:`~test.hw.hw_helpers.compile_dtso_to_dtbo` compiles it with
-   ``dtc -@`` so external ``&label`` phandles survive.
-3. :func:`~test.hw.hw_helpers.deploy_dtbo_via_shell` pushes the ``.dtbo``
-   to ``/tmp`` on the target over the serial console (no SSH required).
-4. :func:`~test.hw.hw_helpers.load_overlay` applies it via configfs.
-5. Verification: no probe/apply errors in dmesg, the expected IIO
-   devices appear, both JESD links reach ``DATA``, and a DDS→DMA
-   loopback tone is detectable in the captured spectrum (numpy FFT
-   peak + SNR against the surrounding noise floor).
-6. :func:`~test.hw.hw_helpers.unload_overlay` tears it down, asserting
-   no kernel fault occurs during removal.
-7. Reload cycle — load/unload/load once more to confirm repeatability.
+Boot strategy: ``KuiperDLDriver.get_boot_files_from_release()`` followed
+by an SD-card stage of the merged DTB (renamed to ``system.dtb`` so
+Kuiper's ZCU102 U-Boot picks it up).  The merged DTB has the AD9081
+SPI nodes already in place, so the overlay exercises the configfs
+lifecycle on top of an already-probed tree.
 
-Boot strategy: ``KuiperDLDriver.get_boot_files_from_release`` is used
-*without* staging a custom DTB so the overlay is applied on top of a
-known-good Kuiper base, mirroring the real "hot-swap a converter" use
-case rather than exercising a fresh merged tree.  See the docstring on
-:func:`booted_board` for the rationale.
+Stock-Kuiper boot was tried first; on the lab's current 2023_R2 image
+the AD9081 SPI probe fails at boot with ``-EBUSY`` (the bitstream's
+clock chain is not yet up when the SPI driver runs), which then makes
+every subsequent overlay test see an unrelated boot-time error.
+Booting with our merged DTB avoids that and is deterministic across
+runs.
 
 LG_ENV / LG_COORDINATOR: see ``.env.example``.  Runs against the
 ``mini2`` labgrid place (ZCU102 + AD9081-FMCA-EBZ).
@@ -30,76 +24,35 @@ LG_ENV / LG_COORDINATOR: see ``.env.example``.  Runs against the
 
 from __future__ import annotations
 
-import os
-import time
-from pathlib import Path
 from typing import Any
 
 import pytest
 
-import shutil as _shutil
-
-from adidt.xsa.pipeline import XsaPipeline
-from adidt.xsa.topology import XsaParser
-from test.hw.hw_helpers import (
-    assert_configfs_overlay_support,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    compile_dts_to_dtb,
-    compile_dtso_to_dtbo,
-    deploy_and_boot,
-    deploy_dtbo_via_shell,
-    load_overlay,
-    open_iio_context,
-    overlay_is_loaded,
-    shell_out,
-    unload_overlay,
+from test.hw.xsa._overlay_base import (  # noqa: F401 — pytest collects these
+    booted_board,
+    overlay_dtbo,
+    pipeline_result,
+    test_overlay_generation_unit,
+    test_configfs_overlay_support,
+    test_load_overlay,
+    test_dma_loopback,
+    test_unload_overlay,
+    test_reload_overlay,
 )
-
-_HAS_LG = bool(os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV"))
-requires_lg = pytest.mark.skipif(
-    not _HAS_LG,
-    reason=(
-        "set LG_COORDINATOR or LG_ENV for AD9081 ZCU102 overlay hardware tests"
-        " (see .env.example)"
-    ),
-)
+from test.hw.xsa._overlay_spec import BoardOverlayProfile, acquire_or_local_xsa
 
 
 DEFAULT_KUIPER_RELEASE = "2023_r2"
 DEFAULT_KUIPER_PROJECT = "zynqmp-zcu102-rev10-ad9081"
 DEFAULT_VCXO_HZ = 122_880_000
 
-OVERLAY_NAME = "ad9081_zcu102_xsa"
-DTBO_REMOTE_PATH = f"/tmp/{OVERLAY_NAME}.dtbo"
-FDT_MAGIC = b"\xd0\x0d\xfe\xed"
-
-# DDS tone used for the DMA loopback check.  1 MHz is far from DC and
-# far from the Nyquist edge at any AD9081 sample rate the XSA pipeline
-# configures, so spectral leakage does not hide the peak.
-DDS_TONE_HZ = 1_000_000
-DDS_SCALE = 0.5
-RX_BUFFER_SIZE = 2**14
-
-# IIO device names the AD9081 overlay should introduce (or refresh).
-# Kuiper's pyadi-iio class hardcodes the ``axi-ad9081-{rx,tx}-hpc``
-# names; the sdtgen-generated merged DTB uses the TPL-core names.  The
-# stock Kuiper image uses the former, so overlay load should keep them.
-EXPECTED_IIO_NAMES_ANY = (
-    "axi-ad9081-rx-hpc",
-    "ad_ip_jesd204_tpl_adc",
-)
-EXPECTED_IIO_NAMES_ALL = ("hmc7044",)
-
 
 def _solve_ad9081_config(vcxo_hz: int = DEFAULT_VCXO_HZ) -> dict[str, Any]:
     """Resolve AD9081 JESD mode + datapath + clocks via pyadi-jif.
 
-    Duplicated from ``test_ad9081_zcu102_xsa_hw`` so the two tests can
-    drift their solver inputs independently if needed.  Uses the same
-    M8/L4 jesd204b pinning: rx_link_mode=10, tx_link_mode=9 (the values
-    Kuiper's reference ``zynqmp-zcu102-rev10-ad9081-m8-l4.dts`` uses).
+    Uses the same M8/L4 jesd204b pinning as Kuiper's reference
+    ``zynqmp-zcu102-rev10-ad9081-m8-l4.dts``: ``rx_link_mode=10``,
+    ``tx_link_mode=9``.
     """
     try:
         import adijif
@@ -144,140 +97,6 @@ def _solve_ad9081_config(vcxo_hz: int = DEFAULT_VCXO_HZ) -> dict[str, Any]:
     }
 
 
-@pytest.fixture(scope="module")
-def pipeline_result(tmp_path_factory) -> dict:
-    """Run :class:`XsaPipeline` once per module and return its output dict.
-
-    Skips the whole module when the AD9081+ZCU102 XSA fixture is not on
-    disk or ``sdtgen``/``dtc`` are missing — these failures are already
-    reported by :func:`~test.hw.hw_helpers.require_hw_prereqs` when a
-    test enters the ``board`` fixture, but fixture-level skipping lets
-    pure-unit tests (``test_overlay_generation_unit``) fail cleanly
-    without needing a labgrid place acquired.
-    """
-    xsa_path = Path(__file__).parent / "ref_data" / "system_top_ad9081_zcu102.xsa"
-    if not xsa_path.exists():
-        # Fallback to the older fixture used by the merged-DTB test.
-        xsa_path = Path(__file__).parent / "system_top.xsa"
-    if not xsa_path.exists():
-        pytest.skip(f"AD9081+ZCU102 XSA fixture not found: {xsa_path}")
-
-    topology = XsaParser().parse(xsa_path)
-    assert topology.has_converter_types("axi_ad9081"), (
-        f"XSA topology is not AD9081: converter IPs = "
-        f"{[c.ip_type for c in topology.converters]}"
-    )
-
-    cfg = _solve_ad9081_config()
-    out_dir = tmp_path_factory.mktemp("overlay") / "out"
-    result = XsaPipeline().run(
-        xsa_path=xsa_path,
-        cfg=cfg,
-        output_dir=out_dir,
-        profile="ad9081_zcu102",
-        sdtgen_timeout=300,
-    )
-    return result
-
-
-@pytest.fixture(scope="module")
-def overlay_dtbo(pipeline_result, tmp_path_factory) -> Path:
-    """Compile the pipeline ``.dtso`` to ``.dtbo`` (module-scoped, once)."""
-    overlay_src: Path = pipeline_result["overlay"]
-    assert overlay_src.exists(), f"pipeline did not emit overlay DTSO: {overlay_src}"
-
-    dtbo_dir = tmp_path_factory.mktemp("dtbo")
-    dtbo = dtbo_dir / f"{OVERLAY_NAME}.dtbo"
-    compile_dtso_to_dtbo(overlay_src, dtbo)
-
-    assert dtbo.exists(), f"dtc -@ did not produce DTBO: {dtbo}"
-    size = dtbo.stat().st_size
-    assert size > 100, f"DTBO suspiciously small ({size} bytes): {dtbo}"
-    magic = dtbo.read_bytes()[:4]
-    assert magic == FDT_MAGIC, f"DTBO missing FDT magic (got {magic.hex()}): {dtbo}"
-    return dtbo
-
-
-@pytest.fixture(scope="module")
-def booted_board(
-    board, built_kernel_image_zynqmp, pipeline_result, overlay_dtbo, tmp_path_factory
-):
-    """Boot ZCU102 with the pipeline's merged DTB and stage the ``.dtbo``.
-
-    The overlay's ``/delete-property/`` directives (see
-    ``adidt/devices/fpga_ip/jesd_overlay.py``) target labels that already
-    exist in the merged base.  Booting from the merged DTB therefore
-    means the AD9081 IIO devices are present from the start; the
-    overlay then exercises the configfs lifecycle (load/unload/reload)
-    on top of an already-probed tree without needing a separate "base
-    minus AD9081" DTB.
-
-    Stock-Kuiper boot was tried first; on the lab's current 2023_R2
-    image the AD9081 SPI probe fails at boot with ``-EBUSY`` (the
-    bitstream's clock chain is not yet up when the SPI driver runs),
-    which then makes every subsequent overlay test see an unrelated
-    boot-time error.  Booting with our merged DTB avoids that and is
-    deterministic across runs.
-
-    Also stages the DTBO to ``/tmp`` on the target so per-test
-    ``load_overlay`` calls do not re-transfer it.
-    """
-    out_dir = tmp_path_factory.mktemp("merged_boot")
-    merged_dts = pipeline_result["merged"]
-    dtb_raw = out_dir / "ad9081_zcu102_xsa.dtb"
-    compile_dts_to_dtb(merged_dts, dtb_raw)
-    # Kuiper's U-Boot picks ``system.dtb`` from the SD card; rename so
-    # our DTB is the one the bootloader actually loads.
-    staged = out_dir / "sd_staging" / "system.dtb"
-    staged.parent.mkdir(parents=True, exist_ok=True)
-    _shutil.copyfile(dtb_raw, staged)
-
-    shell = deploy_and_boot(board, staged, built_kernel_image_zynqmp)
-
-    deploy_dtbo_via_shell(shell, overlay_dtbo, DTBO_REMOTE_PATH)
-
-    # Ensure a clean slate if a previous test run left an entry behind.
-    if overlay_is_loaded(shell, OVERLAY_NAME):
-        unload_overlay(shell, OVERLAY_NAME)
-
-    return board
-
-
-def _shell(booted):
-    return booted.target.get_driver("ADIShellDriver")
-
-
-def _ensure_unloaded(shell) -> None:
-    if overlay_is_loaded(shell, OVERLAY_NAME):
-        unload_overlay(shell, OVERLAY_NAME)
-        # Give the kernel a beat to tear down the overlay's probes before
-        # the next apply — otherwise a racing ``mkdir`` can land while the
-        # previous overlay is still being removed.
-        time.sleep(2.0)
-
-
-def _apply_and_wait(shell) -> None:
-    res = load_overlay(shell, OVERLAY_NAME, DTBO_REMOTE_PATH)
-    assert "RC=0" in res, f"overlay load failed: {res}"
-    # Drivers re-probe asynchronously after overlay application; give the
-    # JESD link FSM time to walk through SYNC -> ILAS -> DATA.
-    time.sleep(5.0)
-
-
-def _assert_iio_devices_present(ctx, *, context: str) -> None:
-    found = {d.name for d in ctx.devices if d.name}
-    suffix = f" ({context})" if context else ""
-    for required in EXPECTED_IIO_NAMES_ALL:
-        assert required in found, (
-            f"IIO device {required!r} not present{suffix}. Devices: {sorted(found)}"
-        )
-    assert any(n in found for n in EXPECTED_IIO_NAMES_ANY), (
-        f"AD9081 RX frontend not present{suffix}. "
-        f"Expected one of {EXPECTED_IIO_NAMES_ANY}; "
-        f"found: {sorted(found)}"
-    )
-
-
 def _create_ad9081(uri: str):
     """Return an ``adi.ad9081`` that tolerates sdtgen IIO device names.
 
@@ -316,231 +135,39 @@ def _create_ad9081(uri: str):
     return dev
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
-def test_overlay_generation_unit(pipeline_result, overlay_dtbo):
-    """No-hardware check: the pipeline's DTSO is a valid overlay + compiles."""
-    dtso: Path = pipeline_result["overlay"]
-    src = dtso.read_text()
-    assert "/plugin/;" in src, (
-        f"Pipeline overlay missing /plugin/; directive — "
-        f"dtc -@ will not treat it as an overlay: {dtso}"
-    )
-    assert "axi-ad9081" in src, (
-        f"Pipeline overlay does not reference axi-ad9081: {dtso}"
-    )
-    assert overlay_dtbo.exists() and overlay_dtbo.stat().st_size > 100
-
-
-@requires_lg
-@pytest.mark.lg_feature(["ad9081", "zcu102"])
-def test_configfs_overlay_support(booted_board):
-    """Target kernel must support runtime overlays via configfs."""
-    assert_configfs_overlay_support(_shell(booted_board))
-
-
-@requires_lg
-@pytest.mark.lg_feature(["ad9081", "zcu102"])
-def test_load_overlay(booted_board, tmp_path):
-    """Apply the overlay; verify clean probe, IIO discovery, and JESD DATA."""
-    shell = _shell(booted_board)
-    _ensure_unloaded(shell)
-
-    # dmesg before overlay-apply is the boot log — filter that out so we
-    # only flag errors caused by the overlay itself.  ``wc -l`` returns
-    # the line count we use as the offset for ``tail -n +<N+1>`` after
-    # the apply.
-    dmesg_baseline = int(shell_out(shell, "dmesg | wc -l").strip() or "0")
-
-    _apply_and_wait(shell)
-
-    dmesg_full = shell_out(shell, "dmesg")
-    (tmp_path / "dmesg_after_load.log").write_text(dmesg_full)
-    dmesg_new = "\n".join(dmesg_full.splitlines()[dmesg_baseline:])
-    (tmp_path / "dmesg_overlay_only.log").write_text(dmesg_new)
-    assert_no_kernel_faults(dmesg_new)
-    assert_no_probe_errors(dmesg_new)
-
-    ctx, _ = open_iio_context(shell)
-    _assert_iio_devices_present(ctx, context="after overlay load")
-
-    rx_status, tx_status = assert_jesd_links_data(shell, context="after overlay load")
-    print(f"$ cat .../*.axi?jesd204?rx/status\n{rx_status}")
-    print(f"$ cat .../*.axi?jesd204?tx/status\n{tx_status}")
-
-
-@requires_lg
-@pytest.mark.lg_feature(["ad9081", "zcu102"])
-def test_dma_loopback(booted_board):
-    """Drive a DDS tone through TX→RX via DMA and detect it in the spectrum.
-
-    Requires the overlay from ``test_load_overlay`` to still be applied
-    (module-scoped fixtures keep the state).  Uses pyadi-iio's
-    ``adi.ad9081`` for the capture.  Spectrum analysis is done with
-    numpy: take an FFT of the complex baseband buffer, find the peak
-    bin, assert it lines up with ``DDS_TONE_HZ``, and check the peak is
-    well above the surrounding noise floor.  genalyzer is available in
-    the repo's dev environment for deeper analysis; using numpy here
-    keeps the test robust across genalyzer API revisions since the only
-    thing we need is "tone at the right place, clearly above noise".
-    """
-    pytest.importorskip("adi")
-    np = pytest.importorskip("numpy")
-
-    shell = _shell(booted_board)
-    if not overlay_is_loaded(shell, OVERLAY_NAME):
-        pytest.skip("overlay not loaded — test_load_overlay must run first")
-
-    ctx, ip = open_iio_context(shell)
-    del ctx  # _create_ad9081 opens its own context
-
-    try:
-        dev = _create_ad9081(f"ip:{ip}")
-    except Exception as exc:  # noqa: BLE001 — any connect failure is a skip
-        pytest.skip(f"could not attach adi.ad9081 to {ip}: {exc}")
-
-    dev.rx_enabled_channels = [0]
-    dev.rx_buffer_size = RX_BUFFER_SIZE
-    sample_rate = int(dev.rx_sample_rate)
-    print(f"AD9081 RX sample rate: {sample_rate} Hz, buffer: {RX_BUFFER_SIZE}")
-
-    try:
-        dev.dds_single_tone(DDS_TONE_HZ, DDS_SCALE, channel=0)
-        # First refills can carry stale samples captured before the DDS
-        # tone propagated through the link — drain a few.
-        for _ in range(3):
-            dev.rx()
-        raw = dev.rx()
-    except TimeoutError:
-        pytest.skip("DMA buffer refill timed out — JESD link may not be in DATA mode")
-    finally:
-        try:
-            dev.disable_dds()
-        except Exception:  # noqa: BLE001 — cleanup is best-effort
-            pass
-        try:
-            dev.rx_destroy_buffer()
-        except Exception:  # noqa: BLE001 — cleanup is best-effort
-            pass
-
-    samples = raw[0] if isinstance(raw, list) else raw
-    samples = np.asarray(samples)
-    assert samples.size >= 1024, f"RX capture too short: {samples.size}"
-    assert np.max(np.abs(samples)) > 0, (
-        "RX data is all zeros — DMA path or JESD link stalled"
-    )
-
-    # Complex baseband: full FFT so positive and negative frequencies
-    # are both represented (a real DDS tone folds to ±DDS_TONE_HZ after
-    # quadrature downconversion; either sideband should satisfy the
-    # ``≤ 2·fbin`` check).  Real data: real-FFT produces one sideband.
-    nfft = 1 << int(np.floor(np.log2(samples.size)))
-    trimmed = samples[:nfft]
-    win = np.hanning(nfft).astype(np.float64)
-    if np.iscomplexobj(trimmed):
-        spectrum = np.fft.fftshift(
-            np.fft.fft(trimmed.astype(np.complex128) * win, n=nfft)
-        )
-        freqs = np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / sample_rate))
-    else:
-        spectrum = np.fft.rfft(trimmed.astype(np.float64) * win, n=nfft)
-        freqs = np.fft.rfftfreq(nfft, d=1.0 / sample_rate)
-
-    mags = np.abs(spectrum)
-
-    # Exclude a ±N-bin guard around DC from the tone search.  AD9081
-    # exhibits a non-trivial DC offset that often dominates the
-    # spectrum even when a loopback tone is present; finding the
-    # strongest *non-DC* bin gives the real tone location.  Same DC
-    # guard is used for the noise-floor median so the floor is not
-    # contaminated by the DC bump either.
-    fbin = sample_rate / nfft
-    nyquist = sample_rate / 2
-    dc_guard = 5
-    zero_idx = int(np.argmin(np.abs(freqs)))
-    nondc_mask = np.ones(mags.size, dtype=bool)
-    nondc_mask[
-        max(0, zero_idx - dc_guard) : min(mags.size, zero_idx + dc_guard + 1)
-    ] = False
-
-    search_mags = np.where(nondc_mask, mags, 0.0)
-    peak_idx = int(np.argmax(search_mags))
-    peak_mag = float(mags[peak_idx])
-    if peak_mag <= 0:
-        pytest.fail("RX spectrum has no non-DC content — JESD/DMA path inert")
-    mags_db = 20.0 * np.log10(np.maximum(mags, 1e-9) / peak_mag)
-    signal_freq = float(abs(freqs[peak_idx]))
-    signal_mag_db = float(mags_db[peak_idx])
-
-    # Noise floor: median of bins outside the DC guard *and* outside a
-    # ±5-bin guard around the peak.
-    noise_mask = nondc_mask.copy()
-    lo = max(0, peak_idx - 5)
-    hi = min(mags.size, peak_idx + 6)
-    noise_mask[lo:hi] = False
-    noise_db = float(np.median(mags_db[noise_mask]))
-    snr_db = signal_mag_db - noise_db
-
-    print(
-        f"Loopback spectrum: peak {signal_freq:.0f} Hz "
-        f"({signal_mag_db:.1f} dB), noise floor {noise_db:.1f} dB, "
-        f"SNR {snr_db:.1f} dB, fbin {fbin:.0f} Hz, DDS req {DDS_TONE_HZ} Hz"
-    )
-    # We don't pin the peak to ``DDS_TONE_HZ`` exactly: the AD9081 RX
-    # CDDC/FDDC NCOs downconvert before samples reach us, so the
-    # loopback tone lands at ``DDS_TONE_HZ - RX_NCO``.  This test is
-    # about overlay lifecycle, not chain calibration — a coherent
-    # non-DC, non-Nyquist peak above the noise floor is sufficient
-    # evidence that the DMA TX→RX path is end-to-end alive.
-    assert signal_freq < nyquist - 10 * fbin, (
-        f"Loopback peak too close to Nyquist ({signal_freq:.0f} Hz > "
-        f"{nyquist - 10 * fbin:.0f} Hz)"
-    )
-    assert snr_db > 10.0, (
-        f"Loopback tone not clearly above noise floor: SNR={snr_db:.1f} dB"
+def _topology_assert(topology) -> None:
+    assert topology.has_converter_types("axi_ad9081"), (
+        f"XSA topology is not AD9081: converter IPs = "
+        f"{[c.ip_type for c in topology.converters]}"
     )
 
 
-@requires_lg
-@pytest.mark.lg_feature(["ad9081", "zcu102"])
-def test_unload_overlay(booted_board):
-    """Removing the configfs entry tears down without kernel faults."""
-    shell = _shell(booted_board)
-    if not overlay_is_loaded(shell, OVERLAY_NAME):
-        # Could happen if test_load_overlay was deselected; apply + unload
-        # rather than skipping so the unload path is always exercised.
-        _apply_and_wait(shell)
-
-    res = unload_overlay(shell, OVERLAY_NAME)
-    assert "RC=0" in res, f"overlay unload failed: {res}"
-    # Give the kernel a moment to finish removing child devices.
-    time.sleep(2.0)
-
-    # The configfs entry must be gone.  The base tree's devices may
-    # persist — unload only removes the overlay's phandles, not the
-    # base-DT nodes Kuiper's stock image probed earlier.
-    assert not overlay_is_loaded(shell, OVERLAY_NAME), (
-        "overlay configfs entry still present after rmdir"
-    )
-
-    dmesg_txt = shell_out(shell, "dmesg")
-    # Only check for *hard* kernel faults during unload: driver ``.remove``
-    # callbacks can log routine messages the probe-error regex would
-    # otherwise flag.
-    assert_no_kernel_faults(dmesg_txt)
+SPEC = BoardOverlayProfile(
+    overlay_name="ad9081_zcu102_xsa",
+    lg_features=("ad9081", "zcu102"),
+    skip_reason_label="ad9081 zcu102",
+    cfg_builder=_solve_ad9081_config,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_ad9081_zcu102.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+        fallback_filenames=("system_top.xsa",),
+    ),
+    sdtgen_profile="ad9081_zcu102",
+    topology_assert=_topology_assert,
+    dtso_must_contain_all=("axi-ad9081",),
+    boot_mode="sd",
+    kernel_fixture_name="built_kernel_image_zynqmp",
+    iio_required_all=("hmc7044",),
+    iio_required_any=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+    iio_frontend_label="AD9081 RX frontend",
+    fft_mode="required",
+    capture_target_names=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+    pyadi_factory=_create_ad9081,
+    pyadi_class_name="ad9081",
+)
 
 
-@requires_lg
-@pytest.mark.lg_feature(["ad9081", "zcu102"])
-def test_reload_overlay(booted_board):
-    """Load → unload → load cycle; re-verify devices + JESD link."""
-    shell = _shell(booted_board)
-    _ensure_unloaded(shell)
-
-    _apply_and_wait(shell)
-    ctx, _ = open_iio_context(shell)
-    _assert_iio_devices_present(ctx, context="after overlay reload")
-    assert_jesd_links_data(shell, context="after overlay reload")
+@pytest.fixture(scope="module")
+def overlay_spec() -> BoardOverlayProfile:
+    return SPEC

--- a/test/hw/xsa/test_adrv9009_zc706_overlay.py
+++ b/test/hw/xsa/test_adrv9009_zc706_overlay.py
@@ -1,124 +1,64 @@
 """ADRV9009 + ZC706 runtime device-tree overlay hardware test.
 
-Mirrors :mod:`test.hw.xsa.test_ad9081_zcu102_overlay` for the ZC706 +
-ADRV9009-FMC daughter card on the ``nemo`` labgrid place.  Same six
-test shape (unit, configfs, load, DMA, unload, reload), same
-configfs lifecycle, same dmesg-delta error gating.
+Same six-test shape as the rest of the overlay suite — fixtures + tests
+live in :mod:`test.hw.xsa._overlay_base`.
 
-Two platform-specific differences from the AD9081 variant:
+Per-board specifics that stay in this file:
 
-1. **Boot transport** — ZC706 boots via :class:`BootFPGASoCTFTP`
-   (Zynq-7000 TFTP).  The merged DTB is renamed to ``devicetree.dtb``
-   so U-Boot's ``tftp devicetree.dtb`` finds it; the kernel is
-   ``uImage`` (legacy U-Boot image, wrapped from the built ``zImage``
-   by :func:`~test.hw.hw_helpers._wrap_zimage_as_uimage`).
-2. **DMA path** — the default post-boot Talise state on ZC706 +
-   ADRV9009 leaves buffered RX inert.  The DMA test pushes a
-   canonical iio-oscilloscope ``DC245p76`` Talise profile via
-   ``adrv9009-phy.profile_config`` first; that re-inits the radio
-   to ``radio_on`` without changing the JESD lane rate.  The
-   ADRV9009 ZC706 reference HDL has no internal DAC→ADC loopback
-   (unlike AD9081's ``ad_ip_jesd204_tpl_*`` cores), so a TX DDS tone
-   may not appear in the RX capture without an external SMA-to-SMA
-   cable on the daughter card.  The FFT stage asserts SNR > 10 dB
-   on a non-DC peak only when one is clearly present and otherwise
-   logs the noise-only result and passes.
+* :func:`_adrv9009_cfg` — JESD framing + GPIO + clock cfg matching the
+  Kuiper reference design ``zynq-zc706-adv7511-adrv9009``.
+* :func:`_filter_si570_probe_noise` — strips the benign si570 ``-EIO``
+  probe lines from dmesg before :func:`assert_no_probe_errors`.  The
+  optional Si570 clock chip on the ADRV9009-FMC sometimes does not ACK
+  at its default I2C address; the failure is present in the production
+  reference DT too and is unrelated to the overlay path.
+
+Per-family hooks pulled in from :mod:`test.hw.xsa._overlay_hooks`:
+
+* :func:`push_talise_profile` — ZC706 + ADRV9009 leaves buffered RX
+  inert in the default post-boot Talise state.  Pushing any DC-245.76
+  MHz profile re-inits the radio to ``radio_on`` without changing the
+  JESD lane rate.
+* :func:`resolve_adrv9009_rx_tpl` — picks the RX TPL by reg address
+  when the OBS TPL shares the same IIO name (sdtgen DTB).
 
 LG_ENV: ``test/hw/env/nemo.yaml``.
 """
 
 from __future__ import annotations
 
-import base64
-import os
-import shutil as _shutil
-import time
-import urllib.request
-from pathlib import Path
 from typing import Any
 
 import pytest
 
-from adidt.xsa.pipeline import XsaPipeline
-from adidt.xsa.topology import XsaParser
-from test.hw.hw_helpers import (
-    acquire_xsa,
-    assert_configfs_overlay_support,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    assert_rx_capture_valid,
-    check_jesd_framing_plausibility,
-    compile_dts_to_dtb,
-    compile_dtso_to_dtbo,
-    deploy_and_boot,
-    deploy_dtbo_via_shell,
-    load_overlay,
-    open_iio_context,
-    overlay_is_loaded,
-    shell_out,
-    unload_overlay,
+from test.hw.hw_helpers import check_jesd_framing_plausibility
+from test.hw.xsa._overlay_base import (  # noqa: F401 — pytest collects these
+    booted_board,
+    overlay_dtbo,
+    pipeline_result,
+    test_overlay_generation_unit,
+    test_configfs_overlay_support,
+    test_load_overlay,
+    test_dma_loopback,
+    test_unload_overlay,
+    test_reload_overlay,
 )
+from test.hw.xsa._overlay_hooks import push_talise_profile, resolve_adrv9009_rx_tpl
+from test.hw.xsa._overlay_spec import BoardOverlayProfile, acquire_or_local_xsa
 
-_HAS_LG = bool(os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV"))
-requires_lg = pytest.mark.skipif(
-    not _HAS_LG,
-    reason=(
-        "set LG_COORDINATOR or LG_ENV for ADRV9009 ZC706 overlay hardware tests"
-        " (see .env.example)"
-    ),
-)
 
 DEFAULT_KUIPER_RELEASE = "2023_r2"
 DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv9009"
-
-OVERLAY_NAME = "adrv9009_zc706_xsa"
-DTBO_REMOTE_PATH = f"/tmp/{OVERLAY_NAME}.dtbo"
-FDT_MAGIC = b"\xd0\x0d\xfe\xed"
-
-# DDS tone the optional FFT stage will request on TX.  Only relevant
-# if the daughter card has a TX→RX cable; otherwise the FFT stage
-# falls back to a noise-only diagnostic without asserting on the peak.
-DDS_TONE_HZ = 1_000_000
-DDS_SCALE = 0.5
-RX_BUFFER_SIZE = 2**14
-
-# Smallest of the canonical Talise filter profiles iio-oscilloscope
-# ships.  All four use ``deviceClock=245.76 MHz`` (matches our cfg's
-# 245.76 MHz device clock), so pushing this profile re-initialises the
-# Talise radio to a state where buffered RX is enabled without
-# changing the JESD lane rate.  ``test_adrv9009_zcu102_hw`` uses the
-# same source URL.
-TALISE_PROFILE_URL = (
-    "https://raw.githubusercontent.com/analogdevicesinc/iio-oscilloscope/"
-    "main/filters/adrv9009/"
-    "Tx_BW100_IR122p88_Rx_BW100_OR122p88_ORx_BW100_OR122p88_DC245p76.txt"
-)
-
-EXPECTED_IIO_NAMES_ANY = (
-    # Kuiper-built DTBs use ``axi-adrv9009-rx-hpc``; the sdtgen-built
-    # merged DTB the overlay test boots from labels the same buffered
-    # ADC frontend ``ad_ip_jesd204_tpl_adc`` instead.  Either is a
-    # valid sign that the RX side probed.
-    "axi-adrv9009-rx-hpc",
-    "axi-adrv9009-rx-obs-hpc",
-    "ad_ip_jesd204_tpl_adc",
-)
-EXPECTED_IIO_NAMES_ALL = ("adrv9009-phy",)
 
 
 def _adrv9009_cfg() -> dict[str, Any]:
     """ADRV9009+ZC706 XSA pipeline cfg.
 
     Hardcoded JESD framing matches Kuiper's stock
-    ``zynq-zc706-adv7511-adrv9009`` reference design (also matches the
-    pyadi-jif solver output for ``M=4, L=2, Np=16`` RX and
-    ``M=4, L=4, Np=16`` TX at 245.76 MHz).  Pre-flighted by
-    :func:`~test.hw.hw_helpers.check_jesd_framing_plausibility` so a
-    typo in this dict surfaces here, not at ILAS-training time on the
-    target.  GPIO numbers follow the production ZC706 wiring (gpio0:106
-    reset, gpio0:112 sysref-req); ADRV9009Builder defaults to ZCU102
-    GPIOs which are wrong for ZC706.
+    ``zynq-zc706-adv7511-adrv9009`` reference design.  ADRV9009Builder
+    defaults to ZCU102 GPIOs (130/136); ZC706 wires the same signals to
+    gpio0:106 (reset) and gpio0:112 (sysref-req), matching the Kuiper
+    production zynq-zc706-adv7511-adrv9009 DT.
     """
     cfg: dict[str, Any] = {
         "adrv9009_board": {
@@ -144,185 +84,8 @@ def _adrv9009_cfg() -> dict[str, Any]:
     return cfg
 
 
-@pytest.fixture(scope="module")
-def pipeline_result(tmp_path_factory) -> dict:
-    """Run :class:`XsaPipeline` once per module and return its output dict.
-
-    Tries the local fixture path first; falls back to
-    :func:`~test.hw.hw_helpers.acquire_xsa` which downloads the XSA
-    from the Kuiper release.  Skips the whole module when neither path
-    yields a usable XSA.
-    """
-    local_xsa = Path(__file__).parent / "system_top_adrv9009_zc706.xsa"
-    if not local_xsa.exists():
-        local_xsa = Path(__file__).parent / "ref_data" / "system_top_adrv9009_zc706.xsa"
-    try:
-        xsa_path = acquire_xsa(
-            local_xsa,
-            DEFAULT_KUIPER_RELEASE,
-            DEFAULT_KUIPER_PROJECT,
-            tmp_path_factory.mktemp("xsa_dl"),
-        )
-    except Exception as exc:  # noqa: BLE001 — any download/IO failure → skip
-        pytest.skip(f"could not acquire ADRV9009+ZC706 XSA: {exc}")
-
-    topology = XsaParser().parse(xsa_path)
-    assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
-    assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
-
-    out_dir = tmp_path_factory.mktemp("overlay") / "out"
-    return XsaPipeline().run(
-        xsa_path=xsa_path,
-        cfg=_adrv9009_cfg(),
-        output_dir=out_dir,
-        profile="adrv9009_zc706",
-        sdtgen_timeout=300,
-    )
-
-
-@pytest.fixture(scope="module")
-def overlay_dtbo(pipeline_result, tmp_path_factory) -> Path:
-    """Compile the pipeline ``.dtso`` to ``.dtbo`` (module-scoped, once)."""
-    overlay_src: Path = pipeline_result["overlay"]
-    assert overlay_src.exists(), f"pipeline did not emit overlay DTSO: {overlay_src}"
-
-    dtbo_dir = tmp_path_factory.mktemp("dtbo")
-    dtbo = dtbo_dir / f"{OVERLAY_NAME}.dtbo"
-    compile_dtso_to_dtbo(overlay_src, dtbo)
-
-    assert dtbo.exists(), f"dtc -@ did not produce DTBO: {dtbo}"
-    size = dtbo.stat().st_size
-    assert size > 100, f"DTBO suspiciously small ({size} bytes): {dtbo}"
-    magic = dtbo.read_bytes()[:4]
-    assert magic == FDT_MAGIC, f"DTBO missing FDT magic (got {magic.hex()}): {dtbo}"
-    return dtbo
-
-
-@pytest.fixture(scope="module")
-def booted_board(
-    board, built_kernel_image_zynq, pipeline_result, overlay_dtbo, tmp_path_factory
-):
-    """Boot ZC706 with the pipeline's merged DTB and stage the ``.dtbo``.
-
-    Same rationale as the AD9081 overlay test: booting from the merged
-    DTB the pipeline produces means the ADRV9009 SPI probe is clean
-    from boot, so the overlay tests exercise the configfs lifecycle on
-    top of an already-probed tree without inheriting unrelated boot
-    issues.
-
-    The DTB is renamed to ``devicetree.dtb`` because
-    ``BootFPGASoCTFTP`` (configured in ``test/hw/env/nemo.yaml``) sets
-    ``dtb_image_name: devicetree.dtb`` — the file U-Boot's
-    ``tftp devicetree.dtb`` looks up in the TFTP root.  Matches the
-    staging in ``test_adrv9009_zc706_hw``.
-    """
-    out_dir = tmp_path_factory.mktemp("merged_boot")
-    merged_dts = pipeline_result["merged"]
-    dtb_raw = out_dir / "adrv9009_zc706_xsa.dtb"
-    compile_dts_to_dtb(merged_dts, dtb_raw)
-
-    staged_dir = out_dir / "tftp_staging"
-    staged_dir.mkdir(parents=True, exist_ok=True)
-    staged = staged_dir / "devicetree.dtb"
-    _shutil.copyfile(dtb_raw, staged)
-
-    shell = deploy_and_boot(board, staged, built_kernel_image_zynq)
-
-    deploy_dtbo_via_shell(shell, overlay_dtbo, DTBO_REMOTE_PATH)
-
-    if overlay_is_loaded(shell, OVERLAY_NAME):
-        unload_overlay(shell, OVERLAY_NAME)
-
-    return board
-
-
-def _shell(booted):
-    return booted.target.get_driver("ADIShellDriver")
-
-
-def _ensure_unloaded(shell) -> None:
-    if overlay_is_loaded(shell, OVERLAY_NAME):
-        unload_overlay(shell, OVERLAY_NAME)
-        time.sleep(2.0)
-
-
-def _apply_and_wait(shell) -> None:
-    res = load_overlay(shell, OVERLAY_NAME, DTBO_REMOTE_PATH)
-    assert "RC=0" in res, f"overlay load failed: {res}"
-    # ADRV9009 / Talise re-init after overlay apply takes longer than
-    # the AD9081 path; give the JESD FSM time to walk SYNC -> ILAS ->
-    # DATA before any sysfs check.
-    time.sleep(8.0)
-
-
-def _load_talise_profile(shell, cache_dir: Path) -> bool:
-    """Push a Talise filter profile to ``adrv9009-phy.profile_config``.
-
-    On ZC706 + ADRV9009 the default post-boot Talise state leaves the
-    buffered RX path inert (unlike ZCU102 where the default profile
-    is RX-capable).  Pushing any profile triggers a Talise re-init
-    that brings the radio up to ``radio_on``, after which DMA
-    capture works.  Returns ``True`` if the profile was applied,
-    ``False`` if the sysfs ``profile_config`` node could not be
-    located (e.g. driver build without debugfs support).
-    """
-    profile_sysfs = shell_out(
-        shell,
-        "find /sys/kernel/debug/iio /sys/bus/iio/devices "
-        "-name profile_config 2>/dev/null | head -1",
-    ).strip()
-    if not profile_sysfs:
-        profile_sysfs = shell_out(
-            shell,
-            "find /sys -name profile_config 2>/dev/null | head -1",
-        ).strip()
-    if not profile_sysfs:
-        return False
-
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    cached = cache_dir / "talise_default.txt"
-    if cached.exists() and cached.stat().st_size > 0:
-        body = cached.read_text()
-    else:
-        with urllib.request.urlopen(TALISE_PROFILE_URL, timeout=30) as resp:  # noqa: S310
-            body = resp.read().decode("utf-8")
-        cached.write_text(body)
-    if not body.lstrip().startswith("<profile "):
-        raise AssertionError(
-            "Talise profile fetch returned non-XML content"
-            f" (first 80 chars: {body[:80]!r})"
-        )
-
-    b64 = base64.b64encode(body.encode()).decode()
-    shell_out(shell, f"printf '%s' '{b64}' | base64 -d > /tmp/talise.txt")
-    size_on_target = shell_out(shell, "stat -c%s /tmp/talise.txt").strip()
-    assert size_on_target == str(len(body.encode())), (
-        f"Talise profile partial push: target has {size_on_target},"
-        f" expected {len(body.encode())}"
-    )
-    shell_out(shell, f"cat /tmp/talise.txt > {profile_sysfs}")
-    # Talise re-init re-runs the JESD bring-up sequence; give the FSM
-    # time to relock both links before any sysfs check.
-    time.sleep(3.0)
-
-    # Profile push leaves the radio in ``calibrated`` (ENSM state 6) on
-    # ZC706 builds — we need ``radio_on`` (state 7) before the buffered
-    # RX path will deliver samples through DMA.  ensm_mode is exposed
-    # at the adrv9009-phy IIO device level (sibling to profile_config).
-    phy_dir = profile_sysfs.rsplit("/", 1)[0]
-    shell_out(shell, f"echo radio_on > {phy_dir}/ensm_mode")
-    time.sleep(1.0)
-    return True
-
-
 def _filter_si570_probe_noise(dmesg_txt: str) -> str:
-    """Strip the benign si570 -EIO probe lines.
-
-    The optional Si570 clock chip on the ADRV9009-FMC sometimes does
-    not ACK at its default I2C address; the probe failure is present
-    in the production reference DT too and is unrelated to the
-    overlay path.
-    """
+    """Strip benign si570 -EIO probe lines from dmesg."""
     return "\n".join(
         line
         for line in dmesg_txt.splitlines()
@@ -330,321 +93,42 @@ def _filter_si570_probe_noise(dmesg_txt: str) -> str:
     )
 
 
-def _assert_iio_devices_present(ctx, *, context: str) -> None:
-    found = {d.name for d in ctx.devices if d.name}
-    suffix = f" ({context})" if context else ""
-    for required in EXPECTED_IIO_NAMES_ALL:
-        assert required in found, (
-            f"IIO device {required!r} not present{suffix}. Devices: {sorted(found)}"
-        )
-    assert any(n in found for n in EXPECTED_IIO_NAMES_ANY), (
-        f"ADRV9009 RX frontend not present{suffix}. "
-        f"Expected one of {EXPECTED_IIO_NAMES_ANY}; "
-        f"found: {sorted(found)}"
-    )
+def _topology_assert(topology) -> None:
+    assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
+    assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
-def test_overlay_generation_unit(pipeline_result, overlay_dtbo):
-    """No-hardware check: the pipeline's DTSO is a valid overlay + compiles."""
-    dtso: Path = pipeline_result["overlay"]
-    src = dtso.read_text()
-    assert "/plugin/;" in src, (
-        f"Pipeline overlay missing /plugin/; directive — "
-        f"dtc -@ will not treat it as an overlay: {dtso}"
-    )
-    assert "axi-jesd204" in src or "adrv9009" in src.lower(), (
-        f"Pipeline overlay does not reference ADRV9009 / JESD nodes: {dtso}"
-    )
-    assert overlay_dtbo.exists() and overlay_dtbo.stat().st_size > 100
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9009", "zc706"])
-def test_configfs_overlay_support(booted_board):
-    """Target kernel must support runtime overlays via configfs."""
-    assert_configfs_overlay_support(_shell(booted_board))
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9009", "zc706"])
-def test_load_overlay(booted_board, tmp_path):
-    """Apply the overlay; verify clean probe, IIO discovery, and JESD DATA."""
-    shell = _shell(booted_board)
-    _ensure_unloaded(shell)
-
-    # dmesg before overlay-apply is the boot log — filter it out so we
-    # only flag errors caused by the overlay itself.
-    dmesg_baseline = int(shell_out(shell, "dmesg | wc -l").strip() or "0")
-
-    _apply_and_wait(shell)
-
-    dmesg_full = shell_out(shell, "dmesg")
-    (tmp_path / "dmesg_after_load.log").write_text(dmesg_full)
-    dmesg_new = "\n".join(dmesg_full.splitlines()[dmesg_baseline:])
-    (tmp_path / "dmesg_overlay_only.log").write_text(dmesg_new)
-    assert_no_kernel_faults(dmesg_new)
-    assert_no_probe_errors(_filter_si570_probe_noise(dmesg_new))
-
-    ctx, _ = open_iio_context(shell)
-    _assert_iio_devices_present(ctx, context="after overlay load")
-
-    rx_status, tx_status = assert_jesd_links_data(shell, context="after overlay load")
-    print(f"$ cat .../*.axi?jesd204?rx/status\n{rx_status}")
-    print(f"$ cat .../*.axi?jesd204?tx/status\n{tx_status}")
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9009", "zc706"])
-def test_dma_loopback(booted_board, tmp_path):
-    """Verify DMA TX→RX data path.
-
-    Setup: push a single Talise filter profile to wake the radio.
-    The default post-boot Talise state on ZC706 + ADRV9009 leaves
-    buffered RX inert; pushing any DC-245.76 MHz profile re-inits
-    the chip into ``radio_on`` without changing the JESD lane rate.
-
-    Two verification phases:
-
-    * **Mandatory:** :func:`assert_rx_capture_valid` confirms that an
-      RX buffer arrives with non-zero, non-latched samples.  Same
-      smoke check ``test_adrv9009_zcu102_hw`` runs.
-    * **Opportunistic FFT:** drive a DDS tone on TX and look for a
-      coherent peak in the RX spectrum.  If one is present (SNR
-      > 10 dB), it must be non-DC and non-Nyquist.  If no peak emerges
-      (the typical case on ZC706 + ADRV9009 without an external
-      TX→RX SMA cable on the FMC), the noise-floor metric is logged
-      and the stage passes — TX→RX coupling is a lab-setup concern,
-      not an overlay-lifecycle concern.
-    """
-    pytest.importorskip("adi")
-    np = pytest.importorskip("numpy")
-
-    shell = _shell(booted_board)
-    if not overlay_is_loaded(shell, OVERLAY_NAME):
-        pytest.skip("overlay not loaded — test_load_overlay must run first")
-
-    profile_loaded = _load_talise_profile(shell, tmp_path / "talise_cache")
-    if profile_loaded:
-        # Talise re-init walks JESD through SYNC → ILAS → DATA again.
-        assert_jesd_links_data(shell, context="after Talise profile push")
-    else:
-        print(
-            "Talise profile_config sysfs not found — proceeding with"
-            " default post-boot Talise state"
-        )
-
-    ctx, ip = open_iio_context(shell)
-
-    # Phase 1: bare data-path smoke check.
-    #
-    # Both the RX TPL (``...@44a00000``) and the OBS TPL
-    # (``...@44a08000``) probe to libiio with the same of_node
-    # name ``ad_ip_jesd204_tpl_adc`` — their unit-names are
-    # identical in the sdtgen-built DTB.  ``find_device`` returns
-    # whichever probed first (typically OBS via ``ad_adc.c``,
-    # before cf_axi_adc binds the RX TPL).  Talise's ``radio_on``
-    # streams framer-A (RX); framer-B (OBS) stays gated, so a
-    # refill on the OBS device returns all zeros even though the
-    # OBS DMA fires its done IRQ.  Prefer the RX TPL by reg
-    # address so we exercise the path ``radio_on`` actually
-    # enables.
-    rx_tpl_dev = None
-    for d in ctx.devices:
-        if d.name != "ad_ip_jesd204_tpl_adc":
-            continue
-        try:
-            of_node = d.attrs["of_node"].value if "of_node" in d.attrs else ""
-        except Exception:  # noqa: BLE001 — attr read may raise on some builds
-            of_node = ""
-        if "44a00000" in of_node:
-            rx_tpl_dev = d
-            break
-    if rx_tpl_dev is None:
-        # ``of_node`` isn't always exposed as an IIO attr; fall back
-        # to the higher-numbered duplicate.  cf_axi_adc binds the RX
-        # TPL after ``ad_adc`` binds OBS, so the RX iio:device has
-        # the larger numeric id.
-        candidates = [d for d in ctx.devices if d.name == "ad_ip_jesd204_tpl_adc"]
-        if candidates:
-            rx_tpl_dev = max(candidates, key=lambda d: int(d.id.rsplit(":device", 1)[1]))
-
-    target_names: tuple[str, ...] = (
+SPEC = BoardOverlayProfile(
+    overlay_name="adrv9009_zc706_xsa",
+    lg_features=("adrv9009", "zc706"),
+    skip_reason_label="adrv9009 zc706",
+    cfg_builder=_adrv9009_cfg,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_adrv9009_zc706.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    sdtgen_profile="adrv9009_zc706",
+    topology_assert=_topology_assert,
+    dtso_must_contain_any=("axi-jesd204", "adrv9009"),
+    boot_mode="tftp",
+    kernel_fixture_name="built_kernel_image_zynq",
+    settle_after_apply_s=8.0,  # Talise re-init is slower than AD9081.
+    iio_required_all=("adrv9009-phy",),
+    iio_required_any=(
         "axi-adrv9009-rx-hpc",
         "axi-adrv9009-rx-obs-hpc",
         "ad_ip_jesd204_tpl_adc",
-    )
-    if rx_tpl_dev is not None:
-        target_names = (rx_tpl_dev.id,)
-
-    try:
-        assert_rx_capture_valid(
-            ctx,
-            target_names,
-            n_samples=2**12,
-            context="adrv9009 zc706 overlay",
-        )
-    except AssertionError:
-        # On-target diagnostics: IRQ counts disambiguate
-        # DMA-not-firing from JESD-not-streaming for the next
-        # round of debugging.
-        print("=== /proc/interrupts ===")
-        print(shell_out(shell, "cat /proc/interrupts"))
-        print("=== dmesg tail ===")
-        print(shell_out(shell, "dmesg | tail -n 60"))
-        raise
-
-    # Phase 2: opportunistic spectrum check via pyadi-iio.
-    #
-    # ``pyadi-iio`` looks up the buffered ADC by the production
-    # name ``axi-adrv9009-rx-hpc``.  Our merged DTB names the same
-    # node ``ad_ip_jesd204_tpl_adc`` (sdtgen unit-name), so the
-    # ``adi.adrv9009`` constructor returns an object with
-    # ``_rxadc = None`` instead of raising — every subsequent
-    # ``dev.rx_*`` access then crashes with ``AttributeError``.
-    # Detect that state up front and skip; Phase 1 already
-    # validated the data path.
-    import adi
-
-    try:
-        dev = adi.adrv9009(uri=f"ip:{ip}")
-    except Exception as exc:  # noqa: BLE001 — connect failure → skip phase 2
-        print(f"adi.adrv9009 unavailable; skipping FFT phase: {exc}")
-        return
-    if getattr(dev, "_rxadc", None) is None:
-        print(
-            "adi.adrv9009 missing 'axi-adrv9009-rx-hpc' IIO name "
-            "(merged DTB exposes 'ad_ip_jesd204_tpl_adc' instead) — "
-            "skipping FFT phase; Phase 1 already validated the data path."
-        )
-        return
-
-    dev.rx_enabled_channels = [0]
-    dev.rx_buffer_size = RX_BUFFER_SIZE
-    sample_rate = int(dev.rx_sample_rate)
-    print(f"ADRV9009 RX sample rate: {sample_rate} Hz, buffer: {RX_BUFFER_SIZE}")
-
-    try:
-        try:
-            dev.dds_single_tone(DDS_TONE_HZ, DDS_SCALE, channel=0)
-        except Exception as exc:  # noqa: BLE001 — log and continue without DDS
-            print(f"adrv9009 DDS setup failed; capturing anyway: {exc}")
-
-        for _ in range(3):
-            dev.rx()
-        raw = dev.rx()
-    except TimeoutError:
-        pytest.skip("DMA buffer refill timed out — JESD link may not be in DATA mode")
-    finally:
-        for cleanup in ("disable_dds", "rx_destroy_buffer"):
-            try:
-                getattr(dev, cleanup)()
-            except Exception:  # noqa: BLE001 — best-effort cleanup
-                pass
-
-    samples = raw[0] if isinstance(raw, list) else raw
-    samples = np.asarray(samples)
-    if samples.size < 1024:
-        print(f"FFT phase: capture too short ({samples.size}); skipping spectrum check")
-        return
-
-    nfft = 1 << int(np.floor(np.log2(samples.size)))
-    trimmed = samples[:nfft]
-    win = np.hanning(nfft).astype(np.float64)
-    if np.iscomplexobj(trimmed):
-        spectrum = np.fft.fftshift(
-            np.fft.fft(trimmed.astype(np.complex128) * win, n=nfft)
-        )
-        freqs = np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / sample_rate))
-    else:
-        spectrum = np.fft.rfft(trimmed.astype(np.float64) * win, n=nfft)
-        freqs = np.fft.rfftfreq(nfft, d=1.0 / sample_rate)
-
-    mags = np.abs(spectrum)
-    fbin = sample_rate / nfft
-    nyquist = sample_rate / 2
-
-    dc_guard = 5
-    zero_idx = int(np.argmin(np.abs(freqs)))
-    nondc_mask = np.ones(mags.size, dtype=bool)
-    nondc_mask[
-        max(0, zero_idx - dc_guard) : min(mags.size, zero_idx + dc_guard + 1)
-    ] = False
-
-    search_mags = np.where(nondc_mask, mags, 0.0)
-    peak_idx = int(np.argmax(search_mags))
-    peak_mag = float(mags[peak_idx])
-    if peak_mag <= 0:
-        print("FFT phase: spectrum has no non-DC content (RX inert?)")
-        return
-    mags_db = 20.0 * np.log10(np.maximum(mags, 1e-9) / peak_mag)
-    signal_freq = float(abs(freqs[peak_idx]))
-    signal_mag_db = float(mags_db[peak_idx])
-
-    noise_mask = nondc_mask.copy()
-    lo = max(0, peak_idx - 5)
-    hi = min(mags.size, peak_idx + 6)
-    noise_mask[lo:hi] = False
-    noise_db = float(np.median(mags_db[noise_mask]))
-    snr_db = signal_mag_db - noise_db
-
-    print(
-        f"FFT phase: strongest non-DC bin {signal_freq:.0f} Hz "
-        f"({signal_mag_db:.1f} dB), noise floor {noise_db:.1f} dB, "
-        f"SNR {snr_db:.1f} dB, fbin {fbin:.0f} Hz, DDS req {DDS_TONE_HZ} Hz"
-    )
-
-    # Only assert the spectral shape when a clear tone emerges.  ZC706
-    # ADRV9009 reference HDL has no internal TX→RX loopback, so without
-    # an external cable the "peak" is just the strongest noise bin and
-    # the SNR vs the floor stays in single digits.
-    if snr_db < 10.0:
-        print(
-            "FFT phase: no coherent tone (SNR ≤ 10 dB) — recording noise-only "
-            "result and passing.  External TX↔RX coupling is a lab-setup "
-            "detail, not an overlay-lifecycle requirement."
-        )
-        return
-
-    assert signal_freq < nyquist - 10 * fbin, (
-        f"Loopback peak too close to Nyquist ({signal_freq:.0f} Hz > "
-        f"{nyquist - 10 * fbin:.0f} Hz)"
-    )
-    print(f"FFT phase: tone detected, SNR {snr_db:.1f} dB at {signal_freq:.0f} Hz")
+    ),
+    iio_frontend_label="ADRV9009 RX frontend",
+    dmesg_filter=_filter_si570_probe_noise,
+    fft_mode="optional",
+    pre_capture_hook=push_talise_profile,
+    capture_targets_resolver=resolve_adrv9009_rx_tpl,
+    pyadi_class_name="adrv9009",
+)
 
 
-@requires_lg
-@pytest.mark.lg_feature(["adrv9009", "zc706"])
-def test_unload_overlay(booted_board):
-    """Removing the configfs entry tears down without kernel faults."""
-    shell = _shell(booted_board)
-    if not overlay_is_loaded(shell, OVERLAY_NAME):
-        _apply_and_wait(shell)
-
-    res = unload_overlay(shell, OVERLAY_NAME)
-    assert "RC=0" in res, f"overlay unload failed: {res}"
-    time.sleep(2.0)
-
-    assert not overlay_is_loaded(shell, OVERLAY_NAME), (
-        "overlay configfs entry still present after rmdir"
-    )
-
-    dmesg_txt = shell_out(shell, "dmesg")
-    assert_no_kernel_faults(dmesg_txt)
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9009", "zc706"])
-def test_reload_overlay(booted_board):
-    """Load → unload → load cycle; re-verify devices + JESD link."""
-    shell = _shell(booted_board)
-    _ensure_unloaded(shell)
-
-    _apply_and_wait(shell)
-    ctx, _ = open_iio_context(shell)
-    _assert_iio_devices_present(ctx, context="after overlay reload")
-    assert_jesd_links_data(shell, context="after overlay reload")
+@pytest.fixture(scope="module")
+def overlay_spec() -> BoardOverlayProfile:
+    return SPEC

--- a/test/hw/xsa/test_adrv9371_zc706_overlay.py
+++ b/test/hw/xsa/test_adrv9371_zc706_overlay.py
@@ -1,133 +1,75 @@
 """ADRV9371 + ZC706 runtime device-tree overlay hardware test.
 
-Mirrors :mod:`test.hw.xsa.test_adrv9009_zc706_overlay` for the ZC706 +
-ADRV9371-FMC daughter card on the ``bq`` labgrid place.  Same six-test
-shape (unit, configfs, load, DMA, unload, reload), same configfs
-lifecycle, same dmesg-delta error gating.
+Same six-test shape as the rest of the overlay suite — fixtures + tests
+live in :mod:`test.hw.xsa._overlay_base`.
 
-Differences from the ADRV9009 variant:
+Per-board specifics that stay in this file:
 
-1. **Profile transport** — ADRV9371 uses the Mykonos firmware
-   architecture; the per-radio configuration is baked into the DT as
-   ``adi,*-profile-*`` / ``adi,clocks-*`` properties on
-   ``ad9371-phy@1`` at probe time (see ``adrv937x_zc706.json`` and
-   :mod:`adidt.xsa.builders.adrv937x`).  There is no runtime
-   ``profile_config`` sysfs equivalent, so the DMA test does not push
-   a profile after overlay apply — the radio is already configured by
-   the merged base DTB before the overlay is applied.
-2. **DMA path** — ZC706 + ADRV9371 reference HDL has no internal
-   DAC→ADC loopback, same as ADRV9009.  Phase 1 (mandatory) asserts
-   non-zero, non-latched RX samples via :func:`assert_rx_capture_valid`.
-   Phase 2 (opportunistic) computes an FFT to look for a coherent
-   tone if a TX→RX SMA cable is wired on the FMC; absence of a peak
-   is logged but not a failure.
+* :func:`_adrv9371_cfg` — the JESD framing + GPIO + AD9528 cfg.  Kept
+  here because it is genuinely board-specific (gpio0:106 reset,
+  gpio0:112 sysref-req, etc.) and is the same wiring the merged-DTB
+  test ``test_adrv9371_zc706_xsa_hw`` uses.
+* :func:`_dmac_irq_failure_probe` — Zynq-7000-specific GIC distributor
+  forensics for the documented HDL IRQ-wiring blocker
+  (``axi_dmac@7c400000`` SPI 31 → GIC IRQ 63).  Wired into the SPEC
+  via ``fft_failure_diagnostics`` so it only fires when capture fails.
 
 Two distinct bring-up blockers were debugged and fixed during this
 test's development against the ``release:zynq-zc706-adv7511-adrv937x``
 bitstream that ``bq`` loads:
 
-1. **ILAS framing mismatch** (``mismatch=0xc7f8``, 9 framing fields
-   disagreeing) — the AD9371 deframer's "received-ILAS" registers
-   were stale zeros because the FPGA TX framer never emitted a valid
-   ILAS sequence.  Root cause: the TPL DAC core
-   (``axi_ad9371_core_tx`` upstream) was missing from the JESD204
-   topology graph, so ``cf_axi_dds_jesd204_post_running_stage`` /
-   ``cf_axi_dds_start_sync`` never armed the DAC data path.  Fixed
-   in ``adidt/xsa/builders/adrv937x.py`` ``tx_core_second`` block
-   (adds ``jesd204-device`` / ``#jesd204-cells`` / ``jesd204-inputs``
-   on the TPL DAC core) and the redirected ``trx_inputs_value``
-   pointing the AD9371 phy at the TPL DAC core for its TX link.
-
+1. **ILAS framing mismatch** — the AD9371 deframer's "received-ILAS"
+   registers were stale zeros because the FPGA TX framer never emitted
+   a valid ILAS sequence.  Fixed in
+   ``adidt/xsa/builders/adrv937x.py`` ``tx_core_second`` block.
 2. **AXI DMAC IRQ number wrong in DT** — sdtgen extracted SPI 31/32
-   from the XSA but the loaded bitstream actually wires the DMAC IRQ
-   wires to SPI 57/56 (= GIC IRQ 89/88).  Confirmed on bq: DMAC
-   ``TRANSFER_DONE`` incremented and ``GICD ICDISPR[2]`` had bit 25
-   set (= IRQ 89 pending) while the DT-declared IRQ stayed at 0 in
-   ``/proc/interrupts``.  Manually injecting IRQ 63 via
-   ``GICD+0x204`` correctly fired the registered handler — proving
-   the kernel's IRQ machinery worked, only the DT-declared IRQ
-   number was wrong.  Fixed in the same builder by setting
-   ``dma_interrupts_str`` on the RX/TX ``JesdLinkModel``s; the
-   ``_render_dma_overlay`` then emits a ``/delete-property/
-   interrupts;`` + ``interrupts = <0 57 4>`` (RX) / ``<0 56 4>``
-   (TX) override matching the upstream Kuiper reference DT.
+   from the XSA but the bitstream wires the DMAC IRQ to SPI 57/56.
+   Fixed by setting ``dma_interrupts_str`` on the RX/TX
+   ``JesdLinkModel``s; the resulting overlay emits a
+   ``/delete-property/ interrupts;`` + ``interrupts = <0 57 4>`` (RX)
+   / ``<0 56 4>`` (TX) override matching upstream Kuiper.
 
 LG_ENV: ``test/hw/env/bq.yaml``.
 """
 
 from __future__ import annotations
 
-import os
-import time
-from pathlib import Path
 from typing import Any
 
 import pytest
 
-from adidt.xsa.pipeline import XsaPipeline
-from adidt.xsa.topology import XsaParser
-from test.hw.hw_helpers import (
-    acquire_xsa,
-    assert_configfs_overlay_support,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    assert_rx_capture_valid,
-    check_jesd_framing_plausibility,
-    compile_dts_to_dtb,
-    compile_dtso_to_dtbo,
-    deploy_and_boot,
-    deploy_dtbo_via_shell,
-    load_overlay,
-    open_iio_context,
-    overlay_is_loaded,
-    shell_out,
-    stage_dtb_as_devicetree,
-    unload_overlay,
+from test.hw.hw_helpers import check_jesd_framing_plausibility, shell_out
+from test.hw.xsa._overlay_base import (  # noqa: F401 — pytest collects these
+    booted_board,
+    overlay_dtbo,
+    pipeline_result,
+    test_overlay_generation_unit,
+    test_configfs_overlay_support,
+    test_load_overlay,
+    test_dma_loopback,
+    test_unload_overlay,
+    test_reload_overlay,
 )
+from test.hw.xsa._overlay_spec import BoardOverlayProfile, acquire_or_local_xsa
 
-_HAS_LG = bool(os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV"))
-requires_lg = pytest.mark.skipif(
-    not _HAS_LG,
-    reason=(
-        "set LG_COORDINATOR or LG_ENV for ADRV9371 ZC706 overlay hardware tests"
-        " (see .env.example)"
-    ),
-)
 
 DEFAULT_KUIPER_RELEASE = "2023_R2_P1"
 DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv937x"
 DEFAULT_VCXO_HZ = 122_880_000
 
-OVERLAY_NAME = "adrv9371_zc706_xsa"
-DTBO_REMOTE_PATH = f"/tmp/{OVERLAY_NAME}.dtbo"
-FDT_MAGIC = b"\xd0\x0d\xfe\xed"
-
-DDS_TONE_HZ = 1_000_000
-DDS_SCALE = 0.5
-RX_BUFFER_SIZE = 2**14
-
-EXPECTED_IIO_NAMES_ANY = (
-    "axi-ad9371-rx-hpc",
-    "ad_ip_jesd204_tpl_adc",
-)
-EXPECTED_IIO_NAMES_ALL = ("ad9528-1", "ad9371-phy")
-
 
 def _adrv9371_cfg() -> dict[str, Any]:
     """ADRV9371+ZC706 XSA pipeline cfg.
 
-    Lifted verbatim from :mod:`test.hw.test_adrv9371_zc706_hw` so the
-    XSA pipeline path the overlay test exercises is identical to the
-    one the full-DTB system test exercises — any framing or GPIO
-    drift between the two stays a single edit.
+    Matches :mod:`test.hw.test_adrv9371_zc706_hw` so the XSA pipeline
+    path the overlay test exercises is identical to the one the
+    full-DTB system test exercises — any framing or GPIO drift between
+    the two stays a single edit.
 
     JESD framing matches the Kuiper reference design
     ``zynq-zc706-adv7511-adrv937x``: RX = M=4 L=2 S=1 → F=4;
-    TX = M=4 L=4 S=1 → F=2 (per ``analogdevicesinc/hdl/projects/
-    adrv9371x/zc706/README``).  Mykonos profile properties come from
-    ``adidt/xsa/profiles/adrv937x_zc706.json`` and are not duplicated
-    here.
+    TX = M=4 L=4 S=1 → F=2.  Mykonos profile properties come from
+    ``adidt/xsa/profiles/adrv937x_zc706.json``.
     """
     cfg: dict[str, Any] = {
         "adrv9009_board": {
@@ -155,394 +97,79 @@ def _adrv9371_cfg() -> dict[str, Any]:
     return cfg
 
 
-@pytest.fixture(scope="module")
-def pipeline_result(tmp_path_factory) -> dict:
-    """Run :class:`XsaPipeline` once per module and return its output dict."""
-    local_xsa = Path(__file__).parent / "system_top_adrv9371_zc706.xsa"
-    try:
-        xsa_path = acquire_xsa(
-            local_xsa,
-            DEFAULT_KUIPER_RELEASE,
-            DEFAULT_KUIPER_PROJECT,
-            tmp_path_factory.mktemp("xsa_dl"),
-        )
-    except Exception as exc:  # noqa: BLE001 — any download/IO failure → skip
-        pytest.skip(f"could not acquire ADRV9371+ZC706 XSA: {exc}")
+def _dmac_irq_failure_probe(shell) -> None:
+    """Print Zynq-7000 GIC + DMAC state when an RX capture fails.
 
-    topology = XsaParser().parse(xsa_path)
+    Surfaces the canonical signature that distinguishes the documented
+    HDL IRQ-wiring blocker from a real DT regression.  If
+    ``TRANSFER_DONE > 0`` + ``IRQ_PENDING != 0`` + ``GICD pending == 0``
+    + ``/proc/interrupts count == 0``, the DMAC IRQ line is the culprit
+    (HDL bitstream).  Anything else is a new bug.
+    """
+    print("=== DMAC HW progress (TRANSFER_DONE / IRQ_PENDING / IRQ_SOURCE) ===")
+    print(
+        shell_out(
+            shell,
+            "for off in 0x084 0x088 0x418 0x428 0x42c; do "
+            "  v=$(busybox devmem $((0x7c400000 + off)) 2>&1 | head -1); "
+            "  printf 'dmac+%s = %s\\n' $off \"$v\"; "
+            "done",
+        )
+    )
+    print("=== GIC distributor (IRQ 63 enable + pending) ===")
+    print(
+        shell_out(
+            shell,
+            # Zynq-7000 GICD at 0xF8F01000;
+            #   ICDISER1=+0x104 (enable for IRQs 32-63)
+            #   ICDISPR1=+0x204 (pending for IRQs 32-63)
+            # axi_dmac@7c400000 → SPI 31 → GIC IRQ 63 → bit 31 of word 1.
+            "for r in 0x104 0x204; do "
+            "  v=$(busybox devmem $((0xF8F01000 + r)) 2>&1 | head -1); "
+            "  printf 'GICD+%s = %s\\n' $r \"$v\"; "
+            "done",
+        )
+    )
+    print("=== /proc/interrupts (jesd + axi_dmac counts) ===")
+    print(
+        shell_out(
+            shell,
+            "grep -E 'jesd|axi_dmac' /proc/interrupts || true",
+        )
+    )
+
+
+def _topology_assert(topology) -> None:
     assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
     assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
 
-    out_dir = tmp_path_factory.mktemp("overlay") / "out"
-    return XsaPipeline().run(
-        xsa_path=xsa_path,
-        cfg=_adrv9371_cfg(),
-        output_dir=out_dir,
-        profile="adrv937x_zc706",
-        sdtgen_timeout=300,
-    )
+
+SPEC = BoardOverlayProfile(
+    overlay_name="adrv9371_zc706_xsa",
+    lg_features=("adrv9371", "zc706"),
+    skip_reason_label="adrv9371 zc706",
+    cfg_builder=_adrv9371_cfg,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_adrv9371_zc706.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    sdtgen_profile="adrv937x_zc706",
+    topology_assert=_topology_assert,
+    dtso_must_contain_any=("ad9371", "axi-jesd204"),
+    boot_mode="tftp",
+    kernel_fixture_name="built_kernel_image_zynq",
+    settle_after_apply_s=8.0,  # Mykonos re-init is slower than AD9081.
+    iio_required_all=("ad9528-1", "ad9371-phy"),
+    iio_required_any=("axi-ad9371-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+    iio_frontend_label="AD9371 RX frontend",
+    fft_mode="optional",
+    capture_target_names=("axi-ad9371-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+    pyadi_class_name="adrv9371",
+    fft_failure_diagnostics=_dmac_irq_failure_probe,
+)
 
 
 @pytest.fixture(scope="module")
-def overlay_dtbo(pipeline_result, tmp_path_factory) -> Path:
-    """Compile the pipeline ``.dtso`` to ``.dtbo`` (module-scoped, once)."""
-    overlay_src: Path = pipeline_result["overlay"]
-    assert overlay_src.exists(), f"pipeline did not emit overlay DTSO: {overlay_src}"
-
-    dtbo_dir = tmp_path_factory.mktemp("dtbo")
-    dtbo = dtbo_dir / f"{OVERLAY_NAME}.dtbo"
-    compile_dtso_to_dtbo(overlay_src, dtbo)
-
-    assert dtbo.exists(), f"dtc -@ did not produce DTBO: {dtbo}"
-    size = dtbo.stat().st_size
-    assert size > 100, f"DTBO suspiciously small ({size} bytes): {dtbo}"
-    magic = dtbo.read_bytes()[:4]
-    assert magic == FDT_MAGIC, f"DTBO missing FDT magic (got {magic.hex()}): {dtbo}"
-    return dtbo
-
-
-@pytest.fixture(scope="module")
-def booted_board(
-    board, built_kernel_image_zynq, pipeline_result, overlay_dtbo, tmp_path_factory
-):
-    """Boot ZC706 with the pipeline's merged DTB and stage the ``.dtbo``.
-
-    Same rationale as the ADRV9009 ZC706 overlay test: the merged DTB
-    has the AD9528 + AD9371 SPI nodes already in place, so the overlay
-    exercises the configfs lifecycle on top of an already-probed tree
-    without inheriting unrelated stock-image boot issues.
-
-    The DTB is renamed to ``devicetree.dtb`` because
-    :class:`BootFPGASoCTFTP` (configured in ``test/hw/env/bq.yaml``)
-    sets ``dtb_image_name: devicetree.dtb`` — the file U-Boot's
-    ``tftp devicetree.dtb`` looks up in the TFTP root.
-    """
-    out_dir = tmp_path_factory.mktemp("merged_boot")
-    merged_dts = pipeline_result["merged"]
-    dtb_raw = out_dir / "adrv9371_zc706_xsa.dtb"
-    compile_dts_to_dtb(merged_dts, dtb_raw)
-
-    staged = stage_dtb_as_devicetree(dtb_raw, out_dir / "tftp_staging")
-
-    shell = deploy_and_boot(board, staged, built_kernel_image_zynq)
-
-    deploy_dtbo_via_shell(shell, overlay_dtbo, DTBO_REMOTE_PATH)
-
-    if overlay_is_loaded(shell, OVERLAY_NAME):
-        unload_overlay(shell, OVERLAY_NAME)
-
-    return board
-
-
-def _shell(booted):
-    return booted.target.get_driver("ADIShellDriver")
-
-
-def _ensure_unloaded(shell) -> None:
-    if overlay_is_loaded(shell, OVERLAY_NAME):
-        unload_overlay(shell, OVERLAY_NAME)
-        time.sleep(2.0)
-
-
-def _apply_and_wait(shell) -> None:
-    res = load_overlay(shell, OVERLAY_NAME, DTBO_REMOTE_PATH)
-    assert "RC=0" in res, f"overlay load failed: {res}"
-    # Mykonos re-init after overlay apply takes longer than the AD9081
-    # path; give the JESD FSM time to walk SYNC -> ILAS -> DATA before
-    # any sysfs check.
-    time.sleep(8.0)
-
-
-def _assert_iio_devices_present(ctx, *, context: str) -> None:
-    found = {d.name for d in ctx.devices if d.name}
-    suffix = f" ({context})" if context else ""
-    for required in EXPECTED_IIO_NAMES_ALL:
-        assert required in found, (
-            f"IIO device {required!r} not present{suffix}. Devices: {sorted(found)}"
-        )
-    assert any(n in found for n in EXPECTED_IIO_NAMES_ANY), (
-        f"AD9371 RX frontend not present{suffix}. "
-        f"Expected one of {EXPECTED_IIO_NAMES_ANY}; "
-        f"found: {sorted(found)}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
-def test_overlay_generation_unit(pipeline_result, overlay_dtbo):
-    """No-hardware check: the pipeline's DTSO is a valid overlay + compiles."""
-    dtso: Path = pipeline_result["overlay"]
-    src = dtso.read_text()
-    assert "/plugin/;" in src, (
-        f"Pipeline overlay missing /plugin/; directive — "
-        f"dtc -@ will not treat it as an overlay: {dtso}"
-    )
-    assert "ad9371" in src.lower() or "axi-jesd204" in src, (
-        f"Pipeline overlay does not reference ADRV9371 / JESD nodes: {dtso}"
-    )
-    assert overlay_dtbo.exists() and overlay_dtbo.stat().st_size > 100
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9371", "zc706"])
-def test_configfs_overlay_support(booted_board):
-    """Target kernel must support runtime overlays via configfs."""
-    assert_configfs_overlay_support(_shell(booted_board))
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9371", "zc706"])
-def test_load_overlay(booted_board, tmp_path):
-    """Apply the overlay; verify clean probe, IIO discovery, and JESD DATA."""
-    shell = _shell(booted_board)
-    _ensure_unloaded(shell)
-
-    # dmesg before overlay-apply is the boot log — filter it out so we
-    # only flag errors caused by the overlay itself.
-    dmesg_baseline = int(shell_out(shell, "dmesg | wc -l").strip() or "0")
-
-    _apply_and_wait(shell)
-
-    dmesg_full = shell_out(shell, "dmesg")
-    (tmp_path / "dmesg_after_load.log").write_text(dmesg_full)
-    dmesg_new = "\n".join(dmesg_full.splitlines()[dmesg_baseline:])
-    (tmp_path / "dmesg_overlay_only.log").write_text(dmesg_new)
-    assert_no_kernel_faults(dmesg_new)
-    assert_no_probe_errors(dmesg_new)
-
-    ctx, _ = open_iio_context(shell)
-    _assert_iio_devices_present(ctx, context="after overlay load")
-
-    rx_status, tx_status = assert_jesd_links_data(shell, context="after overlay load")
-    print(f"$ cat .../*.axi?jesd204?rx/status\n{rx_status}")
-    print(f"$ cat .../*.axi?jesd204?tx/status\n{tx_status}")
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9371", "zc706"])
-def test_dma_loopback(booted_board):
-    """Verify DMA TX→RX data path.
-
-    Two verification phases:
-
-    * **Mandatory:** :func:`assert_rx_capture_valid` confirms that an
-      RX buffer arrives with non-zero, non-latched samples.
-    * **Opportunistic FFT:** drive a DDS tone on TX and look for a
-      coherent peak in the RX spectrum.  ZC706 + ADRV9371 reference
-      HDL has no internal DAC→ADC loopback, so without an external
-      TX→RX SMA cable on the FMC the noise-floor metric is logged
-      and the stage passes — TX→RX coupling is a lab-setup concern,
-      not an overlay-lifecycle concern.
-    """
-    pytest.importorskip("adi")
-    np = pytest.importorskip("numpy")
-
-    shell = _shell(booted_board)
-    if not overlay_is_loaded(shell, OVERLAY_NAME):
-        pytest.skip("overlay not loaded — test_load_overlay must run first")
-
-    ctx, ip = open_iio_context(shell)
-
-    # Probe TPL ADC version + force RSTN + chan-enable BEFORE capture.
-    # Earlier diagnostics showed reg 0x40 (RSTN) reading 0 even though
-    # cf_axi_adc.probe writes 0x3 — the core looks held in reset.
-    # If forcibly setting RSTN unblocks DMA, the issue is between
-    # cf_axi_adc.probe and the JESD post_running stage.
-    # Use AXI register access path — cf_axi_adc routes plain debugfs
-    # writes to the SPI converter (AD9371) by default; OR'ing
-    # 0x80000000 (DEBUGFS_DRA_PCORE_REG_MAGIC, cf_axi_adc.h:193)
-    # routes to the TPL ADC's MMIO registers.
-    # Phase 1: bare data-path smoke check.  AD9371 driver name is
-    # ``ad9371-phy``; pyadi-iio's ``adi.adrv9371`` looks up the
-    # buffered RX ADC by ``axi-ad9371-rx-hpc``.  The sdtgen-generated
-    # merged DTB labels the same buffered frontend
-    # ``ad_ip_jesd204_tpl_adc``; either is a valid capture target.
-    try:
-        assert_rx_capture_valid(
-            ctx,
-            (
-                "axi-ad9371-rx-hpc",
-                "ad_ip_jesd204_tpl_adc",
-            ),
-            n_samples=2**12,
-            context="adrv9371 zc706 overlay",
-        )
-    except AssertionError:
-        # Surface the canonical signature that distinguishes the
-        # documented HDL IRQ-wiring blocker from a real DT regression.
-        # If TRANSFER_DONE > 0 + IRQ_PENDING != 0 + GICD pending == 0
-        # + /proc/interrupts count == 0, the DMAC IRQ line is the
-        # culprit (HDL bitstream).  Anything else is a new bug.
-        print("=== DMAC HW progress (TRANSFER_DONE / IRQ_PENDING / IRQ_SOURCE) ===")
-        print(
-            shell_out(
-                shell,
-                "for off in 0x084 0x088 0x418 0x428 0x42c; do "
-                "  v=$(busybox devmem $((0x7c400000 + off)) 2>&1 | head -1); "
-                "  printf 'dmac+%s = %s\\n' $off \"$v\"; "
-                "done",
-            )
-        )
-        print("=== GIC distributor (IRQ 63 enable + pending) ===")
-        print(
-            shell_out(
-                shell,
-                # Zynq-7000 GICD at 0xF8F01000;
-                #   ICDISER1=+0x104 (enable for IRQs 32-63)
-                #   ICDISPR1=+0x204 (pending for IRQs 32-63)
-                # axi_dmac@7c400000 → SPI 31 → GIC IRQ 63 → bit 31 of word 1.
-                "for r in 0x104 0x204; do "
-                "  v=$(busybox devmem $((0xF8F01000 + r)) 2>&1 | head -1); "
-                "  printf 'GICD+%s = %s\\n' $r \"$v\"; "
-                "done",
-            )
-        )
-        print("=== /proc/interrupts (jesd + axi_dmac counts) ===")
-        print(
-            shell_out(
-                shell,
-                "grep -E 'jesd|axi_dmac' /proc/interrupts || true",
-            )
-        )
-        raise
-
-    # Phase 2: opportunistic spectrum check via pyadi-iio.
-    import adi
-
-    try:
-        dev = adi.adrv9371(uri=f"ip:{ip}")
-    except Exception as exc:  # noqa: BLE001 — connect failure → skip phase 2
-        print(f"adi.adrv9371 unavailable; skipping FFT phase: {exc}")
-        return
-    if getattr(dev, "_rxadc", None) is None:
-        print(
-            "adi.adrv9371 missing 'axi-ad9371-rx-hpc' IIO name "
-            "(merged DTB exposes 'ad_ip_jesd204_tpl_adc' instead) — "
-            "skipping FFT phase; Phase 1 already validated the data path."
-        )
-        return
-
-    dev.rx_enabled_channels = [0]
-    dev.rx_buffer_size = RX_BUFFER_SIZE
-    sample_rate = int(dev.rx_sample_rate)
-    print(f"ADRV9371 RX sample rate: {sample_rate} Hz, buffer: {RX_BUFFER_SIZE}")
-
-    try:
-        try:
-            dev.dds_single_tone(DDS_TONE_HZ, DDS_SCALE, channel=0)
-        except Exception as exc:  # noqa: BLE001 — log and continue without DDS
-            print(f"adrv9371 DDS setup failed; capturing anyway: {exc}")
-
-        for _ in range(3):
-            dev.rx()
-        raw = dev.rx()
-    except TimeoutError:
-        pytest.skip("DMA buffer refill timed out — JESD link may not be in DATA mode")
-    finally:
-        for cleanup in ("disable_dds", "rx_destroy_buffer"):
-            try:
-                getattr(dev, cleanup)()
-            except Exception:  # noqa: BLE001 — best-effort cleanup
-                pass
-
-    samples = raw[0] if isinstance(raw, list) else raw
-    samples = np.asarray(samples)
-    if samples.size < 1024:
-        print(f"FFT phase: capture too short ({samples.size}); skipping spectrum check")
-        return
-
-    nfft = 1 << int(np.floor(np.log2(samples.size)))
-    trimmed = samples[:nfft]
-    win = np.hanning(nfft).astype(np.float64)
-    if np.iscomplexobj(trimmed):
-        spectrum = np.fft.fftshift(
-            np.fft.fft(trimmed.astype(np.complex128) * win, n=nfft)
-        )
-        freqs = np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / sample_rate))
-    else:
-        spectrum = np.fft.rfft(trimmed.astype(np.float64) * win, n=nfft)
-        freqs = np.fft.rfftfreq(nfft, d=1.0 / sample_rate)
-
-    mags = np.abs(spectrum)
-    fbin = sample_rate / nfft
-    nyquist = sample_rate / 2
-
-    dc_guard = 5
-    zero_idx = int(np.argmin(np.abs(freqs)))
-    nondc_mask = np.ones(mags.size, dtype=bool)
-    nondc_mask[
-        max(0, zero_idx - dc_guard) : min(mags.size, zero_idx + dc_guard + 1)
-    ] = False
-
-    search_mags = np.where(nondc_mask, mags, 0.0)
-    peak_idx = int(np.argmax(search_mags))
-    peak_mag = float(mags[peak_idx])
-    if peak_mag <= 0:
-        print("FFT phase: spectrum has no non-DC content (RX inert?)")
-        return
-    mags_db = 20.0 * np.log10(np.maximum(mags, 1e-9) / peak_mag)
-    signal_freq = float(abs(freqs[peak_idx]))
-    signal_mag_db = float(mags_db[peak_idx])
-
-    noise_mask = nondc_mask.copy()
-    lo = max(0, peak_idx - 5)
-    hi = min(mags.size, peak_idx + 6)
-    noise_mask[lo:hi] = False
-    noise_db = float(np.median(mags_db[noise_mask]))
-    snr_db = signal_mag_db - noise_db
-
-    print(
-        f"FFT phase: strongest non-DC bin {signal_freq:.0f} Hz "
-        f"({signal_mag_db:.1f} dB), noise floor {noise_db:.1f} dB, "
-        f"SNR {snr_db:.1f} dB, fbin {fbin:.0f} Hz, DDS req {DDS_TONE_HZ} Hz"
-    )
-
-    if snr_db < 10.0:
-        print(
-            "FFT phase: no coherent tone (SNR ≤ 10 dB) — recording noise-only "
-            "result and passing.  External TX↔RX coupling is a lab-setup "
-            "detail, not an overlay-lifecycle requirement."
-        )
-        return
-
-    assert signal_freq < nyquist - 10 * fbin, (
-        f"Loopback peak too close to Nyquist ({signal_freq:.0f} Hz > "
-        f"{nyquist - 10 * fbin:.0f} Hz)"
-    )
-    print(f"FFT phase: tone detected, SNR {snr_db:.1f} dB at {signal_freq:.0f} Hz")
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9371", "zc706"])
-def test_unload_overlay(booted_board):
-    """Removing the configfs entry tears down without kernel faults."""
-    shell = _shell(booted_board)
-    if not overlay_is_loaded(shell, OVERLAY_NAME):
-        _apply_and_wait(shell)
-
-    res = unload_overlay(shell, OVERLAY_NAME)
-    assert "RC=0" in res, f"overlay unload failed: {res}"
-    time.sleep(2.0)
-
-    assert not overlay_is_loaded(shell, OVERLAY_NAME), (
-        "overlay configfs entry still present after rmdir"
-    )
-
-    dmesg_txt = shell_out(shell, "dmesg")
-    assert_no_kernel_faults(dmesg_txt)
-
-
-@requires_lg
-@pytest.mark.lg_feature(["adrv9371", "zc706"])
-def test_reload_overlay(booted_board):
-    """Load → unload → load cycle; re-verify devices + JESD link."""
-    shell = _shell(booted_board)
-    _ensure_unloaded(shell)
-
-    _apply_and_wait(shell)
-    ctx, _ = open_iio_context(shell)
-    _assert_iio_devices_present(ctx, context="after overlay reload")
-    assert_jesd_links_data(shell, context="after overlay reload")
+def overlay_spec() -> BoardOverlayProfile:
+    return SPEC

--- a/test/hw/xsa/test_fmcdaq3_vcu118_overlay.py
+++ b/test/hw/xsa/test_fmcdaq3_vcu118_overlay.py
@@ -1,101 +1,65 @@
 """FMCDAQ3 + VCU118 runtime device-tree overlay hardware test.
 
-Mirrors :mod:`test.hw.xsa.test_ad9081_zcu102_overlay` for the VCU118 +
-FMCDAQ3 daughter card on the ``nuc`` labgrid place.  Same six-test
-shape (unit, configfs, load, DMA, unload, reload), same configfs
-lifecycle, same dmesg-delta error gating.
+Same six-test shape as the AD9081/ADRV9009/ADRV9371 overlay tests; the
+shared fixtures + tests live in :mod:`test.hw.xsa._overlay_base`.
 
-Differences from the AD9081 / ADRV9009 variants:
+Differences encoded in :data:`SPEC`:
 
-1. **Boot transport** — VCU118 runs a MicroBlaze soft CPU from the FPGA
-   fabric; there is no PS, U-Boot, SD card, or TFTP path.  Labgrid
-   drives the boot through :class:`BootFabric` + :class:`XilinxDeviceJTAG`
-   on the ``nuc`` exporter, which loads the bitstream and a
-   ``simpleImage.vcu118_fmcdaq3.strip`` (kernel + embedded DTB) over
-   JTAG.  The overlay is layered on top of the embedded DTB at runtime
-   via configfs — no DTB rebuild and no kernel-image fixture are
-   required.  The companion full-DTB smoke test
-   :mod:`test.hw.test_fmcdaq3_vcu118_hw` already validates that the
-   embedded DTB probes AD9528 + AD9680 + AD9152 cleanly and that the
-   AD9680 RX path delivers real samples; this test extends that
-   coverage with the configfs apply / unapply / reapply lifecycle.
+* **Boot transport** — VCU118 runs a MicroBlaze soft CPU from the FPGA
+  fabric; there is no PS, U-Boot, SD card, or TFTP path.  Labgrid drives
+  the boot through :class:`BootFabric` + :class:`XilinxDeviceJTAG` on
+  the ``nuc`` exporter, which loads the bitstream and a
+  ``simpleImage.vcu118_fmcdaq3.strip`` (kernel + embedded DTB) over
+  JTAG.  The overlay is layered on top of the embedded DTB at runtime
+  via configfs — no DTB rebuild and no kernel-image fixture are
+  required (``boot_mode="fabric_jtag"``, ``kernel_fixture_name=None``).
 
-2. **Configfs gate** — Kuiper's MicroBlaze simpleImage is the most
-   likely place we will find ``CONFIG_OF_OVERLAY``/``CONFIG_OF_CONFIGFS``
-   missing.  The fixture probes
-   ``/sys/kernel/config/device-tree/overlays`` and skips the
-   lifecycle/DMA tests cleanly when absent;
-   :func:`test_configfs_overlay_support` retains its strict-assert
-   behavior so a configfs-less kernel is still an explicit failure of
-   *that* test.
+* **Configfs gate** — Kuiper's MicroBlaze simpleImage is the most
+  likely place we will find ``CONFIG_OF_OVERLAY``/``CONFIG_OF_CONFIGFS``
+  missing.  The shared ``booted_board`` fixture probes for the
+  configfs overlay directory in ``fabric_jtag`` mode and skips the
+  lifecycle/DMA tests cleanly when absent;
+  :func:`test_configfs_overlay_support` retains its strict-assert
+  behavior so a configfs-less kernel is still an explicit failure of
+  *that* test (it uses the ``board`` fixture directly, bypassing
+  ``booted_board``).
 
-3. **XSA prerequisite** — the standard Kuiper boot-partition release
-   does not include a ``vcu118_fmcdaq3`` project (it only ships Zynq
-   family projects), so :func:`acquire_xsa` cannot download one.  The
-   FMCDAQ3+VCU118 ``system_top.xsa`` from the local HDL/PetaLinux
-   build must be committed to ``test/hw/xsa/system_top_fmcdaq3_vcu118.xsa``
-   before the test can run; the ``pipeline_result`` fixture
-   :func:`pytest.skip` s with a clear message until that file is
-   present.
+* **XSA prerequisite** — the standard Kuiper boot-partition release
+  does not include a ``vcu118_fmcdaq3`` project (it only ships Zynq
+  family projects), so :func:`acquire_xsa` cannot download one.  The
+  FMCDAQ3+VCU118 ``system_top.xsa`` from the local HDL/PetaLinux build
+  must be committed to ``test/hw/xsa/system_top_fmcdaq3_vcu118.xsa``
+  before the test can run; ``local_xsa_or_skip`` ``pytest.skip``s with
+  a clear message until that file is present.
 
 LG_ENV: ``test/hw/env/nuc.yaml``.
 """
 
 from __future__ import annotations
 
-import os
-import time
-from pathlib import Path
 from typing import Any
 
 import pytest
 
-from adidt.xsa.pipeline import XsaPipeline
-from adidt.xsa.topology import XsaParser
-from test.hw.hw_helpers import (
-    CONFIGFS_OVERLAYS,
-    assert_configfs_overlay_support,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    assert_rx_capture_valid,
-    check_jesd_framing_plausibility,
-    compile_dtso_to_dtbo,
-    deploy_dtbo_via_shell,
-    load_overlay,
-    open_iio_context,
-    overlay_is_loaded,
-    shell_out,
-    unload_overlay,
+from test.hw.hw_helpers import check_jesd_framing_plausibility
+from test.hw.xsa._overlay_base import (  # noqa: F401 — pytest collects these
+    # Fixtures (alphabetical, F401 above suppresses unused-import warning).
+    booted_board,
+    overlay_dtbo,
+    pipeline_result,
+    # Tests — import order is collection / execution order.  Keep the
+    # canonical six-step shape: unit, configfs, load, dma, unload, reload.
+    # ``test_dma_loopback`` skips itself if the overlay is not loaded, so
+    # it must follow ``test_load_overlay``; the rest are independent but
+    # share module-scoped fixtures whose teardown happens once at the end.
+    test_overlay_generation_unit,
+    test_configfs_overlay_support,
+    test_load_overlay,
+    test_dma_loopback,
+    test_unload_overlay,
+    test_reload_overlay,
 )
-
-_HAS_LG = bool(os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV"))
-requires_lg = pytest.mark.skipif(
-    not _HAS_LG,
-    reason=(
-        "set LG_COORDINATOR or LG_ENV for FMCDAQ3 VCU118 overlay hardware tests"
-        " (see .env.example)"
-    ),
-)
-
-OVERLAY_NAME = "fmcdaq3_vcu118_xsa"
-DTBO_REMOTE_PATH = f"/tmp/{OVERLAY_NAME}.dtbo"
-FDT_MAGIC = b"\xd0\x0d\xfe\xed"
-
-DDS_TONE_HZ = 1_000_000
-DDS_SCALE = 0.5
-RX_BUFFER_SIZE = 2**14
-
-# IIO device names the FMCDAQ3 base DTB exposes.  The clock chip is
-# AD9528; the AD9680 RX frontend appears under several aliases
-# depending on whether the DTB is Kuiper-built or sdtgen-built.
-EXPECTED_IIO_NAMES_ALL = ("ad9528",)
-EXPECTED_IIO_NAMES_ANY = (
-    "axi-ad9680-hpc",
-    "axi-ad9680-rx-hpc",
-    "axi-ad9680-core-lpc",
-    "ad_ip_jesd204_tpl_adc",
-)
+from test.hw.xsa._overlay_spec import BoardOverlayProfile, local_xsa_or_skip
 
 
 def _fmcdaq3_vcu118_cfg() -> dict[str, Any]:
@@ -123,247 +87,39 @@ def _fmcdaq3_vcu118_cfg() -> dict[str, Any]:
     return cfg
 
 
-@pytest.fixture(scope="module")
-def pipeline_result(tmp_path_factory) -> dict:
-    """Run :class:`XsaPipeline` once per module and return its output dict.
-
-    The XSA must be committed to the repo at one of the paths checked
-    below — :func:`acquire_xsa` cannot download a VCU118 / MicroBlaze
-    XSA from the standard Kuiper boot-partition release because that
-    release only ships Zynq family projects (``zynq*``, ``zynqmp*``,
-    ``versal*``).  The lab's ``simpleImage.vcu118_fmcdaq3.strip`` on
-    the ``nuc`` exporter is built from a separate HDL/PetaLinux flow
-    whose XSA is not part of Kuiper's release tarball.
-
-    Provide the XSA by copying the ``system_top.xsa`` from a local
-    ``hdl/projects/fmcdaq3/vcu118`` build (or the lab's archive of
-    that build) into ``test/hw/xsa/system_top_fmcdaq3_vcu118.xsa``.
-    """
-    candidates = (
-        Path(__file__).parent / "system_top_fmcdaq3_vcu118.xsa",
-        Path(__file__).parent / "ref_data" / "system_top_fmcdaq3_vcu118.xsa",
-    )
-    xsa_path = next((p for p in candidates if p.exists()), None)
-    if xsa_path is None:
-        pytest.skip(
-            "FMCDAQ3+VCU118 XSA fixture missing — commit the system_top.xsa "
-            f"from the FMCDAQ3 VCU118 HDL build to one of: "
-            f"{', '.join(str(p) for p in candidates)}"
-        )
-
-    topology = XsaParser().parse(xsa_path)
+def _topology_assert(topology) -> None:
     assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
     assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
 
-    out_dir = tmp_path_factory.mktemp("overlay") / "out"
-    return XsaPipeline().run(
-        xsa_path=xsa_path,
-        cfg=_fmcdaq3_vcu118_cfg(),
-        output_dir=out_dir,
-        profile="fmcdaq3_vcu118",
-        sdtgen_timeout=300,
-    )
+
+SPEC = BoardOverlayProfile(
+    overlay_name="fmcdaq3_vcu118_xsa",
+    lg_features=("fmcdaq3", "vcu118"),
+    skip_reason_label="fmcdaq3 vcu118",
+    cfg_builder=_fmcdaq3_vcu118_cfg,
+    xsa_resolver=local_xsa_or_skip("system_top_fmcdaq3_vcu118.xsa"),
+    sdtgen_profile="fmcdaq3_vcu118",
+    topology_assert=_topology_assert,
+    dtso_must_contain_any=("ad9680", "ad9152", "axi-jesd204"),
+    boot_mode="fabric_jtag",
+    iio_required_all=("ad9528",),
+    iio_required_any=(
+        "axi-ad9680-hpc",
+        "axi-ad9680-rx-hpc",
+        "axi-ad9680-core-lpc",
+        "ad_ip_jesd204_tpl_adc",
+    ),
+    iio_frontend_label="AD9680 RX frontend",
+    fft_mode="skip",
+    capture_target_names=(
+        "axi-ad9680-hpc",
+        "axi-ad9680-rx-hpc",
+        "axi-ad9680-core-lpc",
+        "ad_ip_jesd204_tpl_adc",
+    ),
+)
 
 
 @pytest.fixture(scope="module")
-def overlay_dtbo(pipeline_result, tmp_path_factory) -> Path:
-    """Compile the pipeline ``.dtso`` to ``.dtbo`` (module-scoped, once)."""
-    overlay_src: Path = pipeline_result["overlay"]
-    assert overlay_src.exists(), f"pipeline did not emit overlay DTSO: {overlay_src}"
-
-    dtbo_dir = tmp_path_factory.mktemp("dtbo")
-    dtbo = dtbo_dir / f"{OVERLAY_NAME}.dtbo"
-    compile_dtso_to_dtbo(overlay_src, dtbo)
-
-    assert dtbo.exists(), f"dtc -@ did not produce DTBO: {dtbo}"
-    size = dtbo.stat().st_size
-    assert size > 100, f"DTBO suspiciously small ({size} bytes): {dtbo}"
-    magic = dtbo.read_bytes()[:4]
-    assert magic == FDT_MAGIC, f"DTBO missing FDT magic (got {magic.hex()}): {dtbo}"
-    return dtbo
-
-
-@pytest.fixture(scope="module")
-def booted_board(board, overlay_dtbo):
-    """Drive ``BootFabric`` to shell, gate-skip on missing configfs, stage DTBO.
-
-    No merged DTB compile or kernel image fixture: the simpleImage on
-    the exporter already embeds the FMCDAQ3 base DTB.  The overlay is
-    layered on top of that pre-probed tree at runtime via configfs.
-    """
-    board.transition("shell")
-    shell = board.target.get_driver("ADIShellDriver")
-
-    res = shell_out(
-        shell,
-        f"test -d {CONFIGFS_OVERLAYS} && echo OK || echo MISSING",
-    )
-    if "OK" not in res:
-        pytest.skip(
-            "MicroBlaze kernel lacks CONFIG_OF_OVERLAY / CONFIG_OF_CONFIGFS "
-            "(simpleImage was not built with overlay support)"
-        )
-
-    deploy_dtbo_via_shell(shell, overlay_dtbo, DTBO_REMOTE_PATH)
-
-    if overlay_is_loaded(shell, OVERLAY_NAME):
-        unload_overlay(shell, OVERLAY_NAME)
-
-    return board
-
-
-def _shell(booted):
-    return booted.target.get_driver("ADIShellDriver")
-
-
-def _ensure_unloaded(shell) -> None:
-    if overlay_is_loaded(shell, OVERLAY_NAME):
-        unload_overlay(shell, OVERLAY_NAME)
-        time.sleep(2.0)
-
-
-def _apply_and_wait(shell) -> None:
-    res = load_overlay(shell, OVERLAY_NAME, DTBO_REMOTE_PATH)
-    assert "RC=0" in res, f"overlay load failed: {res}"
-    # FMCDAQ3 has fewer probe stages than the Talise/Mykonos paths;
-    # 5s is enough for AD9528 → AD9680 / AD9152 re-probe + JESD FSM
-    # to walk SYNC → ILAS → DATA.
-    time.sleep(5.0)
-
-
-def _assert_iio_devices_present(ctx, *, context: str) -> None:
-    found = {d.name for d in ctx.devices if d.name}
-    suffix = f" ({context})" if context else ""
-    for required in EXPECTED_IIO_NAMES_ALL:
-        assert required in found, (
-            f"IIO device {required!r} not present{suffix}. Devices: {sorted(found)}"
-        )
-    assert any(n in found for n in EXPECTED_IIO_NAMES_ANY), (
-        f"AD9680 RX frontend not present{suffix}. "
-        f"Expected one of {EXPECTED_IIO_NAMES_ANY}; "
-        f"found: {sorted(found)}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
-def test_overlay_generation_unit(pipeline_result, overlay_dtbo):
-    """No-hardware check: the pipeline's DTSO is a valid overlay + compiles."""
-    dtso: Path = pipeline_result["overlay"]
-    src = dtso.read_text()
-    assert "/plugin/;" in src, (
-        f"Pipeline overlay missing /plugin/; directive — "
-        f"dtc -@ will not treat it as an overlay: {dtso}"
-    )
-    assert "ad9680" in src.lower() or "ad9152" in src.lower() or "axi-jesd204" in src, (
-        f"Pipeline overlay does not reference FMCDAQ3 / JESD nodes: {dtso}"
-    )
-    assert overlay_dtbo.exists() and overlay_dtbo.stat().st_size > 100
-
-
-@requires_lg
-@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
-def test_configfs_overlay_support(board):
-    """Target kernel must support runtime overlays via configfs.
-
-    Bypasses the ``booted_board`` fixture (which would skip rather than
-    fail on missing configfs) so a configfs-less simpleImage surfaces
-    here as an explicit test failure.
-    """
-    board.transition("shell")
-    shell = board.target.get_driver("ADIShellDriver")
-    assert_configfs_overlay_support(shell)
-
-
-@requires_lg
-@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
-def test_load_overlay(booted_board, tmp_path):
-    """Apply the overlay; verify clean probe, IIO discovery, and JESD DATA."""
-    shell = _shell(booted_board)
-    _ensure_unloaded(shell)
-
-    dmesg_baseline = int(shell_out(shell, "dmesg | wc -l").strip() or "0")
-
-    _apply_and_wait(shell)
-
-    dmesg_full = shell_out(shell, "dmesg")
-    (tmp_path / "dmesg_after_load.log").write_text(dmesg_full)
-    dmesg_new = "\n".join(dmesg_full.splitlines()[dmesg_baseline:])
-    (tmp_path / "dmesg_overlay_only.log").write_text(dmesg_new)
-    assert_no_kernel_faults(dmesg_new)
-    assert_no_probe_errors(dmesg_new)
-
-    ctx, _ = open_iio_context(shell)
-    _assert_iio_devices_present(ctx, context="after overlay load")
-
-    rx_status, tx_status = assert_jesd_links_data(shell, context="after overlay load")
-    print(f"$ cat .../*.axi?jesd204?rx/status\n{rx_status}")
-    print(f"$ cat .../*.axi?jesd204?tx/status\n{tx_status}")
-
-
-@requires_lg
-@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
-def test_dma_loopback(booted_board):
-    """Verify DMA RX data path on AD9680.
-
-    Mandatory: :func:`assert_rx_capture_valid` confirms a non-zero,
-    non-latched RX buffer arrives.  The companion smoke test
-    :mod:`test.hw.test_fmcdaq3_vcu118_hw` already validates the same
-    capture against the embedded base DTB; this run validates it after
-    the overlay has been re-applied through configfs, exercising the
-    overlay tear-down/re-apply path on the data layer.
-
-    No DDS/SNR phase: FMCDAQ3 reference HDL does not have an internal
-    DAC→ADC loopback, and the AD9680 ADC is the only buffered RX path
-    in the design.  An external SMA tone is a lab-setup concern, not
-    an overlay-lifecycle concern.
-    """
-    pytest.importorskip("adi")
-
-    shell = _shell(booted_board)
-    if not overlay_is_loaded(shell, OVERLAY_NAME):
-        pytest.skip("overlay not loaded — test_load_overlay must run first")
-
-    ctx, _ = open_iio_context(shell)
-    assert_rx_capture_valid(
-        ctx,
-        EXPECTED_IIO_NAMES_ANY,
-        n_samples=2**12,
-        context="fmcdaq3 vcu118 overlay",
-    )
-
-
-@requires_lg
-@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
-def test_unload_overlay(booted_board):
-    """Removing the configfs entry tears down without kernel faults."""
-    shell = _shell(booted_board)
-    if not overlay_is_loaded(shell, OVERLAY_NAME):
-        _apply_and_wait(shell)
-
-    res = unload_overlay(shell, OVERLAY_NAME)
-    assert "RC=0" in res, f"overlay unload failed: {res}"
-    time.sleep(2.0)
-
-    assert not overlay_is_loaded(shell, OVERLAY_NAME), (
-        "overlay configfs entry still present after rmdir"
-    )
-
-    dmesg_txt = shell_out(shell, "dmesg")
-    assert_no_kernel_faults(dmesg_txt)
-
-
-@requires_lg
-@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
-def test_reload_overlay(booted_board):
-    """Load → unload → load cycle; re-verify devices + JESD link."""
-    shell = _shell(booted_board)
-    _ensure_unloaded(shell)
-
-    _apply_and_wait(shell)
-    ctx, _ = open_iio_context(shell)
-    _assert_iio_devices_present(ctx, context="after overlay reload")
-    assert_jesd_links_data(shell, context="after overlay reload")
+def overlay_spec() -> BoardOverlayProfile:
+    return SPEC


### PR DESCRIPTION
## Summary

The four `test_*_overlay.py` files added by 2ebe210 share a 6-test
shape with ~60% duplicated structure (same fixtures, same helpers,
near-identical test bodies that diverge only in IIO names, an FFT
mode, and a couple of hooks).  Adding a new board today means
copy-pasting one of these files and editing.

This PR lifts the duplicated structure into a shared
`BoardOverlayProfile` dataclass + a base module so each board file
becomes a SPEC declaration plus only the genuinely board-specific
cfg / hooks.

- 4 board test files: **2113 → 607 LOC** (-1506)
- New shared infrastructure: 959 LOC across 5 files
- Net delta: **-547 LOC**
- Adding board #5 now needs ~80-120 LOC instead of ~400-650

## What changed

**New shared infrastructure** (`test/hw/xsa/_*.py`)
- `_overlay_spec.py` — `BoardOverlayProfile` dataclass with named slots for every variation point + XSA-resolver factories
- `_overlay_base.py` — three shared module-scoped fixtures + the six shared `test_*` functions (boot-mode dispatch handles ``tftp`` / ``sd`` / ``fabric_jtag``)
- `_overlay_fft.py` — single `fft_loopback_check` lifted from the ~80-LOC FFT block that was inlined three times
- `_overlay_hooks.py` — reusable per-family hooks (`push_talise_profile`, `resolve_adrv9009_rx_tpl`)
- `conftest.py` — `pytest_collection_modifyitems(tryfirst=True)` reads `module.SPEC.lg_features` and applies the per-board labgrid marker so it stays a single declaration in the SPEC

**Slimmed-down board files** — preserve all per-board specifics that aren't shareable (AD9081's pyadi-iio name-patching factory, ADRV9009's si570 dmesg filter, ADRV9371's Zynq-7000 GIC distributor failure probe).  Test names and per-file pytest selection are unchanged.

## Test plan

Static / no-hardware checks (already done locally):
- [x] `pytest --collect-only test/hw/xsa/` reports the same 24 tests with the same canonical names, in source order (unit → configfs → load → dma → unload → reload)
- [x] `pytest test/hw/xsa/_overlay_base.py --collect-only` is excluded from directory-mode discovery (filename starts with `_`)
- [x] `pytest test/hw/xsa/ -k overlay_generation_unit -v` — 3 passed (AD9081/ADRV9009/ADRV9371) + 1 skipped (FMCDAQ3, no XSA fixture committed locally — same skip behavior as before the refactor)
- [x] Marker introspection confirms each test carries the correct per-board `lg_feature(...)` tuple plus `requires_lg`'s skipif (no `lg_feature` change since the original)

Hardware validation (still required before merge):
- [ ] `LG_ENV=test/hw/env/nuc.yaml pytest test/hw/xsa/test_fmcdaq3_vcu118_overlay.py -v` on the `nuc` place — exercises `boot_mode="fabric_jtag"` + the configfs gate-skip path
- [ ] `LG_ENV=test/hw/env/mini2.yaml pytest test/hw/xsa/test_ad9081_zcu102_overlay.py -v` on the `mini2` place — exercises `boot_mode="sd"` + `fft_mode="required"` + `pyadi_factory`
- [ ] `LG_ENV=test/hw/env/bq.yaml pytest test/hw/xsa/test_adrv9371_zc706_overlay.py -v` on the `bq` place — exercises `boot_mode="tftp"` + `fft_mode="optional"` + `fft_failure_diagnostics`
- [ ] `LG_ENV=test/hw/env/nemo.yaml pytest test/hw/xsa/test_adrv9009_zc706_overlay.py -v` on the `nemo` place — exercises `pre_capture_hook=push_talise_profile` + `capture_targets_resolver=resolve_adrv9009_rx_tpl` + `dmesg_filter`

## Out of scope

- The merged-DTB tests at `test/hw/test_*_hw.py` are untouched.  They share `test/hw/hw_helpers.py` already and don't fit the 6-test shape; a parallel `BoardSystemProfile` is a possible follow-up.