### PR TITLE
feat(test/hw): petalinux 2023.2 hw test variant for AD9081/ADRV9009/ADRV9371

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,24 @@
 # ADIDT_KERNEL_CACHE=1
 # Override the cache location (default: ~/.cache/adidt/kernel).
 # ADIDT_KERNEL_CACHE_DIR=/tmp/adidt_kernel_cache
+
+# Bypass the pyadi-build dependency by pointing at a pre-built kernel
+# image (e.g. one extracted from a Kuiper sdcard image).  When set,
+# the corresponding fixture returns this path directly without trying
+# to import adibuild or run a build.
+# ADIDT_KERNEL_IMAGE_ZYNQ=/path/to/zynq-common/uImage
+# ADIDT_KERNEL_IMAGE_ZYNQMP=/path/to/zynqmp-common/Image
+
+# -- PetaLinux hw tests ------------------------------------------------------
+# Required for test/hw/test_*_petalinux_hw.py.  The helper sources
+# <PETALINUX_INSTALL>/settings.sh once per session and merges the
+# resulting env into every petalinux-* subprocess (no need to source
+# settings.sh in your shell).
+# PETALINUX_INSTALL=/opt/Xilinx/PetaLinux/2023.2
+
+# Project + sstate cache: skip petalinux-create and
+# `petalinux-config --get-hw-description` when a project for the same
+# XSA already exists.  Set to 0 to force a clean re-create (e.g. after
+# a PetaLinux upgrade).
+# PETALINUX_PROJECT_CACHE=1
+# PETALINUX_PROJECT_CACHE_DIR=/tmp/adidt_petalinux_cache

--- a/adidt/xsa/pipeline.py
+++ b/adidt/xsa/pipeline.py
@@ -215,6 +215,74 @@ class XsaPipeline:
 
         return result
 
