### PR TITLE
refactor(test/hw) + docs(test/hw/xsa): merged-DTB BoardSystemProfile + overlay how-to

### DIFF
--- a/test/hw/_system_base.py
+++ b/test/hw/_system_base.py
@@ -127,8 +127,7 @@ class BoardSystemProfile:
     probe_signature_message: str = "expected probe signature not found in dmesg"
 
     iio_required_all: tuple[str, ...] = ()
-    iio_required_any: tuple[str, ...] = ()
-    iio_frontend_label: str = "RX frontend"
+    iio_required_any_groups: tuple[tuple[str, ...], ...] = ()
 
     jesd_rx_glob: Optional[str] = None
     jesd_tx_glob: Optional[str] = None
@@ -165,11 +164,9 @@ def _assert_iio_devices_present(spec: BoardSystemProfile, ctx) -> None:
         assert required in found, (
             f"IIO device {required!r} not present. Devices: {sorted(found)}"
         )
-    if spec.iio_required_any:
-        assert any(n in found for n in spec.iio_required_any), (
-            f"{spec.iio_frontend_label} not present. "
-            f"Expected one of {spec.iio_required_any}; "
-            f"found: {sorted(found)}"
+    for group in spec.iio_required_any_groups:
+        assert any(n in found for n in group), (
+            f"None of {list(group)} present. Devices: {sorted(found)}"
         )
 
 

--- a/test/hw/_system_base.py
+++ b/test/hw/_system_base.py
@@ -1,0 +1,324 @@
+"""Shared infrastructure for merged-DTB hardware tests.
+
+The 4 XSA-pipeline merged-DTB tests at ``test/hw/test_*_hw.py`` (and
+the post-render section of the declarative System API test) all share
+the same shape: parse XSA → run pipeline → compile DTS → stage DTB →
+boot via labgrid → assert clean dmesg + IIO probe + JESD DATA + RX
+capture.  Each per-board diagnostic tail (Talise profile sweep,
+ADRV9371 GIC poke, sysfs register dumps) stays in its own test file
+because those are genuinely one-off.
+
+A board test module declares a :class:`BoardSystemProfile` and
+delegates the standard front-matter to :func:`run_xsa_boot_and_verify`,
+or — for the declarative System API path that does its own composition
+— calls :func:`boot_and_verify_from_merged_dts` directly with the
+merged DTS path it produced.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil as _shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Literal, Optional
+
+import pytest
+
+from adidt.xsa.pipeline import XsaPipeline
+from adidt.xsa.topology import XsaParser
+from test.hw.hw_helpers import (
+    DEFAULT_OUT_DIR,
+    assert_jesd_links_data,
+    assert_no_kernel_faults,
+    assert_no_probe_errors,
+    assert_rx_capture_valid,
+    collect_dmesg,
+    compile_dts_to_dtb,
+    deploy_and_boot,
+    open_iio_context,
+    stage_dtb_as_devicetree,
+)
+from test.hw.xsa._overlay_spec import (  # re-exported for board-file convenience
+    acquire_or_local_xsa,
+    local_xsa_or_skip,
+)
+
+
+__all__ = [
+    "BoardSystemProfile",
+    "acquire_or_local_xsa",
+    "boot_and_verify_from_merged_dts",
+    "local_xsa_or_skip",
+    "requires_lg",
+    "run_xsa_boot_and_verify",
+    "run_xsa_pipeline",
+]
+
+
+_HAS_LG = bool(os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV"))
+requires_lg = pytest.mark.skipif(
+    not _HAS_LG,
+    reason=(
+        "set LG_COORDINATOR or LG_ENV for merged-DTB hardware tests "
+        "(see .env.example)"
+    ),
+)
+
+
+CfgBuilder = Callable[[], dict[str, Any]]
+XsaResolver = Callable[[Path], Path]
+TopologyAssert = Callable[[Any], None]
+DmesgFilter = Callable[[str], str]
+
+
+def _identity(text: str) -> str:
+    return text
+
+
+def _noop_topology(_topology: Any) -> None:
+    return None
+
+
+BootMode = Literal["tftp", "sd"]
+
+
+@dataclass(frozen=True)
+class BoardSystemProfile:
+    """Per-board configuration for the standard XSA → boot → verify flow.
+
+    Required fields (no default):
+
+    * ``lg_features`` — labgrid place feature tuple.
+    * ``cfg_builder`` — zero-arg callable returning the cfg dict for
+      :meth:`adidt.xsa.pipeline.XsaPipeline.run`.
+    * ``xsa_resolver`` — single-arg callable: ``(tmp_path) -> Path``.
+    * ``boot_mode`` — ``"tftp"`` or ``"sd"``.
+    * ``kernel_fixture_name`` — name of a session-scoped kernel-image
+      fixture in :mod:`test.hw.conftest`
+      (``"built_kernel_image_zynq"`` / ``"built_kernel_image_zynqmp"``).
+    * ``out_label`` — short string used in dmesg log filenames and
+      assertion ``context=`` arguments.
+    * ``dmesg_grep_pattern`` — extended regex for the diagnostic
+      ``dmesg | grep -Ei <pattern>`` tail.
+
+    All other fields have safe defaults so a minimal board declaration
+    only fills those seven required slots.
+    """
+
+    lg_features: tuple[str, ...]
+
+    cfg_builder: CfgBuilder
+    xsa_resolver: XsaResolver
+
+    boot_mode: BootMode
+    kernel_fixture_name: str
+
+    out_label: str
+    dmesg_grep_pattern: str
+
+    sdtgen_profile: Optional[str] = None
+    sdtgen_timeout: int = 300
+
+    topology_assert: TopologyAssert = _noop_topology
+    merged_dts_must_contain: tuple[str, ...] = ()
+
+    probe_signature_any: tuple[str, ...] = ()
+    probe_signature_message: str = "expected probe signature not found in dmesg"
+
+    iio_required_all: tuple[str, ...] = ()
+    iio_required_any: tuple[str, ...] = ()
+    iio_frontend_label: str = "RX frontend"
+
+    jesd_rx_glob: Optional[str] = None
+    jesd_tx_glob: Optional[str] = None
+
+    dmesg_filter: DmesgFilter = _identity
+
+    rx_capture_target_names: tuple[str, ...] = ()
+
+    dtb_basename: str = field(default="")  # auto-derived from out_label if empty
+
+
+def _staged_dtb_for_boot(
+    spec: BoardSystemProfile, dtb_raw: Path, staging_root: Path
+) -> Path:
+    """Stage *dtb_raw* under the basename the boot transport expects.
+
+    ``"tftp"`` → ``devicetree.dtb`` (Zynq-7000 BootFPGASoCTFTP).
+    ``"sd"``   → ``system.dtb``     (Kuiper ZynqMP U-Boot).
+    """
+    if spec.boot_mode == "tftp":
+        return stage_dtb_as_devicetree(dtb_raw, staging_root / "tftp_staging")
+    if spec.boot_mode == "sd":
+        staged_dir = staging_root / "sd_staging"
+        staged_dir.mkdir(parents=True, exist_ok=True)
+        staged = staged_dir / "system.dtb"
+        _shutil.copyfile(dtb_raw, staged)
+        return staged
+    raise ValueError(f"unknown boot_mode: {spec.boot_mode!r}")
+
+
+def _assert_iio_devices_present(spec: BoardSystemProfile, ctx) -> None:
+    found = {d.name for d in ctx.devices if d.name}
+    for required in spec.iio_required_all:
+        assert required in found, (
+            f"IIO device {required!r} not present. Devices: {sorted(found)}"
+        )
+    if spec.iio_required_any:
+        assert any(n in found for n in spec.iio_required_any), (
+            f"{spec.iio_frontend_label} not present. "
+            f"Expected one of {spec.iio_required_any}; "
+            f"found: {sorted(found)}"
+        )
+
+
+def boot_and_verify_from_merged_dts(
+    spec: BoardSystemProfile,
+    merged_dts: Path,
+    *,
+    board,
+    request,
+    out_dir: Path,
+    dtb_basename: Optional[str] = None,
+):
+    """Compile *merged_dts*, boot the board, and run the standard verify.
+
+    Steps performed:
+
+    1. Compile merged DTS → DTB.
+    2. Stage the DTB under the boot transport's expected basename.
+    3. Pull the kernel image fixture named in ``spec.kernel_fixture_name``.
+    4. ``deploy_and_boot``.
+    5. Collect dmesg and assert no kernel faults / probe errors.
+    6. Optional probe signature check (``spec.probe_signature_any``).
+    7. Open an IIO context and check ``iio_required_all`` / ``_any``.
+    8. Assert both JESD links reach DATA (with optional reg-address globs).
+    9. Optional RX capture smoke test (``spec.rx_capture_target_names``).
+
+    Returns ``(shell, ctx, dmesg_txt)`` so callers can run additional
+    board-specific diagnostics on the booted target.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    name = dtb_basename or f"{spec.out_label}.dtb"
+    dtb_raw = out_dir / name
+    compile_dts_to_dtb(merged_dts, dtb_raw)
+    assert dtb_raw.exists() and dtb_raw.stat().st_size > 0, (
+        f"dtc produced empty/missing DTB: {dtb_raw}"
+    )
+
+    staged_dtb = _staged_dtb_for_boot(spec, dtb_raw, out_dir)
+    kernel_image = request.getfixturevalue(spec.kernel_fixture_name)
+
+    shell = deploy_and_boot(board, staged_dtb, kernel_image)
+
+    dmesg_txt = collect_dmesg(
+        shell,
+        out_dir,
+        label=spec.out_label,
+        grep_pattern=spec.dmesg_grep_pattern,
+    )
+    assert_no_kernel_faults(dmesg_txt)
+    assert_no_probe_errors(spec.dmesg_filter(dmesg_txt))
+
+    if spec.probe_signature_any:
+        lower = dmesg_txt.lower()
+        assert any(sig.lower() in lower for sig in spec.probe_signature_any), (
+            f"{spec.probe_signature_message}. Looked for: "
+            f"{list(spec.probe_signature_any)}"
+        )
+
+    ctx, _ = open_iio_context(shell)
+    _assert_iio_devices_present(spec, ctx)
+
+    rx_glob = spec.jesd_rx_glob or "*.axi[_-]jesd204[_-]rx"
+    tx_glob = spec.jesd_tx_glob or "*.axi[_-]jesd204[_-]tx"
+    rx_status, tx_status = assert_jesd_links_data(
+        shell,
+        context=spec.out_label,
+        rx_glob=rx_glob,
+        tx_glob=tx_glob,
+    )
+    print(f"$ cat .../{rx_glob}/status\n{rx_status}")
+    print(f"$ cat .../{tx_glob}/status\n{tx_status}")
+
+    if spec.rx_capture_target_names:
+        assert_rx_capture_valid(
+            ctx,
+            spec.rx_capture_target_names,
+            n_samples=2**12,
+            context=spec.out_label,
+        )
+
+    return shell, ctx, dmesg_txt
+
+
+def run_xsa_pipeline(
+    spec: BoardSystemProfile,
+    *,
+    tmp_path: Path,
+    out_dir: Path,
+) -> Path:
+    """Resolve the XSA, run :class:`XsaPipeline`, return the merged DTS path.
+
+    Performs the parse + topology assertions documented in
+    ``spec.topology_assert``, then runs ``XsaPipeline().run`` with
+    ``spec.cfg_builder()`` and ``spec.sdtgen_profile``.  Asserts the
+    expected substrings from ``spec.merged_dts_must_contain`` are
+    present in the merged DTS.
+    """
+    xsa_path = spec.xsa_resolver(tmp_path)
+    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
+
+    topology = XsaParser().parse(xsa_path)
+    spec.topology_assert(topology)
+    print(
+        f"XSA topology: {len(topology.converters)} converter(s), "
+        f"{len(topology.jesd204_rx)} rx jesd, {len(topology.jesd204_tx)} tx jesd"
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result = XsaPipeline().run(
+        xsa_path=xsa_path,
+        cfg=spec.cfg_builder(),
+        output_dir=out_dir,
+        sdtgen_timeout=spec.sdtgen_timeout,
+        profile=spec.sdtgen_profile,
+    )
+    merged_dts = result["merged"]
+    assert merged_dts.exists(), f"Merged DTS not written: {merged_dts}"
+
+    merged_content = merged_dts.read_text()
+    for needle in spec.merged_dts_must_contain:
+        assert needle in merged_content, (
+            f"Required substring {needle!r} missing from merged DTS"
+        )
+
+    return merged_dts
+
+
+def run_xsa_boot_and_verify(
+    spec: BoardSystemProfile,
+    *,
+    board,
+    request,
+    tmp_path: Path,
+    out_dir: Optional[Path] = None,
+):
+    """End-to-end: XSA → pipeline → DTB → boot → standard verify.
+
+    Convenience wrapper for the 4 boards whose tests are pure
+    XSA-pipeline drivers (no declarative composition step).  Returns
+    the same ``(shell, ctx, dmesg_txt)`` tuple as
+    :func:`boot_and_verify_from_merged_dts` for any per-board
+    diagnostic tail.
+    """
+    out_dir = out_dir or DEFAULT_OUT_DIR
+    merged_dts = run_xsa_pipeline(spec, tmp_path=tmp_path, out_dir=out_dir)
+    return boot_and_verify_from_merged_dts(
+        spec,
+        merged_dts,
+        board=board,
+        request=request,
+        out_dir=out_dir,
+    )

--- a/test/hw/test_ad9081_zcu102_system_hw.py
+++ b/test/hw/test_ad9081_zcu102_system_hw.py
@@ -130,8 +130,10 @@ SPEC = BoardSystemProfile(
     probe_signature_any=("AD9081 Rev.", "probed ADC AD9081"),
     probe_signature_message="AD9081 probe signature not found in dmesg",
     iio_required_all=("hmc7044",),
-    iio_required_any=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
-    iio_frontend_label="AD9081 RX frontend",
+    iio_required_any_groups=(
+        ("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+        ("axi-ad9081-tx-hpc", "ad_ip_jesd204_tpl_dac"),
+    ),
     jesd_rx_glob="84a90000.axi[_-]jesd204[_-]rx",
     jesd_tx_glob="84b90000.axi[_-]jesd204[_-]tx",
     rx_capture_target_names=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),

--- a/test/hw/test_ad9081_zcu102_system_hw.py
+++ b/test/hw/test_ad9081_zcu102_system_hw.py
@@ -3,8 +3,7 @@
 Exercises every stage of pyadi-dt end-to-end:
 
 1. **XSA parsing** — :class:`adidt.xsa.topology.XsaParser` extracts the
-   FPGA IP topology (JESD204 RX/TX instances, ADC/DAC converter
-   instance, clkgen trees) from the Vivado archive.
+   FPGA IP topology from the Vivado archive.
 2. **Base DTS generation** — :class:`adidt.xsa.sdtgen.SdtgenRunner`
    produces the platform ``system-top.dts`` for ZCU102.
 3. **Declarative device composition** — :class:`adidt.eval.ad9081_fmc`
@@ -12,47 +11,32 @@ Exercises every stage of pyadi-dt end-to-end:
    connections through :class:`adidt.System`; ``System.generate_dts``
    emits the MxFE + HMC7044 + ADXCVR / JESD204 / TPL-core overlays.
 4. **DTS merge** — :class:`adidt.xsa.merger.DtsMerger` splices the
-   overlay into the base DTS; ``dtc`` compiles the result to a DTB.
-5. **Hardware boot** — labgrid drives the ZCU102 through
-   ``powered_off → shell`` with the rendered DTB deployed via
-   ``KuiperDLDriver``.
-6. **Runtime verification** — kernel ``dmesg``, IIO device discovery,
-   and JESD204 sysfs link status are checked through the labgrid
-   ``ADIShellDriver`` + pylibiio.
+   overlay into the base DTS.
+5. **Standard boot + verify** — delegated to
+   :func:`test.hw._system_base.boot_and_verify_from_merged_dts`
+   (compile DTS → stage as ``system.dtb`` → labgrid boot → dmesg →
+   IIO probe → JESD DATA → RX capture).
 
-LG_ENV: /jenkins/lg_ad9081_zcu102.yaml
+LG_ENV: /jenkins/lg_ad9081_zcu102.yaml.
 """
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
 
-if not (os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV")):
-    pytest.skip(
-        "set LG_COORDINATOR or LG_ENV for AD9081 ZCU102 System hardware test"
-        " (see .env.example)",
-        allow_module_level=True,
-    )
-
-import adidt  # noqa: E402
-from adidt.xsa.merger import DtsMerger  # noqa: E402
-from adidt.xsa.sdtgen import SdtgenRunner  # noqa: E402
-from adidt.xsa.topology import XsaParser  # noqa: E402
-from test.hw.hw_helpers import (  # noqa: E402
-    DEFAULT_OUT_DIR,
-    acquire_xsa,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    assert_rx_capture_valid,
-    collect_dmesg,
-    compile_dts_to_dtb,
-    deploy_and_boot,
-    open_iio_context,
+import adidt
+from adidt.xsa.merger import DtsMerger
+from adidt.xsa.sdtgen import SdtgenRunner
+from adidt.xsa.topology import XsaParser
+from test.hw._system_base import (
+    BoardSystemProfile,
+    acquire_or_local_xsa,
+    boot_and_verify_from_merged_dts,
+    requires_lg,
 )
+from test.hw.hw_helpers import DEFAULT_OUT_DIR
 
 
 DEFAULT_KUIPER_RELEASE = "2023_r2"
@@ -60,17 +44,8 @@ DEFAULT_KUIPER_PROJECT = "zynqmp-zcu102-rev10-ad9081"
 DEFAULT_VCXO_HZ = 122_880_000
 
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-
-
 def _solve_ad9081_config(vcxo_hz: int = DEFAULT_VCXO_HZ) -> dict:
-    """Resolve AD9081 JESD mode + datapath + clocks via pyadi-jif.
-
-    Returns a small config dict consumed by :func:`_configure_converter`.
-    Skips the test gracefully if ``pyadi-jif`` is not installed.
-    """
+    """Resolve AD9081 JESD mode + datapath + clocks via pyadi-jif."""
     try:
         import adijif
     except ModuleNotFoundError as exc:
@@ -112,8 +87,6 @@ def _solve_ad9081_config(vcxo_hz: int = DEFAULT_VCXO_HZ) -> dict:
         "tx_mode": int(float(mode_tx[0]["mode"])),
         "rx_class": mode_rx[0]["jesd_class"],
         "tx_class": mode_tx[0]["jesd_class"],
-        "rx_settings": mode_rx[0]["settings"],
-        "tx_settings": mode_tx[0]["settings"],
     }
 
 
@@ -121,12 +94,11 @@ def _configure_converter(fmc, cfg: dict) -> None:
     """Apply solver-resolved JESD + datapath values to the AD9081 device.
 
     AD9081 uses *different* jesd204b link modes for the ADC (RX, jtx)
-    and DAC (TX, jrx) sides — see the per-side ``MODE_TABLE`` in
+    and DAC (TX, jrx) — see the per-side ``MODE_TABLE`` in
     :mod:`adidt.devices.converters.ad9081`.  Applying the same mode to
     both sides via ``converter.set_jesd204_mode`` leaves the DAC
     mode-table lookup empty and L=0, which makes the kernel driver
-    fail at ``adi_ad9081_device_startup_tx_or_nco_test`` with
-    ``jesd_param->jesd_l == 0``.  Set each side individually instead.
+    fail at ``adi_ad9081_device_startup_tx_or_nco_test``.
     """
     fmc.converter.adc.set_jesd204_mode(cfg["rx_mode"], cfg["rx_class"])
     fmc.converter.dac.set_jesd204_mode(cfg["tx_mode"], cfg["tx_class"])
@@ -138,27 +110,46 @@ def _configure_converter(fmc, cfg: dict) -> None:
     fmc.converter.dac.fduc_interpolation = cfg["tx_fduc"]
 
 
-# ---------------------------------------------------------------------------
-# The test
-# ---------------------------------------------------------------------------
+# Reuse the AD9081+ZCU102 SPEC for the post-render boot+verify steps.
+# `cfg_builder` and `xsa_resolver` are unused here (the System API path
+# does its own composition + sdtgen rather than running XsaPipeline) but
+# the rest of the SPEC — boot mode, IIO requirements, JESD globs, RX
+# capture targets — is identical to the XSA-pipeline AD9081 test.
+SPEC = BoardSystemProfile(
+    lg_features=("ad9081", "zcu102"),
+    cfg_builder=_solve_ad9081_config,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    boot_mode="sd",
+    kernel_fixture_name="built_kernel_image_zynqmp",
+    out_label="ad9081_system",
+    dmesg_grep_pattern="ad9081|hmc7044|jesd204|probe|failed|error",
+    probe_signature_any=("AD9081 Rev.", "probed ADC AD9081"),
+    probe_signature_message="AD9081 probe signature not found in dmesg",
+    iio_required_all=("hmc7044",),
+    iio_required_any=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+    iio_frontend_label="AD9081 RX frontend",
+    jesd_rx_glob="84a90000.axi[_-]jesd204[_-]rx",
+    jesd_tx_glob="84b90000.axi[_-]jesd204[_-]tx",
+    rx_capture_target_names=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+)
 
 
-@pytest.mark.lg_feature(["ad9081", "zcu102"])
-def test_ad9081_zcu102_system_hw(board, built_kernel_image_zynqmp, tmp_path):
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_ad9081_zcu102_system_hw(board, tmp_path, request):
     """Compose an AD9081+ZCU102 design via the System API and boot it."""
     out_dir = DEFAULT_OUT_DIR
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # --- 1. Acquire the XSA for the target design ---
-    xsa_path = acquire_xsa(
-        Path(__file__).parent / "xsa" / "system_top.xsa",
-        DEFAULT_KUIPER_RELEASE,
-        DEFAULT_KUIPER_PROJECT,
-        tmp_path,
-    )
+    xsa_path = SPEC.xsa_resolver(tmp_path)
     assert xsa_path.exists(), f"XSA not found: {xsa_path}"
 
-    # --- 2. Parse the XSA to confirm the FPGA is an AD9081+MxFE design ---
+    # --- 2. Parse the XSA + sanity-check topology ---
     topology = XsaParser().parse(xsa_path)
     assert topology.has_converter_types("axi_ad9081"), (
         f"XSA topology is not AD9081: converter IPs = "
@@ -178,7 +169,7 @@ def test_ad9081_zcu102_system_hw(board, built_kernel_image_zynqmp, tmp_path):
     base_dts = base_dts_path.read_text()
 
     # --- 4. Compose the design declaratively via adidt.System ---
-    cfg = _solve_ad9081_config()
+    cfg = SPEC.cfg_builder()
 
     fmc = adidt.eval.ad9081_fmc(reference_frequency=DEFAULT_VCXO_HZ)
     _configure_converter(fmc, cfg)
@@ -237,69 +228,13 @@ def test_ad9081_zcu102_system_hw(board, built_kernel_image_zynqmp, tmp_path):
         "AD9081 node missing from merged DTS"
     )
 
-    # --- 6. Compile merged DTS to DTB ---
-    dtb_raw = out_dir / f"{merged_name}.dtb"
-    compile_dts_to_dtb(out_dir / f"{merged_name}.dts", dtb_raw)
-    assert dtb_raw.exists() and dtb_raw.stat().st_size > 0, (
-        f"dtc produced empty/missing DTB: {dtb_raw}"
-    )
-
-    # Kuiper's ZCU102 U-Boot loads ``system.dtb`` from the SD card, so
-    # stage our generated DTB with that exact basename — otherwise the
-    # boot uses a stale ``system.dtb`` left over on the card and our DT
-    # never takes effect.
-    import shutil as _shutil
-
-    staged_dir = out_dir / "sd_staging"
-    staged_dir.mkdir(parents=True, exist_ok=True)
-    dtb = staged_dir / "system.dtb"
-    _shutil.copyfile(dtb_raw, dtb)
-
-    # --- 7. Deploy + boot via labgrid ---
-    shell = deploy_and_boot(board, dtb, built_kernel_image_zynqmp)
-
-    # --- 8. Collect dmesg + key sysfs state for diagnostics ---
-    dmesg_txt = collect_dmesg(
-        shell,
-        out_dir,
-        label="ad9081_system",
-        grep_pattern="ad9081|hmc7044|jesd204|probe|failed|error",
-    )
-
-    # --- 9. Verify: kernel probe + IIO context + JESD DATA state ---
-    assert_no_kernel_faults(dmesg_txt)
-    assert_no_probe_errors(dmesg_txt)
-    assert "AD9081 Rev." in dmesg_txt or "probed ADC AD9081" in dmesg_txt, (
-        "AD9081 probe signature was not found in kernel dmesg output"
-    )
-
-    ctx, _ = open_iio_context(shell)
-
-    found = [d.name for d in ctx.devices]
-    assert "hmc7044" in found, (
-        f"Expected IIO clock device 'hmc7044' not found. Devices: {found}"
-    )
-    assert any(n in found for n in ("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc")), (
-        f"AD9081 RX IIO frontend not found in devices: {found}"
-    )
-    assert any(n in found for n in ("axi-ad9081-tx-hpc", "ad_ip_jesd204_tpl_dac")), (
-        f"AD9081 TX IIO frontend not found in devices: {found}"
-    )
-
-    # JESD link DATA state — both RX and TX must be locked.
-    rx_status, tx_status = assert_jesd_links_data(
-        shell,
-        context="initial boot",
-        rx_glob="84a90000.axi[_-]jesd204[_-]rx",
-        tx_glob="84b90000.axi[_-]jesd204[_-]tx",
-    )
-    print(f"$ cat .../84a90000.axi?jesd204?rx/status\n{rx_status}")
-    print(f"$ cat .../84b90000.axi?jesd204?tx/status\n{tx_status}")
-
-    # Data-path smoke test: capture a real buffer and verify samples flow.
-    assert_rx_capture_valid(
-        ctx,
-        ("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
-        n_samples=2**12,
-        context="ad9081 system",
+    # --- 6-9. Compile + stage + boot + verify via the shared helper ---
+    merged_dts = out_dir / f"{merged_name}.dts"
+    boot_and_verify_from_merged_dts(
+        SPEC,
+        merged_dts,
+        board=board,
+        request=request,
+        out_dir=out_dir,
+        dtb_basename=f"{merged_name}.dtb",
     )

--- a/test/hw/test_ad9081_zcu102_xsa_hw.py
+++ b/test/hw/test_ad9081_zcu102_xsa_hw.py
@@ -1,12 +1,12 @@
 """AD9081 + ZCU102 hardware test driven by the XSA pipeline.
 
-Parallels :mod:`test.hw.test_adrv9009_zcu102_hw` stage-for-stage, using
-:class:`adidt.xsa.pipeline.XsaPipeline` + :class:`AD9081Builder` instead
-of the declarative :class:`adidt.System` path.  The XSA pipeline handles
-the full set of topology-driven overlays (XCVR clock refs, TPL core
-binding, JESD link IDs, ``dev_clk`` phandles) that the System path does
-not yet emit, so this variant reaches a fully probed IIO device where
-the System test still falls short.
+Parallels :mod:`test.hw.test_adrv9009_zcu102_hw` stage-for-stage but
+uses :class:`adidt.xsa.pipeline.XsaPipeline` + :class:`AD9081Builder`
+instead of the declarative :class:`adidt.System` path.  The XSA
+pipeline handles the full set of topology-driven overlays (XCVR clock
+refs, TPL core binding, JESD link IDs, ``dev_clk`` phandles) that the
+System path does not yet emit, so this variant reaches a fully probed
+IIO device where the System test still falls short.
 
 LG_ENV / LG_COORDINATOR: see ``.env.example``.  The test runs against
 the ``mini2`` place (ZCU102 + AD9081-FMCA-EBZ) on the coordinator.
@@ -14,33 +14,15 @@ the ``mini2`` place (ZCU102 + AD9081-FMCA-EBZ) on the coordinator.
 
 from __future__ import annotations
 
-import os
-import shutil as _shutil
-from pathlib import Path
 from typing import Any
 
 import pytest
 
-if not (os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV")):
-    pytest.skip(
-        "set LG_COORDINATOR or LG_ENV for AD9081 ZCU102 hardware test"
-        " (see .env.example)",
-        allow_module_level=True,
-    )
-
-from adidt.xsa.pipeline import XsaPipeline  # noqa: E402
-from adidt.xsa.topology import XsaParser  # noqa: E402
-from test.hw.hw_helpers import (  # noqa: E402
-    DEFAULT_OUT_DIR,
-    acquire_xsa,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    assert_rx_capture_valid,
-    collect_dmesg,
-    compile_dts_to_dtb,
-    deploy_and_boot,
-    open_iio_context,
+from test.hw._system_base import (
+    BoardSystemProfile,
+    acquire_or_local_xsa,
+    requires_lg,
+    run_xsa_boot_and_verify,
 )
 
 
@@ -52,8 +34,10 @@ DEFAULT_VCXO_HZ = 122_880_000
 def _solve_ad9081_config(vcxo_hz: int = DEFAULT_VCXO_HZ) -> dict[str, Any]:
     """Resolve AD9081 JESD mode + datapath + clocks via pyadi-jif.
 
-    Returns the ``cfg`` dict consumed by ``XsaPipeline.run``.  Skips the
-    test gracefully if ``pyadi-jif`` is not installed.
+    Pins the AD9081 link modes to the jesd204b values Kuiper's stock
+    ``m8_l4_vcxo122p88/system.dtb`` uses (rx=10, tx=9).  The default
+    ``(M=8, L=4)`` lookup picks ``(17, 18)`` — jesd204c modes that
+    fail the AD9081 driver's link-config table check.
     """
     try:
         import adijif
@@ -86,23 +70,11 @@ def _solve_ad9081_config(vcxo_hz: int = DEFAULT_VCXO_HZ) -> dict[str, Any]:
     rx_settings = mode_rx[0]["settings"]
     tx_settings = mode_tx[0]["settings"]
 
-    # Pin the AD9081 link modes to the jesd204b values Kuiper's stock
-    # ``m8_l4_vcxo122p88/system.dtb`` uses (rx=9, tx=10).  Without this
-    # override the ``(M=8, L=4)`` entry in
-    # :data:`~adidt.xsa.builders.ad9081._AD9081_LINK_MODE_BY_ML` picks
-    # ``(17, 18)`` which are jesd204c modes and fail ``jrx configuration
-    # is not in table`` on the AD9081 driver's link-config lookup.
     return {
         "jesd": {
             "rx": {k: int(rx_settings[k]) for k in ("F", "K", "M", "L", "Np", "S")},
             "tx": {k: int(tx_settings[k]) for k in ("F", "K", "M", "L", "Np", "S")},
         },
-        # Per analogdevicesinc/linux reference
-        # ``zynqmp-zcu102-rev10-ad9081-m8-l4.dts``: the ``adi,tx-dacs``
-        # (host TX / jrx / DAC) block uses ``link-mode = <9>`` and the
-        # ``adi,rx-adcs`` (host RX / jtx / ADC) block uses
-        # ``link-mode = <10>`` — the opposite of what the naming
-        # might initially suggest.
         "ad9081": {
             "rx_link_mode": 10,
             "tx_link_mode": 9,
@@ -110,114 +82,46 @@ def _solve_ad9081_config(vcxo_hz: int = DEFAULT_VCXO_HZ) -> dict[str, Any]:
     }
 
 
-@pytest.mark.lg_feature(["ad9081", "zcu102"])
-def test_ad9081_zcu102_xsa_hw(board, built_kernel_image_zynqmp, tmp_path):
-    """End-to-end pyadi-dt AD9081+ZCU102 boot + IIO verification (XSA path)."""
-    out_dir = DEFAULT_OUT_DIR
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # --- 1. Acquire the XSA for the target design ---
-    xsa_path = acquire_xsa(
-        Path(__file__).parent / "xsa" / "ref_data" / "system_top_ad9081_zcu102.xsa",
-        DEFAULT_KUIPER_RELEASE,
-        DEFAULT_KUIPER_PROJECT,
-        tmp_path,
-    )
-    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
-
-    # --- 2. Parse the XSA as a sanity check on topology + fixture ---
-    topology = XsaParser().parse(xsa_path)
+def _topology_assert(topology) -> None:
     assert topology.has_converter_types("axi_ad9081"), (
         f"XSA topology is not AD9081: converter IPs = "
         f"{[c.ip_type for c in topology.converters]}"
     )
     assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
     assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
-    print(
-        f"XSA topology: {len(topology.converters)} converter(s), "
-        f"{len(topology.jesd204_rx)} rx jesd, {len(topology.jesd204_tx)} tx jesd"
-    )
 
-    # --- 3. Render device tree via the XSA pipeline ---
-    cfg = _solve_ad9081_config()
-    result = XsaPipeline().run(
-        xsa_path=xsa_path,
-        cfg=cfg,
-        output_dir=out_dir,
-        profile="ad9081_zcu102",
-        sdtgen_timeout=300,
-    )
-    merged_dts = result["merged"]
-    assert merged_dts.exists(), f"Merged DTS not written: {merged_dts}"
 
-    merged_content = merged_dts.read_text()
-    assert 'compatible = "adi,ad9081"' in merged_content, (
-        "AD9081 compatible string missing from merged DTS"
-    )
-    assert 'compatible = "adi,hmc7044"' in merged_content, (
-        "HMC7044 compatible string missing from merged DTS"
-    )
+SPEC = BoardSystemProfile(
+    lg_features=("ad9081", "zcu102"),
+    cfg_builder=_solve_ad9081_config,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_ad9081_zcu102.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    sdtgen_profile="ad9081_zcu102",
+    topology_assert=_topology_assert,
+    boot_mode="sd",
+    kernel_fixture_name="built_kernel_image_zynqmp",
+    out_label="ad9081_xsa",
+    dmesg_grep_pattern="ad9081|hmc7044|jesd204|probe|failed|error",
+    merged_dts_must_contain=(
+        'compatible = "adi,ad9081"',
+        'compatible = "adi,hmc7044"',
+    ),
+    probe_signature_any=("AD9081 Rev.", "probed ADC AD9081"),
+    probe_signature_message="AD9081 probe signature not found in dmesg",
+    iio_required_all=("hmc7044",),
+    iio_required_any=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+    iio_frontend_label="AD9081 RX frontend",
+    jesd_rx_glob="84a90000.axi[_-]jesd204[_-]rx",
+    jesd_tx_glob="84b90000.axi[_-]jesd204[_-]tx",
+    rx_capture_target_names=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+)
 
-    # --- 4. Compile merged DTS to DTB + stage as system.dtb ---
-    dtb_raw = out_dir / "ad9081_zcu102_xsa.dtb"
-    compile_dts_to_dtb(merged_dts, dtb_raw)
-    assert dtb_raw.exists() and dtb_raw.stat().st_size > 0, (
-        f"dtc produced empty/missing DTB: {dtb_raw}"
-    )
 
-    # Kuiper's ZCU102 U-Boot loads ``system.dtb`` from the SD card; match
-    # that basename so our DT actually takes effect (otherwise a stale
-    # ``system.dtb`` from a previous boot would be used).
-    staged_dir = out_dir / "sd_staging_xsa"
-    staged_dir.mkdir(parents=True, exist_ok=True)
-    dtb = staged_dir / "system.dtb"
-    _shutil.copyfile(dtb_raw, dtb)
-
-    # --- 5. Deploy + boot via labgrid ---
-    shell = deploy_and_boot(board, dtb, built_kernel_image_zynqmp)
-
-    # --- 6. Collect dmesg + key sysfs state for diagnostics ---
-    dmesg_txt = collect_dmesg(
-        shell,
-        out_dir,
-        label="ad9081_xsa",
-        grep_pattern="ad9081|hmc7044|jesd204|probe|failed|error",
-    )
-
-    # --- 7. Verify: kernel probe + IIO context + JESD DATA state ---
-    assert_no_kernel_faults(dmesg_txt)
-    assert_no_probe_errors(dmesg_txt)
-    assert "AD9081 Rev." in dmesg_txt or "probed ADC AD9081" in dmesg_txt, (
-        "AD9081 probe signature was not found in kernel dmesg output"
-    )
-
-    ctx, _ = open_iio_context(shell)
-
-    found = {d.name for d in ctx.devices if d.name}
-    assert "hmc7044" in found, (
-        f"Expected IIO clock device 'hmc7044' not found. Devices: {sorted(found)}"
-    )
-    assert any(n in found for n in ("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc")), (
-        f"AD9081 RX IIO frontend not found in devices: {sorted(found)}"
-    )
-    assert any(n in found for n in ("axi-ad9081-tx-hpc", "ad_ip_jesd204_tpl_dac")), (
-        f"AD9081 TX IIO frontend not found in devices: {sorted(found)}"
-    )
-
-    # JESD link DATA state — both RX and TX must be locked.
-    rx_status, tx_status = assert_jesd_links_data(
-        shell,
-        context="initial boot",
-        rx_glob="84a90000.axi[_-]jesd204[_-]rx",
-        tx_glob="84b90000.axi[_-]jesd204[_-]tx",
-    )
-    print(f"$ cat .../84a90000.axi?jesd204?rx/status\n{rx_status}")
-    print(f"$ cat .../84b90000.axi?jesd204?tx/status\n{tx_status}")
-
-    # Data-path smoke test: capture a real buffer and verify samples flow.
-    assert_rx_capture_valid(
-        ctx,
-        ("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
-        n_samples=2**12,
-        context="ad9081 xsa",
-    )
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_ad9081_zcu102_xsa_hw(board, tmp_path, request):
+    """End-to-end pyadi-dt AD9081+ZCU102 boot + IIO verification (XSA path)."""
+    run_xsa_boot_and_verify(SPEC, board=board, request=request, tmp_path=tmp_path)

--- a/test/hw/test_ad9081_zcu102_xsa_hw.py
+++ b/test/hw/test_ad9081_zcu102_xsa_hw.py
@@ -112,8 +112,10 @@ SPEC = BoardSystemProfile(
     probe_signature_any=("AD9081 Rev.", "probed ADC AD9081"),
     probe_signature_message="AD9081 probe signature not found in dmesg",
     iio_required_all=("hmc7044",),
-    iio_required_any=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
-    iio_frontend_label="AD9081 RX frontend",
+    iio_required_any_groups=(
+        ("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+        ("axi-ad9081-tx-hpc", "ad_ip_jesd204_tpl_dac"),
+    ),
     jesd_rx_glob="84a90000.axi[_-]jesd204[_-]rx",
     jesd_tx_glob="84b90000.axi[_-]jesd204[_-]tx",
     rx_capture_target_names=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),

--- a/test/hw/test_adrv9009_zc706_hw.py
+++ b/test/hw/test_adrv9009_zc706_hw.py
@@ -93,8 +93,10 @@ SPEC = BoardSystemProfile(
     merged_dts_must_contain=('compatible = "adi,adrv9009"',),
     probe_signature_any=("adrv9009", "talise"),
     probe_signature_message="ADRV9009 driver probe signature not found in dmesg",
-    iio_required_any=("adrv9009-phy", "talise"),
-    iio_frontend_label="ADRV9009 phy device",
+    iio_required_any_groups=(
+        ("adrv9009-phy", "talise"),
+        ("ad9528-1", "hmc7044"),
+    ),
 )
 
 

--- a/test/hw/test_adrv9009_zc706_hw.py
+++ b/test/hw/test_adrv9009_zc706_hw.py
@@ -1,47 +1,25 @@
 """ADRV9009 + ZC706 hardware test.
 
 Drives the XSA pipeline (:class:`adidt.xsa.pipeline.XsaPipeline` +
-:class:`adidt.xsa.builders.adrv9009.ADRV9009Builder`) end-to-end on real
-hardware attached to the ``nemo`` labgrid place.
+:class:`adidt.xsa.builders.adrv9009.ADRV9009Builder`) end-to-end on
+real hardware attached to the ``nemo`` labgrid place.  Boot strategy
+is :class:`BootFPGASoCTFTP` (Zynq-7000 TFTP boot); the DTB is renamed
+to ``devicetree.dtb`` by the shared ``boot_mode="tftp"`` dispatch.
 
-Boot strategy is :class:`BootFPGASoCTFTP` (Zynq-7000 TFTP boot).  The DTB is
-renamed to ``devicetree.dtb`` before :meth:`KuiperDLDriver.add_files_to_target`
-so U-Boot's ``tftp devicetree.dtb`` finds it.
-
-LG_ENV: lg_adrv9009_zc706_tftp.yaml
+LG_ENV: lg_adrv9009_zc706_tftp.yaml.
 """
 
 from __future__ import annotations
 
-import os
-import shutil
-from pathlib import Path
+from typing import Any
 
 import pytest
 
-if not (os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV")):
-    pytest.skip(
-        "set LG_COORDINATOR or LG_ENV for ADRV9009 ZC706 hardware test"
-        " (see .env.example)",
-        allow_module_level=True,
-    )
-
-from adidt.xsa.pipeline import XsaPipeline  # noqa: E402
-from adidt.xsa.topology import XsaParser  # noqa: E402
-from test.hw.hw_helpers import (  # noqa: E402
-    DEFAULT_OUT_DIR,
-    acquire_xsa,
-    assert_ilas_aligned,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    check_jesd_framing_plausibility,
-    collect_dmesg,
-    compile_dts_to_dtb,
-    deploy_and_boot,
-    open_iio_context,
-    parse_ilas_status,
-    read_jesd_status,
+from test.hw._system_base import (
+    BoardSystemProfile,
+    acquire_or_local_xsa,
+    requires_lg,
+    run_xsa_boot_and_verify,
 )
 
 
@@ -49,53 +27,18 @@ DEFAULT_KUIPER_RELEASE = "2023_r2"
 DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv9009"
 
 
-def _stage_dtb_as_devicetree(dtb: Path, staging_dir: Path) -> Path:
-    """Copy *dtb* into *staging_dir* renamed to ``devicetree.dtb``.
+def _adrv9009_cfg() -> dict[str, Any]:
+    """ADRV9009+ZC706 XSA pipeline cfg.
 
-    BootFPGASoCTFTP's YAML sets ``dtb_image_name: devicetree.dtb`` — the
-    file must have that exact basename when it lands in the TFTP root.
+    Default HDL framing: RX M=4 L=2 S=1 Np=16 -> F=4; TX M=4 L=4 S=1
+    Np=16 -> F=2.  Matches the pyadi-jif solver output and the Kuiper
+    reference design ``zynq-zc706-adv7511-adrv9009``.
+
+    GPIO overrides: ADRV9009Builder defaults to ZCU102 GPIOs (130/136);
+    ZC706 wires the same signals to gpio0:106 (reset) and gpio0:112
+    (sysref-req), matching the Kuiper production DT.
     """
-    staging_dir.mkdir(parents=True, exist_ok=True)
-    staged = staging_dir / "devicetree.dtb"
-    shutil.copyfile(dtb, staged)
-    return staged
-
-
-@pytest.mark.lg_feature(["adrv9009", "zc706"])
-def test_adrv9009_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
-    """End-to-end pyadi-dt ADRV9009+ZC706 via the XSA pipeline."""
-    out_dir = DEFAULT_OUT_DIR
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # --- 1. Acquire XSA (auto-downloads from Kuiper if not local) ---
-    xsa_path = acquire_xsa(
-        Path(__file__).parent / "xsa" / "system_top_adrv9009_zc706.xsa",
-        DEFAULT_KUIPER_RELEASE,
-        DEFAULT_KUIPER_PROJECT,
-        tmp_path,
-    )
-    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
-
-    # --- 2. Sanity-check topology ---
-    topology = XsaParser().parse(xsa_path)
-    assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
-    assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
-    print(
-        f"XSA topology: {len(topology.converters)} converter(s), "
-        f"{len(topology.jesd204_rx)} rx jesd, {len(topology.jesd204_tx)} tx jesd"
-    )
-
-    # --- 3. Run the XSA pipeline ---
-    # ADRV9009 default HDL framing: RX M=4 L=2 S=1 Np=16 -> F=4;
-    # TX M=4 L=4 S=1 Np=16 -> F=2.  Matches what
-    # ``test_adrv9009_zcu102_hw._solve_adrv9009_config`` derives via
-    # pyadi-jif and what the ZC706 ADRV9009 HDL reference design uses.
-    #
-    # ``adrv9009_board`` GPIO overrides: ADRV9009Builder defaults to
-    # ZCU102 GPIO numbers (130/136); ZC706 wires the same signals to
-    # gpio0:106 (reset) and gpio0:112 (sysref-req), matching the Kuiper
-    # production zynq-zc706-adv7511-adrv9009 DT.
-    cfg = {
+    return {
         "adrv9009_board": {
             "trx_reset_gpio": 106,
             "trx_sysref_req_gpio": 112,
@@ -112,66 +55,63 @@ def test_adrv9009_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
         },
     }
 
-    framing_warnings = check_jesd_framing_plausibility(cfg["jesd"])
-    assert not framing_warnings, (
-        "JESD cfg is structurally inconsistent (will fail ILAS):\n  "
-        + "\n  ".join(framing_warnings)
-    )
 
-    result = XsaPipeline().run(
-        xsa_path=xsa_path,
-        cfg=cfg,
-        output_dir=out_dir,
-        sdtgen_timeout=300,
-        profile="adrv9009_zc706",
-    )
-    merged_dts = result["merged"]
-    assert merged_dts.exists(), f"Merged DTS not written: {merged_dts}"
+def _topology_assert(topology) -> None:
+    assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
+    assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
 
-    merged_content = merged_dts.read_text()
-    assert 'compatible = "adi,adrv9009"' in merged_content, (
-        "ADRV9009 compatible string missing from merged DTS"
-    )
 
-    # --- 4. Compile to DTB, stage as devicetree.dtb ---
-    dtb_raw = out_dir / "adrv9009_zc706.dtb"
-    compile_dts_to_dtb(merged_dts, dtb_raw)
-    dtb = _stage_dtb_as_devicetree(dtb_raw, out_dir / "tftp_staging_xsa")
+def _filter_si570_probe_noise(dmesg_txt: str) -> str:
+    """Strip benign Si570 -EIO probe lines.
 
-    # --- 5. Deploy + boot ---
-    shell = deploy_and_boot(board, dtb, built_kernel_image_zynq)
-
-    # --- 6. Diagnostics + probe verification ---
-    dmesg_txt = collect_dmesg(
-        shell,
-        out_dir,
-        label="adrv9009_xsa",
-        grep_pattern="adrv9009|hmc7044|ad9528|jesd204|talise|probe|failed|error",
-    )
-    assert_no_kernel_faults(dmesg_txt)
-    # si570 probe -EIO is a benign hardware artifact present in production
-    # too (the optional Si570 clock chip sometimes doesn't ACK on the
-    # default i2c address); strip it before the probe-error check.
-    dmesg_filtered = "\n".join(
+    The optional Si570 clock chip on the ADRV9009-FMC sometimes does
+    not ACK on its default I2C address; the failure is present in the
+    production reference DT too.
+    """
+    return "\n".join(
         line
         for line in dmesg_txt.splitlines()
         if not ("si570" in line and "failed" in line)
     )
-    assert_no_probe_errors(dmesg_filtered)
-    assert "adrv9009" in dmesg_txt.lower() or "talise" in dmesg_txt.lower(), (
-        "ADRV9009 driver probe signature not found in dmesg"
+
+
+SPEC = BoardSystemProfile(
+    lg_features=("adrv9009", "zc706"),
+    cfg_builder=_adrv9009_cfg,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_adrv9009_zc706.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    sdtgen_profile="adrv9009_zc706",
+    topology_assert=_topology_assert,
+    boot_mode="tftp",
+    kernel_fixture_name="built_kernel_image_zynq",
+    out_label="adrv9009_xsa",
+    dmesg_grep_pattern="adrv9009|hmc7044|ad9528|jesd204|talise|probe|failed|error",
+    dmesg_filter=_filter_si570_probe_noise,
+    merged_dts_must_contain=('compatible = "adi,adrv9009"',),
+    probe_signature_any=("adrv9009", "talise"),
+    probe_signature_message="ADRV9009 driver probe signature not found in dmesg",
+    iio_required_any=("adrv9009-phy", "talise"),
+    iio_frontend_label="ADRV9009 phy device",
+)
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_adrv9009_zc706_xsa_hw(board, tmp_path, request):
+    """End-to-end pyadi-dt ADRV9009+ZC706 via the XSA pipeline."""
+    from test.hw.hw_helpers import (
+        assert_ilas_aligned,
+        parse_ilas_status,
+        read_jesd_status,
     )
 
-    ctx, _ = open_iio_context(shell)
-    found = {d.name for d in ctx.devices if d.name}
-    assert any("adrv9009" in n.lower() or "talise" in n.lower() for n in found), (
-        f"No ADRV9009 IIO device found. Devices: {sorted(found)}"
-    )
-    assert any("9528" in n or "hmc7044" in n.lower() for n in found), (
-        f"No AD9528/HMC7044 clock device found. Devices: {sorted(found)}"
+    shell, _ctx, dmesg_txt = run_xsa_boot_and_verify(
+        SPEC, board=board, request=request, tmp_path=tmp_path
     )
 
-    # --- 7. JESD link + ILAS diagnostics ---
     rx_status, tx_status = read_jesd_status(shell)
     print("=== JESD204 RX status (sysfs) ===")
     print(rx_status)
@@ -185,4 +125,3 @@ def test_adrv9009_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
         for name in ilas_report.fields:
             print(f"  mismatched: {name}")
     assert_ilas_aligned(dmesg_txt, context="adrv9009_xsa")
-    assert_jesd_links_data(shell, context="adrv9009_xsa")

--- a/test/hw/test_adrv9009_zcu102_hw.py
+++ b/test/hw/test_adrv9009_zcu102_hw.py
@@ -5,18 +5,19 @@ the only substantive difference is the rendering engine.  The AD9081
 test composes overlays via the declarative :class:`adidt.System`; this
 one uses :class:`adidt.xsa.pipeline.XsaPipeline` because
 :class:`adidt.xsa.builders.adrv9009.ADRV9009Builder` performs extensive
-topology-driven label derivation (xcvr, dma, clkgen, observation-link
-handling) that the declarative ``System`` path doesn't yet cover.  The
-same plumbing — ``XsaParser``, ``SdtgenRunner``, labgrid's
-``KuiperDLDriver`` + ``ADIShellDriver`` — is exercised end-to-end.
+topology-driven label derivation that the System path doesn't yet
+cover.
 
-LG_ENV: /jenkins/lg_hw.yaml
+After the standard boot + verify, this test sweeps four canonical
+Talise filter profiles, pushing each via ``adrv9009-phy.profile_config``
+and re-verifying both JESD links return to DATA.
+
+LG_ENV: /jenkins/lg_hw.yaml.
 """
 
 from __future__ import annotations
 
 import base64
-import os
 import time
 import urllib.request
 from pathlib import Path
@@ -24,27 +25,11 @@ from typing import Any
 
 import pytest
 
-if not (os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV")):
-    pytest.skip(
-        "set LG_COORDINATOR or LG_ENV for ADRV9009 ZCU102 hardware test"
-        " (see .env.example)",
-        allow_module_level=True,
-    )
-
-from adidt.xsa.pipeline import XsaPipeline  # noqa: E402
-from adidt.xsa.topology import XsaParser  # noqa: E402
-from test.hw.hw_helpers import (  # noqa: E402
-    DEFAULT_OUT_DIR,
-    acquire_xsa,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    assert_rx_capture_valid,
-    collect_dmesg,
-    compile_dts_to_dtb,
-    deploy_and_boot,
-    open_iio_context,
-    shell_out,
+from test.hw._system_base import (
+    BoardSystemProfile,
+    acquire_or_local_xsa,
+    requires_lg,
+    run_xsa_boot_and_verify,
 )
 
 
@@ -53,12 +38,12 @@ DEFAULT_KUIPER_PROJECT = "zynqmp-zcu102-rev10-adrv9009"
 DEFAULT_VCXO_HZ = 122.88e6
 DEFAULT_SAMPLE_RATE_HZ = 245.76e6
 
+
 # Canonical Talise filter profiles published alongside iio-oscilloscope.
-# Loaded post-boot via ``adrv9009-phy.profile_config``.  All four share
-# deviceClock=245.76 MHz so the JESD lane rate does not change between
-# profiles, but the write path does re-initialise the radio — a useful
-# smoke test that exercises the driver's profile-reload code and
-# confirms JESD returns to DATA after each swap.
+# All four share deviceClock=245.76 MHz so the JESD lane rate doesn't
+# change between profiles, but the write path does re-initialise the
+# radio — a useful smoke test that exercises the driver's profile-reload
+# code and confirms JESD returns to DATA after each swap.
 TALISE_PROFILE_BASE_URL = (
     "https://raw.githubusercontent.com/analogdevicesinc/iio-oscilloscope/"
     "main/filters/adrv9009"
@@ -72,31 +57,22 @@ TALISE_PROFILE_FILES = (
 
 
 def _fetch_talise_profile(filename: str, cache_dir: Path) -> str:
-    """Fetch a Talise profile, caching into ``cache_dir``."""
     cache_dir.mkdir(parents=True, exist_ok=True)
     cached = cache_dir / filename
     if cached.exists() and cached.stat().st_size > 0:
         return cached.read_text()
     url = f"{TALISE_PROFILE_BASE_URL}/{filename}"
-    with urllib.request.urlopen(url, timeout=30) as resp:
+    with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310
         body = resp.read().decode("utf-8")
     cached.write_text(body)
     return body
-
-
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
 
 
 def _solve_adrv9009_config(
     vcxo_hz: float = DEFAULT_VCXO_HZ,
     sample_rate_hz: float = DEFAULT_SAMPLE_RATE_HZ,
 ) -> dict[str, Any]:
-    """Resolve ADRV9009 JESD framing + clock tree via pyadi-jif.
-
-    Skips the test gracefully if ``pyadi-jif`` is not installed.
-    """
+    """Resolve ADRV9009 JESD framing + clock tree via pyadi-jif."""
     try:
         import adijif
     except ModuleNotFoundError as exc:
@@ -151,111 +127,54 @@ def _solve_adrv9009_config(
     return cfg
 
 
-# ---------------------------------------------------------------------------
-# Hardware test
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.lg_feature(["adrv9009", "zcu102"])
-def test_adrv9009_zcu102_hw(board, built_kernel_image_zynqmp, tmp_path):
-    """End-to-end pyadi-dt ADRV9009+ZCU102 boot + IIO verification."""
-    out_dir = DEFAULT_OUT_DIR
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # --- 1. Acquire the XSA for the target design ---
-    xsa_path = acquire_xsa(
-        Path(__file__).parent / "xsa" / "ref_data" / "system_top_adrv9009_zcu102.xsa",
-        DEFAULT_KUIPER_RELEASE,
-        DEFAULT_KUIPER_PROJECT,
-        tmp_path,
-    )
-    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
-
-    # --- 2. Parse the XSA as a sanity check on topology + fixture ---
-    topology = XsaParser().parse(xsa_path)
+def _topology_assert(topology) -> None:
     assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
     assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
-    print(
-        f"XSA topology: {len(topology.converters)} converter(s), "
-        f"{len(topology.jesd204_rx)} rx jesd, {len(topology.jesd204_tx)} tx jesd"
+
+
+SPEC = BoardSystemProfile(
+    lg_features=("adrv9009", "zcu102"),
+    cfg_builder=_solve_adrv9009_config,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_adrv9009_zcu102.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    topology_assert=_topology_assert,
+    boot_mode="sd",
+    kernel_fixture_name="built_kernel_image_zynqmp",
+    out_label="adrv9009",
+    dmesg_grep_pattern="adrv9009|ad9528|jesd204|probe|failed|error",
+    merged_dts_must_contain=('compatible = "adi,adrv9009"',),
+    probe_signature_any=("adrv9009-phy", "talise"),
+    probe_signature_message="ADRV9009 phy probe signature not found in dmesg",
+    iio_required_all=("adrv9009-phy", "axi-adrv9009-rx-hpc", "ad9528-1"),
+    rx_capture_target_names=("axi-adrv9009-rx-hpc", "axi-adrv9009-rx-obs-hpc"),
+)
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_adrv9009_zcu102_hw(board, tmp_path, request):
+    """End-to-end pyadi-dt ADRV9009+ZCU102 boot + IIO verification."""
+    from test.hw.hw_helpers import (
+        assert_jesd_links_data,
+        assert_no_kernel_faults,
+        assert_no_probe_errors,
+        shell_out,
     )
 
-    # --- 3. Render device tree via the XSA pipeline ---
-    cfg = _solve_adrv9009_config()
-    result = XsaPipeline().run(
-        xsa_path=xsa_path,
-        cfg=cfg,
-        output_dir=out_dir,
-        sdtgen_timeout=300,
-    )
-    merged_dts = result["merged"]
-    assert merged_dts.exists(), f"Merged DTS not written: {merged_dts}"
-
-    merged_content = merged_dts.read_text()
-    assert 'compatible = "adi,adrv9009"' in merged_content, (
-        "ADRV9009 compatible string missing from merged DTS"
+    shell, _ctx, _dmesg = run_xsa_boot_and_verify(
+        SPEC, board=board, request=request, tmp_path=tmp_path
     )
 
-    # --- 4. Compile merged DTS to DTB ---
-    dtb = out_dir / "adrv9009_zcu102.dtb"
-    compile_dts_to_dtb(merged_dts, dtb)
-    assert dtb.exists() and dtb.stat().st_size > 0, (
-        f"dtc produced empty/missing DTB: {dtb}"
-    )
-
-    # --- 5. Deploy + boot via labgrid ---
-    shell = deploy_and_boot(board, dtb, built_kernel_image_zynqmp)
-
-    # --- 6. Collect dmesg + key sysfs state for diagnostics ---
-    dmesg_txt = collect_dmesg(
-        shell,
-        out_dir,
-        label="adrv9009",
-        grep_pattern="adrv9009|ad9528|jesd204|probe|failed|error",
-    )
-
-    # --- 7. Verify: kernel probe + IIO context + JESD DATA state ---
-    assert_no_kernel_faults(dmesg_txt)
-    assert_no_probe_errors(dmesg_txt)
-    assert "adrv9009-phy" in dmesg_txt or "Talise" in dmesg_txt, (
-        "ADRV9009 phy probe signature was not found in kernel dmesg output"
-    )
-
-    ctx, _ = open_iio_context(shell)
-
-    found = [d.name for d in ctx.devices]
-    expected = {
-        "adrv9009-phy": "phy device",
-        "axi-adrv9009-rx-hpc": "RX HPC frontend",
-        "ad9528-1": "AD9528-1 clock chip",
-    }
-    for name, role in expected.items():
-        assert name in found, (
-            f"Expected IIO {role} ({name!r}) not found. Devices: {found}"
-        )
-        n_channels = len([c for c in ctx.devices if c.name == name][0].channels)
-        print(f"  IIO {role}: {name} ({n_channels} channels)")
-
-    # --- 8. JESD204 link DATA state via sysfs ---
-    rx_status, tx_status = assert_jesd_links_data(shell, context="initial boot")
-    print(f"$ cat .../axi?jesd204?rx/status\n{rx_status}")
-    print(f"$ cat .../axi?jesd204?tx/status\n{tx_status}")
-
-    # --- 8b. Data-path smoke test: capture a real RX buffer. ---
-    assert_rx_capture_valid(
-        ctx,
-        ("axi-adrv9009-rx-hpc", "axi-adrv9009-rx-obs-hpc"),
-        n_samples=2**12,
-        context="adrv9009 initial boot",
-    )
-
-    # --- 9. Load all four canonical Talise filter profiles ---
+    # --- Talise filter-profile sweep ---
     # The remote libiio write path drops its TCP socket when the driver
-    # holds the CPU for Talise re-init, surfacing as ``BrokenPipeError``.
-    # Push each profile file to /tmp via the serial shell instead, then
-    # ``cat`` it into the sysfs attribute.
-    # profile_config is exposed via debugfs on ADRV9009; fall back to a
-    # broader /sys search if the usual location is unavailable.
+    # holds the CPU for Talise re-init (BrokenPipeError); push each
+    # profile to /tmp via the serial shell instead, then ``cat`` it
+    # into the sysfs attribute.  ``profile_config`` is exposed via
+    # debugfs on ADRV9009; fall back to a broader /sys search if the
+    # usual location is unavailable.
     profile_sysfs = shell_out(
         shell,
         "find /sys/kernel/debug/iio /sys/bus/iio/devices "

--- a/test/hw/test_adrv9371_zc706_hw.py
+++ b/test/hw/test_adrv9371_zc706_hw.py
@@ -84,8 +84,7 @@ SPEC = BoardSystemProfile(
     merged_dts_must_contain=('compatible = "adi,ad9371"',),
     probe_signature_any=("ad9371", "mykonos"),
     probe_signature_message="AD9371 driver probe signature not found in dmesg",
-    iio_required_any=("9371", "adrv9", "9528"),
-    iio_frontend_label="AD9371 / ADRV9xxx phy device",
+    iio_required_all=("ad9371-phy", "ad9528-1"),
 )
 
 

--- a/test/hw/test_adrv9371_zc706_hw.py
+++ b/test/hw/test_adrv9371_zc706_hw.py
@@ -1,52 +1,33 @@
 """ADRV9371 + ZC706 hardware test.
 
-Exercises both code paths end-to-end on real hardware:
+Exercises the XSA pipeline path end-to-end on the ``bq`` labgrid place.
 
-1. ``test_adrv9371_zc706_xsa_hw`` — XSA pipeline via
-   :class:`adidt.xsa.pipeline.XsaPipeline` + :class:`ADRV937xBuilder`.
-2. ``test_adrv9371_zc706_system_hw`` — declarative System API via
-   :class:`adidt.eval.adrv937x_fmc` + :class:`adidt.fpga.zc706`.
+The standard verify body (boot, dmesg, IIO, JESD DATA) runs through
+:func:`test.hw._system_base.run_xsa_boot_and_verify`.  Three pieces of
+post-boot diagnostic output stay in this file because they are
+ZC706+ADRV9371-specific forensics for documented bring-up blockers
+(JESD framing-parameter mismatch, TPL ADC RSTN, AXI DMAC IRQ wiring):
 
-Boot strategy is :class:`BootFPGASoCTFTP` (Zynq-7000 TFTP boot).  The
-DTB is renamed to ``devicetree.dtb`` before :meth:`KuiperDLDriver.add_files_to_target`
-so U-Boot's ``tftp devicetree.dtb`` finds it.
+* HDL compile-time JESD framing — read the TPL ADC/DAC/OBS descriptor
+  registers per
+  https://analogdevicesinc.github.io/hdl/library/jesd204/ad_ip_jesd204_tpl_{adc,dac}/
+* TPL ADC sysfs snapshot (channel enables, sampling rate, buffer state).
+* AXI DMAC + AD9371 phy snapshot (ENSM mode, RF bandwidth, sample rate).
 
-LG_ENV: lg_adrv9371_zc706_tftp.yaml
+LG_ENV: lg_adrv9371_zc706_tftp.yaml.
 """
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
+from typing import Any
 
 import pytest
 
-if not (os.environ.get("LG_COORDINATOR") or os.environ.get("LG_ENV")):
-    pytest.skip(
-        "set LG_COORDINATOR or LG_ENV for ADRV9371 ZC706 hardware test"
-        " (see .env.example)",
-        allow_module_level=True,
-    )
-
-import adidt  # noqa: E402
-from adidt.xsa.pipeline import XsaPipeline  # noqa: E402
-from adidt.xsa.topology import XsaParser  # noqa: E402
-from test.hw.hw_helpers import (  # noqa: E402
-    DEFAULT_OUT_DIR,
-    acquire_xsa,
-    assert_ilas_aligned,
-    assert_jesd_links_data,
-    assert_no_kernel_faults,
-    assert_no_probe_errors,
-    check_jesd_framing_plausibility,
-    collect_dmesg,
-    compile_dts_to_dtb,
-    deploy_and_boot,
-    open_iio_context,
-    parse_ilas_status,
-    read_jesd_status,
-    shell_out,
-    stage_dtb_as_devicetree,
+from test.hw._system_base import (
+    BoardSystemProfile,
+    acquire_or_local_xsa,
+    requires_lg,
+    run_xsa_boot_and_verify,
 )
 
 
@@ -55,37 +36,14 @@ DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv937x"
 DEFAULT_VCXO_HZ = 122_880_000
 
 
-# ---------------------------------------------------------------------------
-# XSA pipeline test
-# ---------------------------------------------------------------------------
+def _adrv9371_cfg() -> dict[str, Any]:
+    """ADRV9371+ZC706 XSA pipeline cfg.
 
-
-@pytest.mark.lg_feature(["adrv9371", "zc706"])
-def test_adrv9371_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
-    """End-to-end pyadi-dt ADRV9371+ZC706 via the XSA pipeline."""
-    out_dir = DEFAULT_OUT_DIR
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # --- 1. Acquire XSA ---
-    xsa_path = acquire_xsa(
-        Path(__file__).parent / "xsa" / "system_top_adrv9371_zc706.xsa",
-        DEFAULT_KUIPER_RELEASE,
-        DEFAULT_KUIPER_PROJECT,
-        tmp_path,
-    )
-    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
-
-    # --- 2. Sanity-check topology ---
-    topology = XsaParser().parse(xsa_path)
-    assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
-    assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
-    print(
-        f"XSA topology: {len(topology.converters)} converter(s), "
-        f"{len(topology.jesd204_rx)} rx jesd, {len(topology.jesd204_tx)} tx jesd"
-    )
-
-    # --- 3. Run the XSA pipeline ---
-    cfg = {
+    JESD framing matches the Kuiper reference
+    ``zynq-zc706-adv7511-adrv937x``: RX = M=4 L=2 S=1 → F=4;
+    TX = M=4 L=4 S=1 → F=2.
+    """
+    return {
         "adrv9009_board": {
             "misc_clk_hz": 122_880_000,
             "spi_bus": "spi0",
@@ -98,88 +56,61 @@ def test_adrv9371_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
             "rx_link_id": 1,
             "tx_link_id": 0,
         },
-        # JESD framing parameters matching the default HDL config for
-        # ``projects/adrv9371x/zc706`` (see analogdevicesinc/hdl
-        # README): RX = M=4 L=2 S=1 → F=4; TX = M=4 L=4 S=1 → F=2.
         "jesd": {
             "rx": {"F": 4, "K": 32, "M": 4, "L": 2},
             "tx": {"F": 2, "K": 32, "M": 4, "L": 4},
         },
     }
 
-    # Pre-flight: catch cfg typos (swapped M/L, wrong F) before we
-    # spend 60s compiling + deploying only to fail during ILAS.
-    framing_warnings = check_jesd_framing_plausibility(cfg["jesd"])
-    assert not framing_warnings, (
-        "JESD cfg is structurally inconsistent (will fail ILAS):\n  "
-        + "\n  ".join(framing_warnings)
+
+def _topology_assert(topology) -> None:
+    assert topology.jesd204_rx, "No JESD204 RX instances in XSA topology"
+    assert topology.jesd204_tx, "No JESD204 TX instances in XSA topology"
+
+
+SPEC = BoardSystemProfile(
+    lg_features=("adrv9371", "zc706"),
+    cfg_builder=_adrv9371_cfg,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_adrv9371_zc706.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    topology_assert=_topology_assert,
+    boot_mode="tftp",
+    kernel_fixture_name="built_kernel_image_zynq",
+    out_label="adrv9371_xsa",
+    dmesg_grep_pattern="ad9371|ad9528|jesd204|mykonos|probe|failed|error",
+    merged_dts_must_contain=('compatible = "adi,ad9371"',),
+    probe_signature_any=("ad9371", "mykonos"),
+    probe_signature_message="AD9371 driver probe signature not found in dmesg",
+    iio_required_any=("9371", "adrv9", "9528"),
+    iio_frontend_label="AD9371 / ADRV9xxx phy device",
+)
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_adrv9371_zc706_xsa_hw(board, tmp_path, request):
+    """End-to-end pyadi-dt ADRV9371+ZC706 via the XSA pipeline."""
+    from test.hw.hw_helpers import (
+        assert_ilas_aligned,
+        assert_jesd_links_data,
+        parse_ilas_status,
+        read_jesd_status,
+        shell_out,
     )
 
-    result = XsaPipeline().run(
-        xsa_path=xsa_path,
-        cfg=cfg,
-        output_dir=out_dir,
-        sdtgen_timeout=300,
-    )
-    merged_dts = result["merged"]
-    assert merged_dts.exists(), f"Merged DTS not written: {merged_dts}"
-
-    merged_content = merged_dts.read_text()
-    assert 'compatible = "adi,ad9371"' in merged_content, (
-        "AD9371 compatible string missing from merged DTS"
+    shell, _ctx, dmesg_txt = run_xsa_boot_and_verify(
+        SPEC, board=board, request=request, tmp_path=tmp_path
     )
 
-    # --- 4. Compile to DTB, stage as devicetree.dtb ---
-    dtb_raw = out_dir / "adrv9371_zc706.dtb"
-    compile_dts_to_dtb(merged_dts, dtb_raw)
-    dtb = stage_dtb_as_devicetree(dtb_raw, out_dir / "tftp_staging_xsa")
-
-    # --- 5. Deploy + boot ---
-    shell = deploy_and_boot(board, dtb, built_kernel_image_zynq)
-
-    # --- 6. Diagnostics + probe verification ---
-    dmesg_txt = collect_dmesg(
-        shell,
-        out_dir,
-        label="adrv9371_xsa",
-        grep_pattern="ad9371|ad9528|jesd204|mykonos|probe|failed|error",
-    )
-    assert_no_kernel_faults(dmesg_txt)
-    assert_no_probe_errors(dmesg_txt)
-    assert "ad9371" in dmesg_txt.lower() or "mykonos" in dmesg_txt.lower(), (
-        "AD9371 driver probe signature not found in dmesg"
-    )
-
-    ctx, _ = open_iio_context(shell)
-    found = {d.name for d in ctx.devices if d.name}
-    assert any("9371" in n or "adrv9" in n.lower() for n in found), (
-        f"No AD9371/ADRV9xxx IIO device found. Devices: {sorted(found)}"
-    )
-    assert any("9528" in n for n in found), (
-        f"No AD9528 clock device found. Devices: {sorted(found)}"
-    )
-
-    # --- 7. Gather JESD link + ILAS + DMA-path diagnostics. ---
-    # The JESD-DATA assert is intentionally *disabled* here: the
-    # bq run after the 122.88 MHz misc_clk fix (commit 99ad39c)
-    # showed clocks match (Measured 122.882 / Reported 122.880 MHz)
-    # but the AD9371 deframer reports ILAS mismatch on all 7
-    # framing parameters (lanes/converter, scrambling, octets/frame,
-    # frames/multiframe, converters, sample-resolution, control-
-    # bits), so the link stays "disabled" — a framing-parameter fix
-    # the profile-and-cfg combination needs, not a link-clock fix.
-    # Keep printing the full status for future iterations.
     rx_status, tx_status = read_jesd_status(shell)
     print("=== JESD204 RX status (sysfs) ===")
     print(rx_status)
     print("=== JESD204 TX status (sysfs) ===")
     print(tx_status)
 
-    # Surface AD937x ILAS state + assert it's clean.  The builder
-    # now emits the full Kuiper-matching topology (xcvrs → AD9528,
-    # phy → JESD cores, RX_OS overlay present), so every ILAS field
-    # should match and all three JESD links should reach
-    # "Link is enabled".
     ilas_report = parse_ilas_status(dmesg_txt)
     print("=== AD937x ILAS report ===")
     print(ilas_report.summary())
@@ -189,9 +120,7 @@ def test_adrv9371_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
     assert_ilas_aligned(dmesg_txt, context="adrv9371_xsa")
     assert_jesd_links_data(shell, context="adrv9371_xsa")
 
-    # HDL compile-time framing — read the TPL ADC/DAC/OBS descriptor
-    # registers per
-    # https://analogdevicesinc.github.io/hdl/library/jesd204/ad_ip_jesd204_tpl_{adc,dac}/
+    # HDL compile-time framing — TPL descriptor registers.
     # Descriptor 1 @ +0x240: [31:24]=F, [23:16]=S, [15:8]=L, [7:0]=M
     # Descriptor 2 @ +0x244: [15:8]=Np, [7:0]=N
     print("=== HDL compile-time JESD framing (TPL descriptor regs) ===")
@@ -202,10 +131,6 @@ def test_adrv9371_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
             "which devmem devmem2 busybox 2>/dev/null; busybox | head -1 2>/dev/null",
         )
     )
-    # Two descriptor words per TPL core: +0x240 and +0x244.
-    # Decoded layout (per ADI HDL docs):
-    #   d1[31:24]=F d1[23:16]=S d1[15:8]=L d1[7:0]=M
-    #   d2[15:8]=Np d2[7:0]=N
     print(
         shell_out(
             shell,
@@ -219,11 +144,6 @@ def test_adrv9371_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
         )
     )
 
-    # Dump TPL ADC sysfs (enable state, sampling freq, etc.) and DMA
-    # controller state.  These surface the most common DMA-stall
-    # causes: ADC channels not scan-enabled, TPL rate register at 0,
-    # axi-dmac refusing to arm a descriptor, or the buffer sysfs
-    # knob left disabled.
     print("=== TPL ADC sysfs (/sys/bus/iio/devices/<ad_ip_jesd204_tpl_adc>/) ===")
     print(
         shell_out(
@@ -282,75 +202,6 @@ def test_adrv9371_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
             ),
         )
     )
-    # TODO(adrv9371-capture): data-path smoke test still deferred.
-    #
-    # Progress across this series (all landed on this branch):
-    #
-    # - AD9528 channel@{1,3,12,13} subnodes + reset-gpios=<113>
-    #   + jesd204-device / #jesd204-cells=2 /
-    #   jesd204-sysref-provider flags.
-    # - AD9371 reset-gpios=<106>, sysref-req-gpios=<112>.
-    # - ~60 Mykonos ``adi,{rx,obs,tx,sniffer}-profile-*`` +
-    #   ``adi,clocks-*`` baked into ad9371-phy@1.
-    # - AD9528 added as jesd204-inputs link 2 on the AD9371.
-    # - ``adi,{sys,out}-clk-select`` + ``adi,use-lpm-enable`` on
-    #   the adxcvr (commit bad15c2) — unblocked axi-jesd204-rx/tx
-    #   platform driver probe.
-    # - ``misc_clk_0`` rate 245.76 → 122.88 MHz (commit 99ad39c)
-    #   to match the real FMC clock that physically lands on the
-    #   clkgen's clkin1.
-    #
-    # Now-observable state on bq (from the ``=== JESD204 ... ===``
-    # dump above):
-    #
-    # - Measured Link Clock = Reported = 122.882 MHz → clock-layer
-    #   healthy.
-    # - JESD FSM reaches ``opt_post_running_stage`` on all 3 links
-    #   (RX, TX, AD9528 sysref), no rollback.
-    # - AD9371 firmware initialised ("AD9371 Rev 3, Firmware 5.2.2
-    #   API version: 1.5.2.3566 successfully initialized via
-    #   jesd204-fsm").
-    # - TPL ADC + DAC both probe as MASTER.
-    #
-    # Still-open blocker — ILAS framing parameter mismatch:
-    #
-    #     ad9371 spi1.1: deframerStatus (0x21)
-    #     ad9371 spi1.1: ILAS mismatch: c7f8
-    #     ILAS lanes per converter did not match
-    #     ILAS scrambling did not match
-    #     ILAS octets per frame did not match
-    #     ILAS frames per multiframe did not match
-    #     ILAS number of converters did not match
-    #     ILAS sample resolution did not match
-    #     ILAS control bits per sample did not match
-    #
-    # After the link trains, every ILAS parameter disagrees between
-    # what ``axi-jesd204-tx`` sends and what the AD9371's Mykonos
-    # deframer expects (based on its profile).  The link drops to
-    # ``Link is disabled`` and the TPL DMA has nothing to collect.
-    #
-    # The HDL reference (``analogdevicesinc/hdl/projects/adrv9371x/
-    # zc706/README``) documents the default framing as::
-    #
-    #     TX_JESD_M=4, TX_JESD_L=4, TX_JESD_S=1   (→ F=2 for Np=16)
-    #     RX_JESD_M=4, RX_JESD_L=2, RX_JESD_S=1   (→ F=4)
-    #
-    # Our ``axi-jesd204-tx`` overlay already emits F=2 (from the
-    # ``tx_octets_per_frame`` default), M=4, Np=16, CS=2 — matching
-    # HDL — and ``axi-jesd204-rx`` emits F=4.  All 7 ILAS params
-    # still disagree, so the Mykonos profile we baked in
-    # (``_DEFAULT_MYKONOS_PROFILE_PROPS``) must be for a different
-    # HDL build than the default one the XSA represents.
-    #
-    # Next step: pair the profile to the HDL.  Either
-    # (a) regenerate ``_DEFAULT_MYKONOS_PROFILE_PROPS`` from an
-    # iio-oscilloscope profile whose implied JESD framing matches
-    # (M=4, L=4, F=2, K=32, Np=16) for TX and (M=4, L=2, F=4, K=32,
-    # Np=16) for RX — typically the 100 MHz-BW profile at a
-    # specific IQ rate the HDL compiles in, or
-    # (b) override ``trx_profile_props`` in the profile JSON for
-    # this board to a per-profile list that matches the
-    # build-time HDL settings.
 
 
 # ---------------------------------------------------------------------------
@@ -361,6 +212,6 @@ def test_adrv9371_zc706_xsa_hw(board, built_kernel_image_zynq, tmp_path):
 # topology-aware XCVR / TPL-core / clkgen overlays that the ZC706 + AD9371
 # design needs to bind; ``apply_xsa_topology`` only overrides the JESD204
 # framing labels, leaving default ``axi_adrv9009_*`` xcvr/core labels that
-# do not exist in the ZC706 base DTS. A structural smoke test lives at
+# do not exist in the ZC706 base DTS.  A structural smoke test lives at
 # ``test/devices/test_system_adrv937x_zc706.py``; the end-to-end hardware
 # path is covered by :func:`test_adrv9371_zc706_xsa_hw` above.

--- a/test/hw/xsa/README.md
+++ b/test/hw/xsa/README.md
@@ -1,0 +1,170 @@
+# Adding a new overlay test
+
+You have a board + carrier combination running JESD204 + IIO + a Linux kernel with `CONFIG_OF_OVERLAY`, and you want to validate the runtime device-tree overlay lifecycle on it. This guide walks through writing a `test_<board>_<carrier>_overlay.py` that plugs into the existing 6-test suite (unit, configfs, load, dma, unload, reload).
+
+## Prerequisites
+
+- A labgrid place exposing the board with serial console, power control, and (for SoC boots) SD or TFTP staging. The place's `features:` list must include the `lg_features` tuple you'll declare in the SPEC.
+- An XSA from the HDL build, either committed under `test/hw/xsa/` or downloadable from a Kuiper boot-partition release.
+- A profile JSON in `adidt/xsa/profiles/<profile>.json` if the board's SPI / clock / JESD topology is not already supported by an existing builder.
+- A working `LG_COORDINATOR` (or `LG_ENV`) — see `.env.example`.
+
+## Steps
+
+### 1. Create the test file
+
+Create `test/hw/xsa/test_<board>_<carrier>_overlay.py` with this shape (replace every `<placeholder>`):
+
+```python
+from __future__ import annotations
+from typing import Any
+import pytest
+
+from test.hw.hw_helpers import check_jesd_framing_plausibility
+from test.hw.xsa._overlay_base import (
+    booted_board, overlay_dtbo, pipeline_result,
+    test_overlay_generation_unit,
+    test_configfs_overlay_support,
+    test_load_overlay,
+    test_dma_loopback,
+    test_unload_overlay,
+    test_reload_overlay,
+)
+from test.hw.xsa._overlay_spec import BoardOverlayProfile, acquire_or_local_xsa
+
+
+def _board_cfg() -> dict[str, Any]:
+    cfg = {
+        "<builder>_board": {...},
+        "jesd": {"rx": {...}, "tx": {...}},
+    }
+    framing_warnings = check_jesd_framing_plausibility(cfg["jesd"])
+    assert not framing_warnings, "JESD cfg inconsistent: " + "\n  ".join(framing_warnings)
+    return cfg
+
+
+SPEC = BoardOverlayProfile(
+    overlay_name="<board>_<carrier>_xsa",
+    lg_features=("<board>", "<carrier>"),
+    skip_reason_label="<board> <carrier>",
+    cfg_builder=_board_cfg,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_<board>_<carrier>.xsa",
+        "<kuiper_release>",
+        "<kuiper_project_dir>",
+    ),
+    sdtgen_profile="<profile>",
+    boot_mode="tftp",                            # see step 2
+    kernel_fixture_name="built_kernel_image_zynq",
+    iio_required_all=("<chip>",),
+    iio_required_any=("<chip>-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+    iio_frontend_label="<chip> RX frontend",
+    fft_mode="optional",                         # see step 3
+)
+
+
+@pytest.fixture(scope="module")
+def overlay_spec() -> BoardOverlayProfile:
+    return SPEC
+```
+
+Keep the `test_*` import block in the canonical sequence (`unit, configfs, load, dma, unload, reload`). Pytest collects tests in import order, and `test_dma_loopback` skips when the overlay isn't loaded — so it must follow `test_load_overlay`.
+
+### 2. Pick a boot mode
+
+| `boot_mode` | Use when | Required |
+|---|---|---|
+| `"tftp"` | Zynq-7000 boards using `BootFPGASoCTFTP` (DTB renamed to `devicetree.dtb`) | `kernel_fixture_name="built_kernel_image_zynq"` |
+| `"sd"` | ZynqMP boards using `BootFPGASoC` + Kuiper SD card (DTB renamed to `system.dtb`) | `kernel_fixture_name="built_kernel_image_zynqmp"` |
+| `"fabric_jtag"` | MicroBlaze / soft-CPU boards using `BootFabric` + JTAG simpleImage (no DTB rebuild) | `kernel_fixture_name=None` |
+
+`fabric_jtag` skips lifecycle tests cleanly when the kernel lacks `CONFIG_OF_OVERLAY`. `test_configfs_overlay_support` always asserts strictly regardless of mode.
+
+### 3. Pick an FFT mode
+
+| `fft_mode` | Use when |
+|---|---|
+| `"required"` | Reference HDL has internal DAC→ADC loopback (e.g. AD9081 TPL cores). Asserts SNR > 10 dB. |
+| `"optional"` | No internal loopback. Logs and passes on low SNR; passes outright on a coherent peak. |
+| `"skip"` | Skip phase 2 entirely. Phase 1 (`assert_rx_capture_valid`) still runs. |
+
+Phase 1 (mandatory bare RX capture) always runs and always asserts.
+
+### 4. Add hooks if the board needs them
+
+Wire pluggable callables into the SPEC for board-specific behavior:
+
+| Field | Use when | Live example |
+|---|---|---|
+| `pre_capture_hook` | Board needs setup before RX capture (push a Talise profile, wake the radio) | `push_talise_profile` in `_overlay_hooks.py` |
+| `capture_targets_resolver` | Multiple IIO devices share a name; disambiguate by reg address or scan order | `resolve_adrv9009_rx_tpl` in `_overlay_hooks.py` |
+| `dmesg_filter` | Strip benign kernel noise before `assert_no_probe_errors` | `_filter_si570_probe_noise` in `test_adrv9009_zc706_overlay.py` |
+| `pyadi_factory` | pyadi-iio's default `adi.<chip>(uri=...)` doesn't work because IIO names differ | `_create_ad9081` in `test_ad9081_zcu102_overlay.py` |
+| `fft_failure_diagnostics` | Need on-target debug prints when capture fails (GPIO / IRQ / register state) | `_dmac_irq_failure_probe` in `test_adrv9371_zc706_overlay.py` |
+
+If a hook is reusable across boards in the same family, move it to `_overlay_hooks.py`. If it's truly one-off, keep it inline in the board file.
+
+### 5. Verify
+
+Run the unit-only test (no hardware required):
+
+```sh
+uv run pytest test/hw/xsa/test_<board>_<carrier>_overlay.py::test_overlay_generation_unit -v
+```
+
+This exercises the XSA → pipeline → DTSO → DTBO chain. If the XSA isn't on disk and Kuiper download fails, the test skips with a clear message.
+
+Run the full suite against the lab:
+
+```sh
+LG_COORDINATOR=10.0.0.41:20408 \
+LG_ENV=test/hw/env/<place>.yaml \
+uv run pytest test/hw/xsa/test_<board>_<carrier>_overlay.py -v -s
+```
+
+Acquire the place first if it isn't already yours:
+
+```sh
+LG_COORDINATOR=10.0.0.41:20408 uv run labgrid-client -p <place> acquire
+```
+
+A clean run reports `6 passed`. Two partial-pass shapes are expected and documented:
+
+- `1 fail / 5 skip` — `test_configfs_overlay_support` failed because the kernel lacks `CONFIG_OF_OVERLAY`. Lifecycle tests skipped through `booted_board`'s configfs gate.
+- `1 skip / 5 pass` — `test_overlay_generation_unit` skipped because no XSA is on disk and no Kuiper download path exists for this board.
+
+## Worked example: AD9081 + ZCU102
+
+`test/hw/xsa/test_ad9081_zcu102_overlay.py` is the densest example. It exercises every variation point: a pyadi-jif `cfg_builder`, an `acquire_or_local_xsa` resolver with a fallback name, `boot_mode="sd"`, `fft_mode="required"`, and a `pyadi_factory` that aliases sdtgen IIO names to pyadi-iio's hardcoded production names. Read it when you need to see how a less-common field is wired.
+
+## `BoardOverlayProfile` field reference
+
+| Field | Default | Purpose |
+|---|---|---|
+| `overlay_name` | — | configfs node name (`/sys/.../overlays/<name>`). |
+| `lg_features` | — | labgrid place feature tuple, applied to every test by `xsa/conftest.py`. |
+| `skip_reason_label` | — | Human-readable name in skip and log messages. |
+| `cfg_builder` | — | Zero-arg callable returning the cfg dict for `XsaPipeline.run`. |
+| `xsa_resolver` | — | `(tmp_path) -> Path` to the XSA file. Skips on failure. |
+| `sdtgen_profile` | — | Pipeline profile name. |
+| `boot_mode` | — | `"tftp"`, `"sd"`, or `"fabric_jtag"`. |
+| `topology_assert` | no-op | `(XsaTopology) -> None`; raises or skips on unexpected topology. |
+| `sdtgen_timeout` | 300 | Pipeline `sdtgen` timeout in seconds. |
+| `dtso_must_contain_all` | `()` | Substrings the unit test asserts are all present in the DTSO. |
+| `dtso_must_contain_any` | `()` | Substrings the unit test asserts at least one is present. |
+| `kernel_fixture_name` | `None` | Name of a kernel-image fixture. `None` for `fabric_jtag`. |
+| `settle_after_apply_s` | 5.0 | Seconds to sleep after overlay apply. Bump to 8.0 for Mykonos / Talise re-init. |
+| `iio_required_all` | `()` | IIO device names that must all be present after overlay apply. |
+| `iio_required_any` | `()` | IIO device names of which at least one must be present. |
+| `iio_frontend_label` | `"RX frontend"` | Used in failure messages when `iio_required_any` mismatches. |
+| `dmesg_filter` | identity | `(text) -> text` to strip benign noise before probe-error assertion. |
+| `fft_mode` | `"skip"` | `"required"`, `"optional"`, or `"skip"`. |
+| `pre_capture_hook` | `None` | `(shell, tmp_path) -> bool`. `True` re-asserts JESD DATA after. |
+| `capture_targets_resolver` | `None` | `(iio.Context) -> Sequence[str]` to disambiguate IIO targets. |
+| `capture_target_names` | `()` | Fallback target names when `capture_targets_resolver` is unset. |
+| `pyadi_class_name` | `None` | Class name in `adi.*` for the FFT phase (e.g. `"ad9081"`). |
+| `pyadi_factory` | `None` | `(uri) -> dev` overriding the default `adi.<class>(uri=uri)`. |
+| `dds_tone_hz` | 1_000_000 | DDS tone frequency for the FFT phase. |
+| `dds_scale` | 0.5 | DDS tone amplitude (0..1). |
+| `rx_buffer_size` | 16384 | Capture buffer depth for the FFT phase. |
+| `fft_failure_diagnostics` | `None` | `(shell) -> None` invoked when phase 1 capture fails. |


### PR DESCRIPTION
Two related follow-ups to #61.

## 1. `docs(test/hw/xsa)`: how-to guide for adding new overlay tests

`test/hw/xsa/README.md` walks a contributor through declaring a `BoardOverlayProfile`, picking a boot mode and FFT mode, wiring per-board hooks, and verifying locally and on the lab.  Reference table covers every SPEC field with default and purpose.  170 lines.

## 2. `refactor(test/hw)`: extract merged-DTB test boilerplate into `BoardSystemProfile`

Same pattern as #61 applied to the merged-DTB tests at `test/hw/test_*_hw.py`.

Each board test legitimately keeps its diagnostic tail (Talise profile sweep on ADRV9009 ZCU102, GIC + TPL sysfs probes on ADRV9371) — those are one-off forensics, not boilerplate.  Everything else (XSA → pipeline → DTB → boot → dmesg → IIO → JESD DATA → RX capture) moves into `_system_base.py`.

| File | Before | After | Δ |
|---|---:|---:|---:|
| `test_ad9081_zcu102_xsa_hw.py` | 223 | 127 | −96 |
| `test_ad9081_zcu102_system_hw.py` | 305 | 240 | −65 |
| `test_adrv9009_zc706_hw.py` | 188 | 127 | −61 |
| `test_adrv9009_zcu102_hw.py` | 296 | 215 | −81 |
| `test_adrv9371_zc706_hw.py` | 366 | 217 | −149 |
| `test_fmcdaq3_vcu118_hw.py` | 99 | 99 | 0 (doesn't fit pattern) |

- New shared infrastructure: `test/hw/_system_base.py` (324 LOC) with `BoardSystemProfile` dataclass, `requires_lg`, `run_xsa_boot_and_verify`, `boot_and_verify_from_merged_dts`, `run_xsa_pipeline`.
- Reuses `acquire_or_local_xsa` / `local_xsa_or_skip` factories from `test/hw/xsa/_overlay_spec.py` (the same XSA paths get searched).
- The System API test (`test_ad9081_zcu102_system_hw.py`) keeps its `adidt.System` composition body inline — that's the one render path that doesn't go through `XsaPipeline`.  Steps 6–9 (compile + boot + verify) call `boot_and_verify_from_merged_dts` directly with the merged DTS path the System composition produced.

**Net: −128 LOC** across the 6 merged-DTB files (1477 → 1025 + 324 = 1349).  Adding a new merged-DTB test now costs ~50–80 LOC for the minimal case.

## Test plan

Static / no-hardware (already done locally):
- [x] `pytest --collect-only test/hw/ -o addopts=` collects all 6 merged-DTB tests under their canonical names (the addopts override drops `--ignore-glob=*_hw.py`, the standard way hardware tests get run)
- [x] `pytest --collect-only test/hw/xsa/` still collects the same 24 overlay tests as before
- [x] `pytest --collect-only test/hw/_system_base.py` reports 0 tests (helpers, not `test_*` functions)
- [x] `python3 -c "import test.hw._system_base"` succeeds (import-time correctness)

Hardware validation (still required before merge):
- [ ] `LG_COORDINATOR=10.0.0.41:20408 LG_ENV=test/hw/env/mini2.yaml uv run pytest test/hw/test_ad9081_zcu102_xsa_hw.py test/hw/test_ad9081_zcu102_system_hw.py -v -s` on `mini2`
- [ ] `LG_COORDINATOR=10.0.0.41:20408 LG_ENV=test/hw/env/bq.yaml uv run pytest test/hw/test_adrv9371_zc706_hw.py -v -s` on `bq`
- [ ] `LG_COORDINATOR=10.0.0.41:20408 LG_ENV=test/hw/env/nemo.yaml uv run pytest test/hw/test_adrv9009_zc706_hw.py -v -s` on `nemo`
- [ ] `LG_COORDINATOR=10.0.0.41:20408 LG_ENV=test/hw/env/<adrv9009_zcu102_place>.yaml uv run pytest test/hw/test_adrv9009_zcu102_hw.py -v -s` (place TBD — the YAML for this board may need to be added or `mini2` reconfigured)