### PR TITLE
fix(adidt/xsa/node_builder): skip clkgens unreferenced by JESD chain

### DIFF
--- a/adidt/xsa/node_builder.py
+++ b/adidt/xsa/node_builder.py
@@ -113,7 +113,21 @@ class NodeBuilder:
         rx_labels: list[str] = []
         tx_labels: list[str] = []
 
+        # Only render clkgens that some JESD instance in the topology actually
+        # references as its link clock.  ZC706 reference designs ship an
+        # ``axi_hdmi_clkgen`` for the HDMI output that has nothing to do with
+        # the converter chain; the base DTS already declares it via #include
+        # and re-rendering it here makes the merger emit a noisy
+        # ``Replaced included node with duplicate label`` warning.
+        used_clkgen_names: set[str] = set()
+        for jesd_inst in (*topology.jesd204_rx, *topology.jesd204_tx):
+            clkgen = clock_map.get(jesd_inst.link_clk)
+            if clkgen is not None:
+                used_clkgen_names.add(clkgen.name)
+
         for clkgen in topology.clkgens:
+            if clkgen.name not in used_clkgen_names:
+                continue
             if self._is_adrv90xx_name(clkgen.name) and any(
                 isinstance(b, ADRV9009Builder) for b in matched_builders
             ):

--- a/test/xsa/test_node_builder.py
+++ b/test/xsa/test_node_builder.py
@@ -1307,3 +1307,29 @@ def test_build_adrv9009_fmcomms8_uses_hmc7044_and_tpl_core_labels(cfg):
         "clocks = <&hmc7044_fmc 2>, <&hmc7044_fmc 5>, <&hmc7044_fmc 3>, <&hmc7044_fmc 7>;"
         in merged
     )  # trx1: dev=ch2, fmc=ch5, sysref_dev=ch3, sysref_fmc=ch7
+
+
+def test_build_skips_clkgens_unreferenced_by_jesd_chain(topo, cfg):
+    """Clkgens that no JESD instance references must not get rendered.
+
+    ZC706 reference designs ship an ``axi_hdmi_clkgen`` for the HDMI
+    output that has nothing to do with the converter chain.  The base
+    DTS already declares it via ``#include``, so re-rendering it from
+    the topology would make the merger emit a noisy
+    ``Replaced included node with duplicate label`` warning at apply
+    time.  Filter at the source instead.
+    """
+    topo.clkgens.append(
+        ClkgenInstance(
+            name="axi_hdmi_clkgen",
+            base_addr=0x79000000,
+            output_clks=["axi_hdmi_clkgen_0", "axi_hdmi_clkgen_1"],
+        )
+    )
+    nodes = NodeBuilder().build(topo, cfg)
+    rendered = "\n".join(nodes["clkgens"])
+    assert "axi_hdmi_clkgen" not in rendered, (
+        "axi_hdmi_clkgen is unreferenced by any JESD instance and must be skipped"
+    )
+    # The chain clkgen the JESD instances DO reference still renders.
+    assert "axi_clkgen_0" in rendered


### PR DESCRIPTION
## Summary

`NodeBuilder` rendered every clkgen in the XSA topology, including unrelated ones like `axi_hdmi_clkgen` on ZC706 reference HDL.  The base DTS already declared those via `#include`, so the merger compensated by inserting `/delete-node/ &<label>;` and emitting

```
WARNING adidt.xsa.merge: Replaced included node with duplicate label 'axi_hdmi_clkgen'
```

on every ADRV9009 / ADRV9371 ZC706 run.  Functionally harmless — final DTB identical — but loud and misleading (suggests a real conflict where there isn't one).

Filter at the source: render a clkgen only if some JESD instance in the topology references it as its link clock.  The two existing by-name skips for ADRV9009 / ADRV937x chain clkgens (where a board-specific builder takes over) stay as-is.

Discovered during the hardware validation runs for #62.

## Test plan

- [x] `pytest test/xsa/` — 384 passed, 1 skipped (no regressions)
- [x] New regression test `test_build_skips_clkgens_unreferenced_by_jesd_chain` covers the filter
- [x] **bq (ADRV9371 ZC706)**: 1 passed in 1m25s, zero "Replaced included node" warnings (down from one per run before)
- [ ] **nemo (ADRV9009 ZC706)** — recommended additional validation since the warning fired here too historically