+    def run_petalinux_only(
+        self,
+        xsa_path: Path,
+        cfg: PipelineConfig | dict[str, Any],
+        output_dir: Path,
+        profile: str | None = None,
+    ) -> dict[str, Path]:
+        """Generate ``system-user.dtsi`` + ``device-tree.bbappend`` without sdtgen.
+
+        Use when PetaLinux's own DTG (invoked by ``petalinux-config
+        --get-hw-description``) provides the base device tree — pyadi-dt's
+        sdtgen call is then redundant and forces a Vitis dependency that
+        callers in PetaLinux-only environments don't have.
+
+        Produces the same ``system-user.dtsi`` and ``device-tree.bbappend``
+        as :meth:`run` with ``output_format="petalinux"``, but skips
+        sdtgen, the merged DTS, the HTML report, and the clock graphs.
+
+        The overlay's bus reference (``&amba`` vs ``&amba_pl``) is determined
+        the same way: a stub base DTS declares ``amba``; the
+        :class:`PetalinuxFormatter` rewrites to ``amba_pl`` for ZynqMP
+        platforms based on ``topology.inferred_platform()``.
+
+        Returns:
+            Dict with ``"system_user_dtsi"`` and ``"bbappend"`` keys.
+        """
+        from .petalinux import PetalinuxFormatter
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        topology = XsaParser().parse(xsa_path)
+        inferred_name = self._derive_name(topology)
+        name = profile or inferred_name
+
+        cfg_merged = cfg
+        selected_profile = profile or self._auto_profile_name(topology)
+        if selected_profile:
+            profile_data = ProfileManager().load(selected_profile)
+            cfg_merged = merge_profile_defaults(cfg, profile_data)
+            cfg_merged = self._apply_profile_jesd_defaults(
+                cfg, cfg_merged, selected_profile
+            )
+
+        # Stub base DTS: only used by DtsMerger._build_overlay to detect
+        # the bus label.  Both Zynq-7000 and ZynqMP sdtgen output use
+        # ``amba`` as the PL bus label — PetaLinux's DTG matches this on
+        # Zynq-7000 and produces ``amba_pl`` on ZynqMP.  PetalinuxFormatter
+        # handles the ZynqMP rewrite based on inferred platform.
+        stub_base_dts = "/dts-v1/;\n/ {\n\tamba: amba {\n\t};\n};\n"
+
+        nodes = NodeBuilder().build(topology, cfg_merged)
+        overlay_content = DtsMerger()._build_overlay(stub_base_dts, nodes, name)
+
+        formatter = PetalinuxFormatter()
+        plat = topology.inferred_platform()
+        dtsi = formatter.format_system_user_dtsi(overlay_content, platform=plat)
+        dtsi_path = output_dir / "system-user.dtsi"
+        dtsi_path.write_text(dtsi)
+
+        bbappend = formatter.generate_bbappend()
+        bbappend_path = output_dir / "device-tree.bbappend"
+        bbappend_path.write_text(bbappend)
+
+        return {
+            "system_user_dtsi": dtsi_path,
+            "bbappend": bbappend_path,
+        }
+
     def _derive_name(self, topology: XsaTopology) -> str:
         """Return a ``"<converter_family>_<platform>"`` name string inferred from the topology.
 

--- a/doc/source/petalinux.rst
+++ b/doc/source/petalinux.rst
@@ -5,6 +5,10 @@ pyadi-dt generates PetaLinux-ready ``system-user.dtsi`` files from
 Vivado XSA archives, eliminating the need to hand-write ADI device tree
 nodes for clock chips, JESD204 links, and high-speed converters.
 
+The flow is regularly exercised against PetaLinux **2023.2** on the
+ADI hardware lab (see `Hardware tests`_).  Earlier 2020.1+ releases work
+with the same code path but are not continuously verified.
+
 .. contents:: Contents
    :local:
    :depth: 2
@@ -120,6 +124,13 @@ Step 2: Import the hardware description
 
 This imports the XSA and generates the base device tree via DTG.
 
+.. note::
+
+   ``--get-hw-description`` takes a *directory* containing the
+   ``.xsa`` file, not the ``.xsa`` path itself.  PetaLinux scans the
+   directory and picks the first ``.xsa`` alphabetically, so isolate
+   the XSA in its own directory if other ``.xsa`` files live alongside.
+
 Step 3: Generate system-user.dtsi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -184,7 +195,8 @@ Step 5: Build the device tree
    petalinux-build -c device-tree
 
 This compiles the base DTS with your ``system-user.dtsi`` overlay into
-a DTB.  It is much faster than a full build.
+a DTB.  Typical runtime is ≈3 minutes on a warm sstate cache, versus
+30-60 minutes for a full ``petalinux-build``.
 
 Step 6: Full build and package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -192,7 +204,19 @@ Step 6: Full build and package
 .. code-block:: bash
 
    petalinux-build
+
+ZynqMP packaging:
+
+.. code-block:: bash
+
    petalinux-package --boot --fsbl images/linux/zynqmp_fsbl.elf \
+       --fpga images/linux/system.bit --u-boot --force
+
+Zynq-7000 (ZC706) packaging:
+
+.. code-block:: bash
+
+   petalinux-package --boot --fsbl images/linux/zynq_fsbl.elf \
        --fpga images/linux/system.bit --u-boot --force
 
 Step 7: Boot and verify
@@ -241,6 +265,25 @@ Use the formatter standalone:
        petalinux_version="2024.1", # includes system-conf.dtsi
    )
    Path("system-user.dtsi").write_text(dtsi)
+
+Hardware tests
+--------------
+
+pyadi-dt ships hardware integration tests that exercise the full
+PetaLinux flow on real boards.  Each test creates (or reuses a cached)
+PetaLinux project, imports the XSA, drops in a pyadi-dt-generated
+``system-user.dtsi``, runs ``petalinux-build -c device-tree``, and boots
+the produced ``images/linux/system.dtb`` on a labgrid-controlled board:
+
+* ``test/hw/test_ad9081_zcu102_petalinux_hw.py``   (ZynqMP, SD boot)
+* ``test/hw/test_adrv9009_zc706_petalinux_hw.py``  (Zynq-7000, TFTP boot)
+* ``test/hw/test_adrv9371_zc706_petalinux_hw.py``  (Zynq-7000, TFTP boot)
+
+Boot+verify is shared with the corresponding ``test_*_xsa_hw.py`` so the
+two test families differ only in *how* the DTB was produced.  See
+``test/hw/README.md`` ("PetaLinux variant" section) for prerequisites
+(``PETALINUX_INSTALL``, project cache layout) and the per-board pytest
+invocations.
 
 Platform notes
 --------------

--- a/test/hw/README.md
+++ b/test/hw/README.md
@@ -128,6 +128,140 @@ A clean run reports `1 passed`.  Common failure shapes:
 
 For a board that adds a diagnostic tail, see `test_adrv9371_zc706_hw.py`.  For a board with a post-boot sweep, see `test_adrv9009_zcu102_hw.py`.
 
+## PetaLinux variant
+
+Each XSA-pipeline merged-DTB test has a sibling `test_<board>_<carrier>_petalinux_hw.py` that exercises the same overlay through the PetaLinux DTG path instead of `sdtgen`/lopper.  The pipeline is:
+
+```
+XSA → petalinux-create → petalinux-config --get-hw-description
+    → pyadi-dt system-user.dtsi (PetalinuxFormatter, --format petalinux)
+    → petalinux-build -c device-tree
+    → images/linux/system.dtb
+    → boot via labgrid (Kuiper kernel + rootfs)
+    → standard verify (no kernel faults, IIO probe, JESD DATA, RX capture)
+```
+
+This catches regressions specific to PetaLinux's device-tree assembly (`amba_pl` vs `amba` bus-label rewrites, `system-conf.dtsi` include semantics, label resolution against the DTG-generated base) that the sdtgen path doesn't see.  The boot+verify half is the same `boot_and_verify_from_dtb` shared with the XSA tests, so a failure here points at the PetaLinux build/format step rather than the kernel side.
+
+### Prerequisites
+
+- PetaLinux 2023.2 (or newer) installed at `/opt/Xilinx/PetaLinux/2023.2`.  Override with `PETALINUX_INSTALL`.
+- One-time smoke check:
+  ```sh
+  bash -lc "source $PETALINUX_INSTALL/settings.sh && petalinux-create --help" >/dev/null
+  ```
+  You do **not** need to source `settings.sh` in your test shell — the helper does it once per pytest session and merges the env into every PetaLinux subprocess.
+- Same `LG_COORDINATOR` / `LG_ENV` as the XSA tests (see `.env.example`).
+
+### Cache layout
+
+PetaLinux project creation + hardware import takes 5-10 minutes.  Cached under `${PETALINUX_PROJECT_CACHE_DIR}` (default `~/.cache/adidt/petalinux`), keyed by sha256 of the XSA bytes:
+
+```
+${PETALINUX_PROJECT_CACHE_DIR}/
+  zynqMP/<sha16-of-xsa>/proj/             # petalinux-create + --get-hw-description product
+  zynqMP/<sha16-of-xsa>/proj/xsa_import/  # private XSA copy used for --get-hw-description
+  zynq/<sha16-of-xsa>/proj/...
+```
+
+Cache hit ⇒ skip `petalinux-create` and `petalinux-config --get-hw-description`.  The pyadi-dt overlay injection and `petalinux-build -c device-tree` always re-run because the overlay can change for the same XSA.  Set `PETALINUX_PROJECT_CACHE=0` to force a clean re-create (e.g. after a PetaLinux upgrade).
+
+### Test file template
+
+```python
+from __future__ import annotations
+import dataclasses
+import pytest
+
+from test.hw._petalinux_base import (
+    requires_lg,
+    requires_petalinux,
+    run_petalinux_build_and_verify,
+)
+from test.hw.test_<board>_<carrier>_xsa_hw import SPEC as XSA_SPEC
+
+SPEC = dataclasses.replace(XSA_SPEC, out_label="<board>_<carrier>_petalinux")
+
+
+@requires_lg
+@requires_petalinux
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_<board>_<carrier>_petalinux_hw(board, tmp_path, request):
+    run_petalinux_build_and_verify(SPEC, board=board, request=request, tmp_path=tmp_path)
+```
+
+The `out_label` rename keeps the PetaLinux-variant `dmesg_<label>.log` files distinct from the XSA-variant ones in `test/hw/output/`.  If the XSA test appends a per-board diagnostic tail (ILAS dump, sysfs snapshots), copy that tail into the PetaLinux test verbatim — the helper returns the same `(shell, ctx, dmesg_txt)` tuple as `run_xsa_boot_and_verify`.
+
+### Run commands
+
+| Board | Place | Env yaml | Run from |
+|---|---|---|---|
+| AD9081 / ZCU102 | `mini2` | `test/hw/env/mini2.yaml` | any host (USBSDMux) |
+| ADRV9009 / ZC706 | `nemo`  | `test/hw/env/nemo.yaml`  | `nemo` (local TFTP) |
+| ADRV9371 / ZC706 | `bq`    | `test/hw/env/bq.yaml`    | `bq` (local TFTP) |
+
+```sh
+# AD9081 / ZCU102 — any host
+LG_COORDINATOR=10.0.0.41:20408 \
+LG_ENV=test/hw/env/mini2.yaml \
+PETALINUX_INSTALL=/opt/Xilinx/PetaLinux/2023.2 \
+uv run pytest test/hw/test_ad9081_zcu102_petalinux_hw.py -v -s
+
+# ADRV9009 / ZC706 — run on the nemo host
+LG_COORDINATOR=10.0.0.41:20408 \
+LG_ENV=test/hw/env/nemo.yaml \
+PETALINUX_INSTALL=/opt/Xilinx/PetaLinux/2023.2 \
+uv run pytest test/hw/test_adrv9009_zc706_petalinux_hw.py -v -s
+
+# ADRV9371 / ZC706 — run on the bq host
+LG_COORDINATOR=10.0.0.41:20408 \
+LG_ENV=test/hw/env/bq.yaml \
+PETALINUX_INSTALL=/opt/Xilinx/PetaLinux/2023.2 \
+uv run pytest test/hw/test_adrv9371_zc706_petalinux_hw.py -v -s
+```
+
+Expected runtime: ~10-12 min/board on first cache miss (5-10 min create + import, ~3 min device-tree build, 1-2 min boot+verify); ~5 min/board on warm cache.
+
+### Common failures specific to the PetaLinux path
+
+- `Reference to non-existent node or label "amba"` during `petalinux-build` — the pipeline didn't rewrite `&amba` to `&amba_pl` because `topology.inferred_platform()` returned `"unknown"` for a ZynqMP XSA.  The helper fails fast with a clearer hint when it sees this on a `boot_mode="sd"` board.
+- `petalinux-create not found` — `PETALINUX_INSTALL` is unset and `petalinux-create` isn't on PATH; the test reports `SKIPPED [requires_petalinux]`.
+- First-ever build on a host hits the network for sstate; allow up to 30 min.  Subsequent builds are ~3 min.
+
+### Post-build DTB fixups
+
+`run_petalinux_build_and_verify` patches the produced ``images/linux/system.dtb`` in place via `_apply_dtb_fixups` before staging it for boot.  The fixups paper over PetaLinux 2023.2's stock DTG output not matching the board-level wiring our reference Kuiper rootfs / U-Boot expects:
+
+- **Strip `/chosen/bootargs`** — PetaLinux bakes `bootargs = "earlycon ... root=/dev/ram0 rw"` into the DTB (driven by `CONFIG_SUBSYSTEM_BOOTARGS_AUTO`).  Most U-Boot builds don't overwrite an existing `/chosen/bootargs`, so the kernel ends up with `root=/dev/ram0` and panics with `Unable to mount root fs on unknown-block(179,2)` when the SD-card rootfs is on `/dev/mmcblk0p2`.  Removing the property lets U-Boot's own `bootargs` env var (set by `uEnv.txt`) flow through.
+
+- **Add `no-1-8-v` to `mmc@ff170000` on ZynqMP boards** — the ZCU102 SD slot has 3.3 V-only level translators.  Without `no-1-8-v` the kernel negotiates UHS-I SDR104 at 1.8 V; the SD card then throws read I/O errors during the rootfs mount with the same panic shape.  PetaLinux's stock DTG emits the SDHCI1 node without this property; Kuiper's hand-written DTB does include it.
+
+The proper long-term fix for both is a per-board PetaLinux fragment (BSP/template tweak) rather than a runtime DTB rewrite, but the workaround keeps the hw test path self-contained and obvious.
+
+### Other host-side prerequisites (TFTP boards)
+
+The TFTP-boot boards (`nemo`, `bq`) don't need ssh access to the exporter host (boot files travel over TFTP, console+power are proxied by labgrid), but a few host-local pieces still matter:
+
+- **`libiio0` system package**: `pylibiio` (the python ``iio`` module) loads `libiio.so.0` via ctypes; without it, every test that opens an IIO context fails with `undefined symbol: iio_get_backends_count`.
+  ```sh
+  sudo apt install -y libiio0
+  ```
+
+- **`/var/lib/tftpboot` writable by the test user**: the labgrid `TFTPServerDriver` (a pure-python `SimpleTFTPServer`) writes the staged kernel/DTB into the directory configured on `TFTPServerResource`.
+  ```sh
+  sudo install -d -o $USER -g $USER /var/lib/tftpboot
+  ```
+
+- **Pre-built kernel uImage** when the `pyadi-build` package isn't available: set `ADIDT_KERNEL_IMAGE_ZYNQ` (Zynq-7000) or `ADIDT_KERNEL_IMAGE_ZYNQMP` (ZynqMP) to a local kernel image path.  The corresponding fixture returns it directly and `deploy_and_boot` uploads it via the same path the built kernel would have taken.
+
+- **iptables UDP 69→3069 redirect** if the board's U-Boot (typically pre-2019) ignores `tftpdstport` and always queries the well-known TFTP port.  The labgrid `SimpleTFTPServer` listens on the unprivileged port 3069 (per `TFTPServerResource.port`); a one-line redirect bridges the two without running the test as root:
+  ```sh
+  sudo iptables -t nat -A PREROUTING -p udp --dport 69 -j REDIRECT --to-port 3069
+  ```
+  Symptom when missing: U-Boot logs `TFTP server died; starting again` after the RRQ.  `tcpdump 'udp port 69'` will show the request hitting your host on port 69 with nothing answering.
+
+- **SD-boot boards** (`mini2`'s `USBSDMuxDriver`) currently shell out to ssh on the exporter host (e.g. `ssh mini2 usbsdmux ...`) to operate the SD card mux.  This requires a passwordless ssh key for the runner-user → exporter-user path.  Without it the test fails with `BootFPGASoC is in broken state` and `Permission denied (publickey,password)` in the labgrid log.  This is the same blocker for both the XSA and PetaLinux variants of the SD-boot tests.
+
 ## `BoardSystemProfile` field reference
 
 | Field | Default | Purpose |

--- a/test/hw/_petalinux_base.py
+++ b/test/hw/_petalinux_base.py
@@ -1,0 +1,517 @@
+"""PetaLinux variant of the merged-DTB hardware test harness.
+
+The XSA hw tests in ``test/hw/test_*_xsa_hw.py`` exercise the pyadi-dt
+overlay through the Xilinx ``sdtgen``/lopper path: parse XSA → render
+overlay → merge with sdtgen base DTS → ``dtc`` → boot.  The PetaLinux
+variant runs the same overlay through PetaLinux's own DTG instead:
+
+    XSA → petalinux-create → petalinux-config --get-hw-description
+        → pyadi-dt ``XsaPipeline.run(output_format="petalinux")``
+        → install ``system-user.dtsi`` + ``device-tree.bbappend``
+        → petalinux-build -c device-tree
+        → ``images/linux/system.dtb``
+        → boot via labgrid (Kuiper kernel + rootfs)
+        → standard verify (no kernel faults, IIO probe, JESD DATA, RX capture)
+
+A board test module declares the same :class:`BoardSystemProfile` it uses
+for its XSA variant (typically with a renamed ``out_label``) and calls
+:func:`run_petalinux_build_and_verify`.  The boot+verify half is delegated
+to :func:`boot_and_verify_from_dtb` so the two variants share post-DTB
+behavior bit-for-bit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import pytest
+
+from adidt.xsa.petalinux import validate_petalinux_project
+from adidt.xsa.pipeline import XsaPipeline
+from adidt.xsa.topology import XsaParser
+from test.hw._system_base import (
+    BoardSystemProfile,
+    acquire_or_local_xsa,
+    boot_and_verify_from_dtb,
+    local_xsa_or_skip,
+    requires_lg,
+)
+from test.hw.hw_helpers import DEFAULT_OUT_DIR
+
+
+__all__ = [
+    "acquire_or_local_xsa",
+    "BoardSystemProfile",
+    "local_xsa_or_skip",
+    "requires_lg",
+    "requires_petalinux",
+    "run_petalinux_build_and_verify",
+]
+
+
+_DEFAULT_PETALINUX_INSTALL = "/opt/Xilinx/PetaLinux/2023.2"
+
+
+DEFAULT_PROJECT_CACHE = os.environ.get(
+    "PETALINUX_PROJECT_CACHE", "1"
+).lower() not in {"0", "false", "no"}
+
+PROJECT_CACHE_DIR = Path(
+    os.environ.get(
+        "PETALINUX_PROJECT_CACHE_DIR",
+        str(Path.home() / ".cache" / "adidt" / "petalinux"),
+    )
+)
+
+
+def _has_petalinux_install() -> bool:
+    install = Path(os.environ.get("PETALINUX_INSTALL", _DEFAULT_PETALINUX_INSTALL))
+    if (install / "settings.sh").is_file():
+        return True
+    return shutil.which("petalinux-create") is not None
+
+
+requires_petalinux = pytest.mark.skipif(
+    not _has_petalinux_install(),
+    reason=(
+        "PetaLinux install not found.  Set PETALINUX_INSTALL to the "
+        "PetaLinux 2023.2+ install root (containing settings.sh) "
+        "or ensure petalinux-create is on PATH."
+    ),
+)
+
+
+def _resolve_petalinux_install(spec: BoardSystemProfile) -> Path:
+    install = Path(
+        os.environ.get(spec.petalinux_install_env, _DEFAULT_PETALINUX_INSTALL)
+    )
+    if not (install / "settings.sh").is_file():
+        # Tools may be on PATH already; we'll let _petalinux_env handle it.
+        if shutil.which("petalinux-create") is None:
+            pytest.skip(
+                f"PetaLinux install not found: {install}/settings.sh missing "
+                f"and petalinux-create not on PATH"
+            )
+    return install
+
+
+_ENV_CACHE: dict[str, dict[str, str]] = {}
+
+
+def _petalinux_env(install: Path) -> dict[str, str]:
+    """Return the environment variables that ``source settings.sh`` sets.
+
+    Cached per install path for the lifetime of the pytest session.  Falls
+    back to the current environment when ``settings.sh`` is missing (for
+    setups where the user has already sourced it in their shell).
+    """
+    key = str(install)
+    cached = _ENV_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    settings = install / "settings.sh"
+    if not settings.is_file():
+        env = dict(os.environ)
+        _ENV_CACHE[key] = env
+        return env
+
+    cmd = ["bash", "-lc", f"source {settings} && env -0"]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        check=True,
+        timeout=120,
+    )
+    env: dict[str, str] = {}
+    for entry in result.stdout.split(b"\x00"):
+        if not entry:
+            continue
+        try:
+            text = entry.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "=" not in text:
+            continue
+        k, _, v = text.partition("=")
+        env[k] = v
+    _ENV_CACHE[key] = env
+    return env
+
+
+def _pl_run(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    timeout: int,
+    label: str,
+) -> str:
+    """Run a PetaLinux subprocess; on non-zero, fail the test with tail logs."""
+    print(f"$ ({label}) {' '.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        env=dict(env),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"PetaLinux step failed: {label}\n"
+            f"cmd: {' '.join(cmd)}\n"
+            f"cwd: {cwd}\n"
+            f"returncode: {result.returncode}\n"
+            f"stdout (last 4 KB):\n{result.stdout[-4096:]}\n"
+            f"stderr (last 4 KB):\n{result.stderr[-4096:]}"
+        )
+    return result.stdout
+
+
+def _xsa_sha256(xsa_path: Path) -> str:
+    h = hashlib.sha256()
+    with xsa_path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+def _template_for_boot_mode(boot_mode: str) -> str:
+    if boot_mode == "sd":
+        return "zynqMP"
+    if boot_mode == "tftp":
+        return "zynq"
+    raise ValueError(
+        f"cannot infer petalinux template for boot_mode={boot_mode!r}; "
+        "set spec.petalinux_template explicitly"
+    )
+
+
+def _petalinux_project_root(xsa_path: Path, *, template: str) -> Path:
+    return PROJECT_CACHE_DIR / template / _xsa_sha256(xsa_path) / "proj"
+
+
+def _project_is_created(project_dir: Path) -> bool:
+    """Return True if ``petalinux-create`` already produced this project."""
+    return (project_dir / "project-spec").is_dir()
+
+
+def _project_has_hw(project_dir: Path) -> bool:
+    """Return True if ``petalinux-config --get-hw-description`` already ran.
+
+    PetaLinux 2023.2 stages the imported XSA at
+    ``project-spec/hw-description/system.xsa`` regardless of the source
+    XSA filename — so its presence is a reliable indicator that the
+    hw-description step completed successfully.
+    """
+    return (
+        project_dir / "project-spec" / "hw-description" / "system.xsa"
+    ).is_file()
+
+
+def _petalinux_create(
+    install: Path,
+    project_dir: Path,
+    template: str,
+    *,
+    env: Mapping[str, str],
+) -> None:
+    """Create a fresh PetaLinux project at *project_dir* if absent."""
+    if _project_is_created(project_dir):
+        return
+    parent = project_dir.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    # ``petalinux-create`` refuses to write into an existing directory; if a
+    # half-baked tree from a prior failed run is present, clear it first.
+    if project_dir.exists():
+        shutil.rmtree(project_dir)
+    # PetaLinux 2023.2 ``petalinux-create`` writes into the current
+    # working directory; there is no ``-o`` flag.  ``cwd=parent`` controls
+    # where the project tree is created.
+    _pl_run(
+        [
+            "petalinux-create",
+            "-t",
+            "project",
+            "--template",
+            template,
+            "--name",
+            project_dir.name,
+        ],
+        cwd=parent,
+        env=env,
+        timeout=300,
+        label="petalinux-create",
+    )
+    assert project_dir.exists(), (
+        f"petalinux-create did not produce {project_dir}"
+    )
+
+
+def _petalinux_get_hw_description(
+    install: Path,
+    project_dir: Path,
+    xsa_path: Path,
+    *,
+    env: Mapping[str, str],
+    timeout: int = 1800,
+) -> None:
+    """Import the XSA into *project_dir*.
+
+    PetaLinux scans the supplied directory for ``*.xsa`` and uses the first
+    one alphabetically.  We isolate the XSA in a private ``xsa_import/``
+    subdir under the project so sibling XSA files in the source location
+    don't get picked up by mistake.
+    """
+    if _project_has_hw(project_dir):
+        return
+    import_dir = project_dir / "xsa_import"
+    import_dir.mkdir(parents=True, exist_ok=True)
+    staged_xsa = import_dir / "system_top.xsa"
+    if not staged_xsa.exists() or staged_xsa.stat().st_size != xsa_path.stat().st_size:
+        shutil.copy2(xsa_path, staged_xsa)
+    _pl_run(
+        [
+            "petalinux-config",
+            f"--get-hw-description={import_dir}",
+            "--silentconfig",
+        ],
+        cwd=project_dir,
+        env=env,
+        timeout=timeout,
+        label="petalinux-config --get-hw-description",
+    )
+    assert _project_has_hw(project_dir), (
+        "petalinux-config --get-hw-description ran but "
+        "project-spec/hw-description/system.xsa was not created"
+    )
+
+
+def _install_pyadi_outputs(
+    project_dir: Path,
+    system_user_dtsi: Path,
+    bbappend: Path,
+) -> None:
+    """Copy pyadi-dt outputs into the PetaLinux device-tree recipe.
+
+    Mirrors ``adidt/cli/main.py`` install behavior: backs up an existing
+    ``system-user.dtsi`` to ``.bak`` once, then ``shutil.copy2`` (preserves
+    mtime so identical re-installs do not invalidate the bitbake cache).
+    Skips the copy entirely when source bytes already match destination.
+    """
+    validate_petalinux_project(project_dir)
+    dt_recipe = project_dir / "project-spec" / "meta-user" / "recipes-bsp" / "device-tree"
+    dt_files = dt_recipe / "files"
+    dt_files.mkdir(parents=True, exist_ok=True)
+
+    dest_dtsi = dt_files / "system-user.dtsi"
+    backup = dt_files / "system-user.dtsi.bak"
+    new_bytes = system_user_dtsi.read_bytes()
+    if not dest_dtsi.exists():
+        shutil.copy2(system_user_dtsi, dest_dtsi)
+    elif dest_dtsi.read_bytes() != new_bytes:
+        if not backup.exists():
+            shutil.copy2(dest_dtsi, backup)
+        shutil.copy2(system_user_dtsi, dest_dtsi)
+
+    dest_bbappend = dt_recipe / "device-tree.bbappend"
+    bbappend_bytes = bbappend.read_bytes()
+    if not dest_bbappend.exists() or dest_bbappend.read_bytes() != bbappend_bytes:
+        shutil.copy2(bbappend, dest_bbappend)
+
+
+def _petalinux_build_dt(
+    install: Path,
+    project_dir: Path,
+    *,
+    env: Mapping[str, str],
+    timeout: int = 1800,
+) -> None:
+    _pl_run(
+        ["petalinux-build", "-c", "device-tree"],
+        cwd=project_dir,
+        env=env,
+        timeout=timeout,
+        label="petalinux-build -c device-tree",
+    )
+
+
+def _extract_dtb(project_dir: Path) -> Path:
+    dtb = project_dir / "images" / "linux" / "system.dtb"
+    assert dtb.exists() and dtb.stat().st_size > 0, (
+        f"petalinux-build did not produce a non-empty DTB at {dtb}"
+    )
+    return dtb
+
+
+def _apply_dtb_fixups(spec: BoardSystemProfile, dtb: Path) -> None:
+    """Patch the produced DTB in place for known PetaLinux/board mismatches.
+
+    PetaLinux 2023.2's stock DTG output for ZynqMP doesn't always match the
+    board-level wiring assumed by the Kuiper-style boot setup we use to
+    verify these tests:
+
+    * ``/chosen/bootargs`` is hardcoded to ``"earlycon ... root=/dev/ram0
+      rw"`` (driven by ``CONFIG_SUBSYSTEM_BOOTARGS_AUTO``).  Most U-Boot
+      builds don't overwrite an existing ``/chosen/bootargs``, so when
+      the same DTB is booted against the Kuiper SD-card rootfs the
+      kernel panics with ``Unable to mount root fs on
+      unknown-block(179,2)``.  Stripping the property lets U-Boot's own
+      ``bootargs`` env var flow through.
+    * For ZynqMP boards the ZCU102 SD slot has 3.3 V-only level
+      translators; the SDHCI1 node needs ``no-1-8-v`` to prevent the
+      kernel from negotiating UHS-I SDR104 at 1.8 V (the SD card then
+      throws read I/O errors and the rootfs mount panics, identical
+      symptom to the bootargs case).  PetaLinux's stock DTG emits the
+      node without ``no-1-8-v``; add it so SDR104 is skipped.
+
+    Both fixups are no-ops when the property/node is already in the
+    desired state, so the function is safe to call unconditionally.
+    """
+    import fdt
+
+    text = dtb.read_bytes()
+    tree = fdt.parse_dtb(text)
+    changed = False
+
+    chosen = tree.get_node("/chosen")
+    if chosen is not None and chosen.exist_property("bootargs"):
+        chosen.remove_property("bootargs")
+        changed = True
+
+    if spec.boot_mode == "sd":
+        # SDHCI1 lives under different bus paths depending on PetaLinux
+        # template / version (e.g. ``/axi/mmc@ff170000`` in 2023.2).
+        # Walk all subtrees once and patch the @ff170000 node.
+        for node in _walk_nodes(tree):
+            if node.name and "@ff170000" in node.name:
+                if not node.exist_property("no-1-8-v"):
+                    node.append(fdt.Property("no-1-8-v"))
+                    changed = True
+
+    if changed:
+        dtb.write_bytes(tree.to_dtb(version=17))
+
+
+def _walk_nodes(tree):
+    """Yield every node in *tree*, depth-first."""
+    stack = [tree.root]
+    while stack:
+        node = stack.pop()
+        yield node
+        for child in node.nodes:
+            stack.append(child)
+
+
+def _assert_zynqmp_platform_inferred(spec: BoardSystemProfile, topology) -> None:
+    """Catch a silent ``inferred_platform() == 'unknown'`` on ZynqMP.
+
+    :class:`PetalinuxFormatter` only rewrites ``&amba`` → ``&amba_pl`` for
+    platforms in its ``_ZYNQMP_PLATFORMS`` set
+    (``adidt/xsa/petalinux.py:13-21``).  If inference fails on a ZynqMP
+    XSA the build fails later with a phandle error — fail fast here with
+    a clearer hint.
+    """
+    if spec.boot_mode != "sd":
+        return
+    plat = (topology.inferred_platform() or "").lower()
+    if plat in {"", "unknown"}:
+        pytest.fail(
+            f"ZynqMP boot_mode='sd' but topology.inferred_platform() = "
+            f"{plat!r}; PetaLinux build will fail with a phandle error "
+            "because &amba won't be rewritten to &amba_pl.  Inspect the "
+            "XSA or override the platform in the cfg."
+        )
+
+
+def run_petalinux_build_and_verify(
+    spec: BoardSystemProfile,
+    *,
+    board,
+    request,
+    tmp_path: Path,
+    out_dir: Optional[Path] = None,
+) -> tuple[Any, Any, str]:
+    """End-to-end PetaLinux device-tree build + boot + verify.
+
+    Steps:
+
+    1. Resolve ``${PETALINUX_INSTALL}`` (default ``/opt/Xilinx/PetaLinux/2023.2``)
+       and extract its env (``source settings.sh``) once per session.
+    2. Resolve the XSA via ``spec.xsa_resolver``.
+    3. Pick or reuse a cached PetaLinux project keyed by sha256 of the XSA.
+    4. ``petalinux-create`` (cache miss only) and
+       ``petalinux-config --get-hw-description`` (cache miss only).
+    5. Run ``XsaPipeline().run(..., output_format="petalinux")`` and install
+       the produced ``system-user.dtsi`` + ``device-tree.bbappend`` into the
+       project.
+    6. ``petalinux-build -c device-tree``.
+    7. Extract ``images/linux/system.dtb``, copy it under *out_dir* with
+       ``spec.out_label`` so per-board log/staging files don't collide.
+    8. Delegate to :func:`boot_and_verify_from_dtb`.
+
+    Returns ``(shell, ctx, dmesg_txt)``.
+    """
+    out_dir = out_dir or (DEFAULT_OUT_DIR / "petalinux" / spec.out_label)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    install = _resolve_petalinux_install(spec)
+    env = _petalinux_env(install)
+
+    xsa_path = spec.xsa_resolver(tmp_path)
+    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
+
+    topology = XsaParser().parse(xsa_path)
+    spec.topology_assert(topology)
+    _assert_zynqmp_platform_inferred(spec, topology)
+
+    template = spec.petalinux_template or _template_for_boot_mode(spec.boot_mode)
+    project_dir = _petalinux_project_root(xsa_path, template=template)
+
+    if not DEFAULT_PROJECT_CACHE and project_dir.exists():
+        shutil.rmtree(project_dir)
+
+    _petalinux_create(install, project_dir, template, env=env)
+    _petalinux_get_hw_description(install, project_dir, xsa_path, env=env)
+
+    pipeline_out = out_dir / "pyadi"
+    pipeline_out.mkdir(parents=True, exist_ok=True)
+    # PetaLinux's own DTG provides the base DTS via
+    # ``petalinux-config --get-hw-description``; pyadi-dt only needs to
+    # render the overlay nodes and format them as system-user.dtsi.
+    # ``run_petalinux_only`` skips the redundant sdtgen call so this flow
+    # works in PetaLinux-only environments without Vivado/Vitis installed.
+    result = XsaPipeline().run_petalinux_only(
+        xsa_path=xsa_path,
+        cfg=spec.cfg_builder(),
+        output_dir=pipeline_out,
+        profile=spec.sdtgen_profile,
+    )
+    system_user_dtsi: Path = result["system_user_dtsi"]
+    bbappend: Path = result["bbappend"]
+    assert system_user_dtsi.exists(), (
+        f"pipeline did not produce system-user.dtsi: {system_user_dtsi}"
+    )
+
+    _install_pyadi_outputs(project_dir, system_user_dtsi, bbappend)
+
+    _petalinux_build_dt(install, project_dir, env=env)
+
+    pl_dtb = _extract_dtb(project_dir)
+    local_dtb = out_dir / f"{spec.out_label}.dtb"
+    shutil.copyfile(pl_dtb, local_dtb)
+    _apply_dtb_fixups(spec, local_dtb)
+
+    return boot_and_verify_from_dtb(
+        spec,
+        local_dtb,
+        board=board,
+        request=request,
+        out_dir=out_dir,
+    )

