### PR TITLE
refactor(adidt/xsa): share ZynqMP dedup helper between merger + hw harness

### DIFF
--- a/adidt/xsa/dts_normalize.py
+++ b/adidt/xsa/dts_normalize.py
@@ -1,0 +1,93 @@
+"""DTS post-processing helpers shared between the merger and test harness.
+
+These functions operate on a preprocessed DTS file on disk and rewrite
+it in place to work around known sdtgen output quirks.  Both the
+merger's optional ``dtc`` smoke test and the hardware test harness's
+``compile_dts_to_dtb`` need the same fix-ups, so they live here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ROOT_BLOCK_OPEN_RE = re.compile(r"^/ \{", re.M)
+
+
+def dedup_zynqmp_root_nodes(pp_dts: Path) -> None:
+    """Rewrite *pp_dts* to remove the duplicate sdtgen ZynqMP root block.
+
+    sdtgen for ZynqMP generates ``system-top.dts`` that ``#include``s
+    ``zynqmp.dtsi``, ``zynqmp-clk-ccf.dtsi``, and ``pl.dtsi``.  After
+    ``cpp`` preprocessing, the file has 4 ``/ { ... };`` blocks:
+
+    * Block 0: ``zynqmp.dtsi`` (canonical A53 CPU, peripherals, clocks)
+    * Block 1: ``zynqmp-clk-ccf.dtsi`` (PS reference clock)
+    * Block 2: ``pl.dtsi`` (FPGA PL bus with all AXI IPs)
+    * Block 3: ``system-top.dts`` (sdtgen re-declaration of cpus,
+      amba_pl, etc.)
+
+    Block 3 duplicates everything already defined in Blocks 0-2 and
+    causes ``dtc`` ``duplicate_node_names`` errors.  Remove it
+    entirely — the content after Block 3 (overlay ``&label { ... }``
+    references appended by the merger) is preserved.
+
+    The ``chosen`` and ``aliases`` sub-nodes from Block 3 are required
+    for console output and device aliasing, so they're spliced into a
+    new minimal root block before the trailing overlay references.
+
+    Also renames the MicroBlaze PMU CPU node label collision
+    (``cpus_microblaze_0: cpus`` clashes with ``cpus_a53: cpus`` from
+    ``zynqmp.dtsi``).  The MicroBlaze PMU CPU node only carries
+    address-map metadata so the rename is a no-op for the running OS.
+
+    No-op when the file does not match the ZynqMP sdtgen pattern (fewer
+    than 4 root blocks).
+    """
+    text = pp_dts.read_text()
+
+    root_blocks: list[tuple[int, int]] = []
+    for m in _ROOT_BLOCK_OPEN_RE.finditer(text):
+        start = m.start()
+        depth = 0
+        for i in range(m.end() - 1, len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    if end < len(text) and text[end] == ";":
+                        end += 1
+                    if end < len(text) and text[end] == "\n":
+                        end += 1
+                    root_blocks.append((start, end))
+                    break
+
+    if len(root_blocks) >= 4:
+        last_start, last_end = root_blocks[-1]
+        last_block = text[last_start:last_end]
+
+        preserved: list[str] = []
+        for node_name in ("chosen", "aliases"):
+            node_re = re.compile(
+                rf"^ {node_name}\b[^\{{]*\{{.*?^ \}};",
+                re.M | re.S,
+            )
+            m = node_re.search(last_block)
+            if m:
+                preserved.append(m.group())
+
+        text = text[:last_start] + text[last_end:]
+
+        if preserved:
+            preserved_block = "/ {\n" + "\n".join(preserved) + "\n};\n"
+            text = text.rstrip() + "\n\n" + preserved_block + "\n"
+
+    text = text.replace(
+        "cpus_microblaze_0: cpus {",
+        "cpus_microblaze_0: cpus-pmu {",
+    )
+
+    pp_dts.write_text(text)

--- a/adidt/xsa/merger.py
+++ b/adidt/xsa/merger.py
@@ -7,6 +7,8 @@ import subprocess
 import warnings
 from pathlib import Path
 
+from .dts_normalize import dedup_zynqmp_root_nodes
+
 _LABEL_RE = re.compile(r"^\s*([a-zA-Z_]\w*)\s*:\s*\w", re.MULTILINE)
 _NODE_ADDR_RE = re.compile(r"@([0-9a-fA-F]+)\s*\{")
 _NODE_LABEL_IN_SNIPPET_RE = re.compile(r"^\s*([a-zA-Z_]\w*)\s*:")
@@ -632,6 +634,11 @@ class DtsMerger:
                 if cpp_result.returncode != 0:
                     _log.warning("cpp preprocessing failed: %s", cpp_result.stderr)
                     return
+                # Normalize sdtgen-emitted ZynqMP root-block duplicates so the
+                # smoke test catches real merge bugs instead of the known
+                # sdtgen quirk that the downstream ``compile_dts_to_dtb``
+                # already handles.
+                dedup_zynqmp_root_nodes(preprocessed)
                 compile_input = preprocessed
             result = subprocess.run(
                 [

--- a/test/hw/hw_helpers.py
+++ b/test/hw/hw_helpers.py
@@ -12,86 +12,9 @@ import pytest
 
 import re as _re
 
+from adidt.xsa.dts_normalize import dedup_zynqmp_root_nodes
+
 HERE = Path(__file__).parent
-
-
-def _dedup_root_nodes(pp_dts: Path) -> None:
-    """Remove the duplicate sdtgen root block from a preprocessed ZynqMP DTS.
-
-    sdtgen for ZynqMP generates ``system-top.dts`` that ``#include``s
-    ``zynqmp.dtsi``, ``zynqmp-clk-ccf.dtsi``, and ``pl.dtsi``.  After
-    ``cpp`` preprocessing, the file has 4 ``/ { ... };`` blocks:
-
-    - Block 0: ``zynqmp.dtsi`` (canonical A53 CPU, peripherals, clocks)
-    - Block 1: ``zynqmp-clk-ccf.dtsi`` (PS reference clock)
-    - Block 2: ``pl.dtsi`` (FPGA PL bus with all AXI IPs)
-    - Block 3: ``system-top.dts`` (sdtgen re-declaration of cpus, amba_pl, etc.)
-
-    Block 3 duplicates everything already defined in Blocks 0-2 and causes
-    ``dtc`` ``duplicate_node_names`` errors.  Remove it entirely — the
-    content after Block 3 (overlay ``&label { ... }`` references from the
-    merger) is preserved.
-    """
-    import re
-
-    text = pp_dts.read_text()
-
-    # Find all "/ {" block positions using brace counting
-    root_re = re.compile(r"^/ \{", re.M)
-    root_blocks: list[tuple[int, int]] = []
-    for m in root_re.finditer(text):
-        start = m.start()
-        depth = 0
-        for i in range(m.end() - 1, len(text)):
-            if text[i] == "{":
-                depth += 1
-            elif text[i] == "}":
-                depth -= 1
-                if depth == 0:
-                    end = i + 1
-                    if end < len(text) and text[end] == ";":
-                        end += 1
-                    if end < len(text) and text[end] == "\n":
-                        end += 1
-                    root_blocks.append((start, end))
-                    break
-
-    # Remove the last root block when there are 4+ (the ZynqMP sdtgen pattern).
-    # Block 3 (system-top.dts) re-declares everything from Blocks 0-2.
-    # BUT preserve `chosen` and `aliases` nodes which only exist in Block 3
-    # and are required for console output and device aliasing.
-    if len(root_blocks) >= 4:
-        last_start, last_end = root_blocks[-1]
-        last_block = text[last_start:last_end]
-
-        # Extract chosen and aliases sub-nodes from the removed block
-        preserved: list[str] = []
-        for node_name in ("chosen", "aliases"):
-            node_re = re.compile(
-                rf"^ {node_name}\b[^\{{]*\{{.*?^ \}};",
-                re.M | re.S,
-            )
-            m = node_re.search(last_block)
-            if m:
-                preserved.append(m.group())
-
-        text = text[:last_start] + text[last_end:]
-
-        # Re-insert preserved nodes in a new root block
-        if preserved:
-            preserved_block = "/ {\n" + "\n".join(preserved) + "\n};\n"
-            # Insert before any overlay &label references at end of file
-            text = text.rstrip() + "\n\n" + preserved_block + "\n"
-
-    # Rename "cpus_microblaze_0: cpus {" → "cpus_microblaze_0: cpus-pmu {"
-    # to avoid conflict with "cpus_a53: cpus" from zynqmp.dtsi.
-    # The MicroBlaze PMU CPU node is only used for address-map metadata.
-    text = text.replace(
-        "cpus_microblaze_0: cpus {",
-        "cpus_microblaze_0: cpus-pmu {",
-    )
-
-    pp_dts.write_text(text)
 
 
 DEFAULT_OUT_DIR = HERE / "output"
@@ -178,7 +101,7 @@ def compile_dts_to_dtb(dts_path: Path, dtb_path: Path) -> None:
     # Fix duplicate node names from sdtgen (e.g., cpus_a53 and
     # cpus_microblaze_0 both using node name "cpus")
     if compile_input != dts_path:
-        _dedup_root_nodes(compile_input)
+        dedup_zynqmp_root_nodes(compile_input)
 
     res = subprocess.run(
         ["dtc", "-I", "dts", "-O", "dtb", "-o", str(dtb_path), str(compile_input)],

--- a/test/xsa/test_dts_normalize.py
+++ b/test/xsa/test_dts_normalize.py
@@ -1,0 +1,124 @@
+"""Unit tests for adidt.xsa.dts_normalize.dedup_zynqmp_root_nodes."""
+
+from __future__ import annotations
+
+import textwrap
+
+from adidt.xsa.dts_normalize import dedup_zynqmp_root_nodes
+
+
+def _write(tmp_path, body: str):
+    p = tmp_path / "pp.dts"
+    p.write_text(textwrap.dedent(body).lstrip("\n"))
+    return p
+
+
+def test_dedup_zynqmp_root_nodes_drops_fourth_block(tmp_path):
+    """A 4-root-block input loses the last (sdtgen system-top) block."""
+    p = _write(
+        tmp_path,
+        """
+        /dts-v1/;
+        / {
+         block0_marker;
+        };
+        / {
+         block1_marker;
+        };
+        / {
+         block2_marker;
+        };
+        / {
+         block3_marker;
+        };
+        """,
+    )
+    dedup_zynqmp_root_nodes(p)
+    text = p.read_text()
+    assert "block0_marker" in text
+    assert "block1_marker" in text
+    assert "block2_marker" in text
+    assert "block3_marker" not in text
+
+
+def test_dedup_zynqmp_root_nodes_preserves_chosen_and_aliases(tmp_path):
+    """``chosen`` and ``aliases`` from the dropped block re-appear at EOF."""
+    p = _write(
+        tmp_path,
+        """
+        /dts-v1/;
+        / {
+         block0;
+        };
+        / {
+         block1;
+        };
+        / {
+         block2;
+        };
+        / {
+         chosen {
+          stdout-path = "serial0:115200n8";
+         };
+         aliases {
+          serial0 = "/amba/serial@e0001000";
+         };
+         dropped_other;
+        };
+        &amba {
+         post_marker;
+        };
+        """,
+    )
+    dedup_zynqmp_root_nodes(p)
+    text = p.read_text()
+    assert "dropped_other" not in text
+    assert "stdout-path" in text
+    assert 'serial0 = "/amba/serial@e0001000"' in text
+    assert "post_marker" in text  # trailing &label refs preserved
+
+
+def test_dedup_zynqmp_root_nodes_renames_microblaze_pmu_cpus(tmp_path):
+    """The MicroBlaze PMU ``cpus`` label gets renamed to ``cpus-pmu``.
+
+    Avoids the duplicate ``cpus`` node-name conflict with the A53 ``cpus``
+    block that ``zynqmp.dtsi`` includes.
+    """
+    p = _write(
+        tmp_path,
+        """
+        /dts-v1/;
+        / {
+         block0;
+        };
+        cpus_microblaze_0: cpus {
+         pmu_node;
+        };
+        """,
+    )
+    dedup_zynqmp_root_nodes(p)
+    text = p.read_text()
+    assert "cpus_microblaze_0: cpus-pmu {" in text
+    assert "cpus_microblaze_0: cpus {" not in text
+
+
+def test_dedup_zynqmp_root_nodes_no_op_when_fewer_than_four_blocks(tmp_path):
+    """A 3-root-block input is left alone (Zynq-7000 / non-ZynqMP)."""
+    body = textwrap.dedent(
+        """
+        /dts-v1/;
+        / {
+         block0;
+        };
+        / {
+         block1;
+        };
+        / {
+         block2;
+        };
+        """
+    ).lstrip("\n")
+    p = tmp_path / "pp.dts"
+    p.write_text(body)
+    dedup_zynqmp_root_nodes(p)
+    assert p.read_text() == body


### PR DESCRIPTION
## Summary

Both the merger's optional `dtc` smoke test and the hardware test harness's `compile_dts_to_dtb` need the same fix-up for sdtgen's ZynqMP output: it emits 4 root `/ { ... };` blocks (`zynqmp.dtsi`, `zynqmp-clk-ccf.dtsi`, `pl.dtsi`, `system-top.dts`) and the last one re-declares `cpus` from the first.  Bare `dtc` rejects this with `duplicate_node_names: /cpus`.

The hardware harness has carried a private `_dedup_root_nodes` for this since the start; the merger didn't, so

```
WARNING adidt.xsa.merge: dtc compilation failed:
  ad9081_zcu102.pp.dts:93.26-102.4: ERROR (duplicate_node_names): /cpus: Duplicate node name
```

fired on every AD9081 ZCU102 (and any other ZynqMP) run, even though the downstream `compile_dts_to_dtb` produced a valid DTB.

Move the helper into a new `adidt.xsa.dts_normalize` module as `dedup_zynqmp_root_nodes` and call it from both places.  The merger's smoke test becomes meaningful again — it'll catch real merge bugs instead of being silenced by the known sdtgen quirk.

Discovered during the hardware validation runs for #62.

## Files changed

- **`adidt/xsa/dts_normalize.py` (new)** — extracted helper, public API + comprehensive docstring covering the 4-block pattern and the MicroBlaze PMU `cpus` rename.
- **`test/xsa/test_dts_normalize.py` (new)** — 4 unit tests: drop-4th-block, preserve-chosen+aliases, rename-MB-PMU, no-op (fewer-than-4 blocks).
- **`adidt/xsa/merger.py`** — call the helper after `cpp` succeeds, before invoking dtc.
- **`test/hw/hw_helpers.py`** — use the shared helper, drop the local copy.

## Test plan

- [x] `pytest test/xsa/` — 387 passed, 1 skipped (4 new normalize tests, no regressions)
- [x] **mini2 (AD9081 ZCU102)** — pipeline + merger smoke test ran clean both times: zero `dtc compilation failed` warnings (down from one per run before).  Two boot attempts failed downstream for unrelated lab reasons (SD mass-storage partuuid race + serial-port `rfc2217://mini2:None` exporter handshake).  The pipeline path my change touches works; the lab needs to settle before a clean end-to-end run.
- [ ] Recommended: re-run AD9081 XSA + System tests once mini2 is stable to confirm no new warnings and the boot path still works end-to-end.