--- a/test/hw/_system_base.py
+++ b/test/hw/_system_base.py
@@ -48,6 +48,7 @@ from test.hw.xsa._overlay_spec import (  # re-exported for board-file convenienc
 __all__ = [
     "BoardSystemProfile",
     "acquire_or_local_xsa",
+    "boot_and_verify_from_dtb",
     "boot_and_verify_from_merged_dts",
     "local_xsa_or_skip",
     "requires_lg",
@@ -138,6 +139,9 @@ class BoardSystemProfile:
 
     dtb_basename: str = field(default="")  # auto-derived from out_label if empty
 
+    petalinux_template: Optional[Literal["zynqMP", "zynq"]] = None
+    petalinux_install_env: str = "PETALINUX_INSTALL"
+
 
 def _staged_dtb_for_boot(
     spec: BoardSystemProfile, dtb_raw: Path, staging_root: Path
@@ -170,41 +174,37 @@ def _assert_iio_devices_present(spec: BoardSystemProfile, ctx) -> None:
         )
 
 
-def boot_and_verify_from_merged_dts(
+def boot_and_verify_from_dtb(
     spec: BoardSystemProfile,
-    merged_dts: Path,
+    dtb_path: Path,
     *,
     board,
     request,
     out_dir: Path,
-    dtb_basename: Optional[str] = None,
 ):
-    """Compile *merged_dts*, boot the board, and run the standard verify.
+    """Stage *dtb_path*, boot the board, and run the standard verify.
+
+    Assumes ``dtb_path`` is an already-compiled, non-empty DTB.
 
     Steps performed:
 
-    1. Compile merged DTS → DTB.
-    2. Stage the DTB under the boot transport's expected basename.
-    3. Pull the kernel image fixture named in ``spec.kernel_fixture_name``.
-    4. ``deploy_and_boot``.
-    5. Collect dmesg and assert no kernel faults / probe errors.
-    6. Optional probe signature check (``spec.probe_signature_any``).
-    7. Open an IIO context and check ``iio_required_all`` / ``_any``.
-    8. Assert both JESD links reach DATA (with optional reg-address globs).
-    9. Optional RX capture smoke test (``spec.rx_capture_target_names``).
+    1. Stage the DTB under the boot transport's expected basename.
+    2. Pull the kernel image fixture named in ``spec.kernel_fixture_name``.
+    3. ``deploy_and_boot``.
+    4. Collect dmesg and assert no kernel faults / probe errors.
+    5. Optional probe signature check (``spec.probe_signature_any``).
+    6. Open an IIO context and check ``iio_required_all`` / ``_any``.
+    7. Assert both JESD links reach DATA (with optional reg-address globs).
+    8. Optional RX capture smoke test (``spec.rx_capture_target_names``).
 
     Returns ``(shell, ctx, dmesg_txt)`` so callers can run additional
     board-specific diagnostics on the booted target.
     """
-    out_dir.mkdir(parents=True, exist_ok=True)
-    name = dtb_basename or f"{spec.out_label}.dtb"
-    dtb_raw = out_dir / name
-    compile_dts_to_dtb(merged_dts, dtb_raw)
-    assert dtb_raw.exists() and dtb_raw.stat().st_size > 0, (
-        f"dtc produced empty/missing DTB: {dtb_raw}"
+    assert dtb_path.exists() and dtb_path.stat().st_size > 0, (
+        f"empty/missing DTB: {dtb_path}"
     )
 
-    staged_dtb = _staged_dtb_for_boot(spec, dtb_raw, out_dir)
+    staged_dtb = _staged_dtb_for_boot(spec, dtb_path, out_dir)
     kernel_image = request.getfixturevalue(spec.kernel_fixture_name)
 
     shell = deploy_and_boot(board, staged_dtb, kernel_image)
@@ -248,6 +248,32 @@ def boot_and_verify_from_merged_dts(
         )
 
     return shell, ctx, dmesg_txt
+
+
+def boot_and_verify_from_merged_dts(
+    spec: BoardSystemProfile,
+    merged_dts: Path,
+    *,
+    board,
+    request,
+    out_dir: Path,
+    dtb_basename: Optional[str] = None,
+):
+    """Compile *merged_dts* with dtc, then boot and run the standard verify.
+
+    Thin wrapper: dtc compile → :func:`boot_and_verify_from_dtb`.
+    See that function for the full step list and return value.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    name = dtb_basename or f"{spec.out_label}.dtb"
+    dtb_raw = out_dir / name
+    compile_dts_to_dtb(merged_dts, dtb_raw)
+    assert dtb_raw.exists() and dtb_raw.stat().st_size > 0, (
+        f"dtc produced empty/missing DTB: {dtb_raw}"
+    )
+    return boot_and_verify_from_dtb(
+        spec, dtb_raw, board=board, request=request, out_dir=out_dir
+    )
 
 
 def run_xsa_pipeline(

--- a/test/hw/hw_helpers.py
+++ b/test/hw/hw_helpers.py
@@ -879,6 +879,19 @@ def build_kernel_image(platform_arch: str) -> Path | None:
         RuntimeError: if the build produced no kernel image or the resulting
             file does not exist on disk.
     """
+    # Allow tests to bypass the pyadi-build dependency by pointing at a
+    # pre-built kernel image — useful in environments without the
+    # private pyadi-build package, or for fast iteration when the kernel
+    # is already known-good (e.g. matching a Kuiper sdcard image).
+    override_var = f"ADIDT_KERNEL_IMAGE_{platform_arch.upper()}"
+    override = os.environ.get(override_var)
+    if override:
+        path = Path(override)
+        if not path.is_file():
+            pytest.skip(f"{override_var}={override!s} does not exist")
+        print(f"Using pre-built {platform_arch} kernel image from {override_var}: {path}")
+        return path
+
     if not DEFAULT_BUILD_KERNEL:
         return None
 

--- a/test/hw/test_ad9081_zcu102_petalinux_hw.py
+++ b/test/hw/test_ad9081_zcu102_petalinux_hw.py
@@ -1,0 +1,48 @@
+"""AD9081 + ZCU102 hardware test driven by the PetaLinux flow.
+
+PetaLinux variant of :mod:`test.hw.test_ad9081_zcu102_xsa_hw`.  Reuses
+the same :class:`BoardSystemProfile`; only the DTB source differs.
+
+Pipeline:
+
+    XSA → petalinux-create → petalinux-config --get-hw-description
+        → pyadi-dt system-user.dtsi (PetalinuxFormatter)
+        → petalinux-build -c device-tree
+        → images/linux/system.dtb
+        → boot via labgrid (Kuiper kernel + rootfs on SD)
+        → standard verify (probes, IIO, JESD DATA, RX capture)
+
+Prereqs:
+
+* ``PETALINUX_INSTALL`` pointing at a 2023.2+ install root (default
+  ``/opt/Xilinx/PetaLinux/2023.2``).
+* Project + sstate cache under ``${PETALINUX_PROJECT_CACHE_DIR}``
+  (default ``~/.cache/adidt/petalinux``).
+* ``LG_COORDINATOR`` / ``LG_ENV`` for the ``mini2`` place.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from test.hw._petalinux_base import (
+    requires_lg,
+    requires_petalinux,
+    run_petalinux_build_and_verify,
+)
+from test.hw.test_ad9081_zcu102_xsa_hw import SPEC as XSA_SPEC
+
+
+SPEC = dataclasses.replace(XSA_SPEC, out_label="ad9081_zcu102_petalinux")
+
+
+@requires_lg
+@requires_petalinux
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_ad9081_zcu102_petalinux_hw(board, tmp_path, request):
+    """End-to-end pyadi-dt AD9081+ZCU102 boot + verify (PetaLinux path)."""
+    run_petalinux_build_and_verify(
+        SPEC, board=board, request=request, tmp_path=tmp_path
+    )

--- a/test/hw/test_adrv9009_zc706_petalinux_hw.py
+++ b/test/hw/test_adrv9009_zc706_petalinux_hw.py
@@ -1,0 +1,55 @@
+"""ADRV9009 + ZC706 hardware test driven by the PetaLinux flow.
+
+PetaLinux variant of :mod:`test.hw.test_adrv9009_zc706_hw`.  Same SPEC,
+same diagnostic tail (JESD sysfs status + ILAS report), only the DTB
+source differs.
+
+LG_ENV: ``test/hw/env/nemo.yaml``.  The ``nemo`` host owns the local
+``TFTPServerResource`` so this test must be invoked from there.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from test.hw._petalinux_base import (
+    requires_lg,
+    requires_petalinux,
+    run_petalinux_build_and_verify,
+)
+from test.hw.test_adrv9009_zc706_hw import SPEC as XSA_SPEC
+
+
+SPEC = dataclasses.replace(XSA_SPEC, out_label="adrv9009_zc706_petalinux")
+
+
+@requires_lg
+@requires_petalinux
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_adrv9009_zc706_petalinux_hw(board, tmp_path, request):
+    """End-to-end pyadi-dt ADRV9009+ZC706 boot + verify (PetaLinux path)."""
+    from test.hw.hw_helpers import (
+        assert_ilas_aligned,
+        parse_ilas_status,
+        read_jesd_status,
+    )
+
+    shell, _ctx, dmesg_txt = run_petalinux_build_and_verify(
+        SPEC, board=board, request=request, tmp_path=tmp_path
+    )
+
+    rx_status, tx_status = read_jesd_status(shell)
+    print("=== JESD204 RX status (sysfs) ===")
+    print(rx_status)
+    print("=== JESD204 TX status (sysfs) ===")
+    print(tx_status)
+
+    ilas_report = parse_ilas_status(dmesg_txt)
+    print("=== ADRV9009 ILAS report ===")
+    print(ilas_report.summary())
+    if ilas_report.fields:
+        for name in ilas_report.fields:
+            print(f"  mismatched: {name}")
+    assert_ilas_aligned(dmesg_txt, context=SPEC.out_label)

--- a/test/hw/test_adrv9371_zc706_petalinux_hw.py
+++ b/test/hw/test_adrv9371_zc706_petalinux_hw.py
@@ -1,0 +1,141 @@
+"""ADRV9371 + ZC706 hardware test driven by the PetaLinux flow.
+
+PetaLinux variant of :mod:`test.hw.test_adrv9371_zc706_hw`.  Reuses the
+same SPEC and the same ZC706+ADRV9371-specific diagnostic tail (TPL
+descriptor regs, AXI DMAC state, AD9371 phy snapshot).
+
+LG_ENV: ``test/hw/env/bq.yaml``.  The ``bq`` host owns the local
+``TFTPServerResource`` so this test must be invoked from there.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from test.hw._petalinux_base import (
+    requires_lg,
+    requires_petalinux,
+    run_petalinux_build_and_verify,
+)
+from test.hw.test_adrv9371_zc706_hw import SPEC as XSA_SPEC
+
+
+SPEC = dataclasses.replace(XSA_SPEC, out_label="adrv9371_zc706_petalinux")
+
+
+@requires_lg
+@requires_petalinux
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_adrv9371_zc706_petalinux_hw(board, tmp_path, request):
+    """End-to-end pyadi-dt ADRV9371+ZC706 boot + verify (PetaLinux path)."""
+    from test.hw.hw_helpers import (
+        assert_ilas_aligned,
+        assert_jesd_links_data,
+        parse_ilas_status,
+        read_jesd_status,
+        shell_out,
+    )
+
+    shell, _ctx, dmesg_txt = run_petalinux_build_and_verify(
+        SPEC, board=board, request=request, tmp_path=tmp_path
+    )
+
+    rx_status, tx_status = read_jesd_status(shell)
+    print("=== JESD204 RX status (sysfs) ===")
+    print(rx_status)
+    print("=== JESD204 TX status (sysfs) ===")
+    print(tx_status)
+
+    ilas_report = parse_ilas_status(dmesg_txt)
+    print("=== AD937x ILAS report ===")
+    print(ilas_report.summary())
+    if ilas_report.fields:
+        for name in ilas_report.fields:
+            print(f"  mismatched: {name}")
+    assert_ilas_aligned(dmesg_txt, context=SPEC.out_label)
+    assert_jesd_links_data(shell, context=SPEC.out_label)
+
+    # HDL compile-time framing — TPL descriptor registers.
+    # Descriptor 1 @ +0x240: [31:24]=F, [23:16]=S, [15:8]=L, [7:0]=M
+    # Descriptor 2 @ +0x244: [15:8]=Np, [7:0]=N
+    print("=== HDL compile-time JESD framing (TPL descriptor regs) ===")
+    print(
+        "which devmem: "
+        + shell_out(
+            shell,
+            "which devmem devmem2 busybox 2>/dev/null; busybox | head -1 2>/dev/null",
+        )
+    )
+    print(
+        shell_out(
+            shell,
+            (
+                "for base in 0x44a00000 0x44a04000 0x44a08000; do "
+                '  echo "--- TPL @ $base ---"; '
+                "  busybox devmem $(printf '0x%x' $((base + 0x240))) 2>&1; "
+                "  busybox devmem $(printf '0x%x' $((base + 0x244))) 2>&1; "
+                "done"
+            ),
+        )
+    )
+
+    print("=== TPL ADC sysfs (/sys/bus/iio/devices/<ad_ip_jesd204_tpl_adc>/) ===")
+    print(
+        shell_out(
+            shell,
+            (
+                "tpl=$(ls -d /sys/bus/iio/devices/iio:device* 2>/dev/null "
+                "| while read d; do "
+                "  name=$(cat $d/name 2>/dev/null); "
+                '  case "$name" in *tpl_adc*|*ad9371*rx*|*axi-ad9371-rx*) echo $d; esac; '
+                "done | head -1); "
+                'echo "PATH: $tpl"; '
+                '[ -n "$tpl" ] && ls -la $tpl/; '
+                'for f in "$tpl"/name "$tpl"/sampling_frequency "$tpl"/buffer/enable '
+                '         "$tpl"/buffer/length "$tpl"/buffer/watermark; do '
+                "  [ -e $f ] && printf '%s = %s\\n' $f \"$(cat $f 2>/dev/null)\"; "
+                "done"
+            ),
+        )
+    )
+    print("=== TPL ADC channel enables ===")
+    print(
+        shell_out(
+            shell,
+            (
+                "for ch in /sys/bus/iio/devices/iio:device*/scan_elements/*_en; do "
+                "  [ -e $ch ] && printf '%s = %s\\n' $ch \"$(cat $ch 2>/dev/null)\"; "
+                "done | grep -E 'tpl_adc|ad9371'"
+            ),
+        )
+    )
+    print("=== AXI DMAC (rx/tx) state ===")
+    print(
+        shell_out(
+            shell,
+            (
+                "for d in /sys/bus/platform/devices/7c4?0000.axi_dmac; do "
+                '  echo "--- $d ---"; ls $d 2>/dev/null; '
+                "done; "
+                "dmesg | grep -iE 'dmac|axi-dmac|dma' | tail -n 20"
+            ),
+        )
+    )
+    print("=== AD9371 phy sysfs snapshot ===")
+    print(
+        shell_out(
+            shell,
+            (
+                "phy=$(find /sys/bus/iio/devices -maxdepth 2 -name ensm_mode 2>/dev/null "
+                "     | xargs dirname 2>/dev/null | head -1); "
+                'echo "PHY: $phy"; '
+                '[ -n "$phy" ] && for f in $phy/ensm_mode $phy/gain_control_mode '
+                "     $phy/in_voltage0_rf_bandwidth $phy/in_voltage0_sampling_frequency "
+                "     $phy/rx_path_clks; do "
+                "  [ -e $f ] && printf '%s = %s\\n' $f \"$(cat $f 2>/dev/null)\"; "
+                "done"
+            ),
+        )
+    )


### PR DESCRIPTION
## Summary

- Add a PetaLinux variant of the merged-DTB hw test for each of the three actively-tested boards (AD9081/ZCU102, ADRV9009/ZC706, ADRV9371/ZC706). Each runs `XSA → petalinux-create → petalinux-config → pyadi-dt system-user.dtsi → petalinux-build -c device-tree → boot via labgrid → standard verify`.
- Reuses the existing per-board `BoardSystemProfile` (only `out_label` is renamed) so cfg/JESD globs/IIO asserts/diagnostic tails stay in lockstep with the matching XSA tests.
- Refactors `boot_and_verify_from_merged_dts` so the post-DTB-compile half (stage → boot → dmesg + IIO + JESD verify + RX capture) is reusable across the merged-DTS and PetaLinux paths.
- Adds `XsaPipeline.run_petalinux_only` that bypasses sdtgen — PetaLinux's own DTG provides the base, so the sdtgen call is redundant and forces a Vitis dependency PetaLinux-only environments don't have.
- Adds `_apply_dtb_fixups` (strip `/chosen/bootargs`, add `no-1-8-v` to the ZynqMP SDHCI1 node) to paper over per-board template fragments missing from PetaLinux 2023.2's stock DTG output. Both fixups are no-ops when already in the desired state; documented in the README with rationale for why they're temporary.
- Adds `ADIDT_KERNEL_IMAGE_<arch>` env-var override for `build_kernel_image` so the kernel-image fixture works without the private `pyadi-build` package.

## Test plan

All three new tests pass against the labgrid coordinator at `10.0.0.41:20408`:

- [x] `pytest test/xsa/test_petalinux.py` — 21/21 unit tests still pass after refactor
- [x] `pytest --collect-only test/hw/test_*_petalinux_hw.py` — collection clean (skips on hosts without PetaLinux)
- [x] `pytest --collect-only test/hw/test_ad9081_zcu102_xsa_hw.py test/hw/test_adrv9009_zc706_hw.py test/hw/test_adrv9371_zc706_hw.py` — existing XSA hw tests still collect after the `_system_base.py` refactor
- [x] `LG_COORDINATOR=10.0.0.41:20408 LG_ENV=test/hw/env/mini2.yaml PETALINUX_INSTALL=/opt/Xilinx/PetaLinux/2023.2 ADIDT_KERNEL_IMAGE_ZYNQMP=... pytest -v -s test/hw/test_ad9081_zcu102_petalinux_hw.py` — **1 passed in 2:26**; AD9081 probed, JESD RX/TX both DATA, SYSREF captured, RX capture: 8 channels with non-zero data
- [x] `LG_COORDINATOR=... LG_ENV=test/hw/env/nemo.yaml PETALINUX_INSTALL=... ADIDT_KERNEL_IMAGE_ZYNQ=... pytest -v -s test/hw/test_adrv9009_zc706_petalinux_hw.py` — **1 passed in 2:00**; both JESD links DATA, SYSREF captured
- [x] `LG_COORDINATOR=... LG_ENV=test/hw/env/bq.yaml PETALINUX_INSTALL=... ADIDT_KERNEL_IMAGE_ZYNQ=... pytest -v -s test/hw/test_adrv9371_zc706_petalinux_hw.py` — **1 passed in 5:44** (cold petalinux build for new XSA)

Host prereqs (documented in `test/hw/README.md`): `libiio0` apt package, `/var/lib/tftpboot` writable by the test user, `iptables -t nat -A PREROUTING -p udp --dport 69 -j REDIRECT --to-port 3069` for older U-Boots that ignore `tftpdstport`, ssh access from runner-user → exporter-user for SD-mux boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)