### PR TITLE
feat(test/hw): adidtc CLI hardware tests

### DIFF
--- a/.github/hw-nodes.json
+++ b/.github/hw-nodes.json
@@ -11,7 +11,10 @@
     "env_remote": "test/hw/env/mini2.yaml",
     "tests": [
       "test/hw/test_ad9081_zcu102_xsa_hw.py",
-      "test/hw/test_ad9081_zcu102_system_hw.py"
+      "test/hw/test_ad9081_zcu102_system_hw.py",
+      "test/hw/test_cli_dts_gen_ad9081_zcu102_hw.py",
+      "test/hw/test_cli_live_ad9081_zcu102_hw.py",
+      "test/hw/test_cli_mcp_ad9081_zcu102_hw.py"
     ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ python_functions = ["test_*"]
 addopts = "-v --ignore-glob=*_hw.py"
 markers = [
     "network: tests requiring internet downloads",
+    "slow: reboot-heavy hw tests; opt out via -m 'not slow'",
 ]
 
 [tool.ty.rules]

--- a/test/hw/_cli_base.py
+++ b/test/hw/_cli_base.py
@@ -1,0 +1,185 @@
+"""Shared helpers for ``adidtc`` CLI hardware tests.
+
+The CLI hw tests under ``test/hw/test_cli_*_hw.py`` exercise the same
+``adidtc`` entry points a user would run.  They reuse the standard
+labgrid+:class:`BoardSystemProfile` boot path from
+:mod:`test.hw._system_base`, then drive the CLI in-process with
+:class:`click.testing.CliRunner` so exit codes and ``click.echo``
+output are easy to assert against.
+
+Two pieces of glue are provided here:
+
+* :func:`run_adidtc` / :func:`run_adidtc_jif` — invoke the top-level
+  ``adidtc`` group (or the ``jif`` subgroup registered out-of-band at
+  :func:`adidt.cli.jif.register`) and assert the exit code.
+* :func:`discover_board_ipv4` / :func:`wait_for_ssh` /
+  :func:`sd_marker_cleanup` — utilities for exercising commands that
+  talk to the booted board over SSH.  ``discover_board_ipv4`` mirrors
+  the ``ip = str(ip_addresses[0].ip).split('/')[0]`` pattern from
+  :func:`test.hw.hw_helpers.open_iio_context` so the CLI sees the same
+  reachable IP as the IIO probe path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from pathlib import Path
+from typing import Iterator
+
+from click.testing import CliRunner, Result
+
+from adidt.cli.main import cli as adidtc_cli
+
+
+# Default Kuiper rootfs credentials.  Mirror :class:`adidt.dt.dt`'s
+# hardcoded defaults at adidt/dt.py:33-35 so the CLI's own --username /
+# --password defaults do not need to be overridden in tests.
+KUIPER_USER = "root"
+KUIPER_PASSWORD = "analog"
+
+
+def run_adidtc(
+    args: list[str],
+    *,
+    expect_exit: int = 0,
+    catch_exceptions: bool = False,
+) -> Result:
+    """Invoke ``adidtc`` with *args* via :class:`CliRunner`; assert exit code.
+
+    Args:
+        args: Argument vector passed to the top-level ``adidtc`` group
+            (without the leading ``adidtc``).
+        expect_exit: Expected ``result.exit_code``.  Mismatches raise
+            ``AssertionError`` with the captured output for triage.
+        catch_exceptions: Forwarded to :meth:`CliRunner.invoke`.  Off by
+            default so tracebacks surface during test development; set
+            ``True`` when verifying CLI-level error handling.
+
+    Returns:
+        The :class:`click.testing.Result` for further assertions on
+        ``result.output``.
+    """
+    runner = CliRunner()
+    result = runner.invoke(adidtc_cli, args, catch_exceptions=catch_exceptions)
+    if result.exit_code != expect_exit:
+        raise AssertionError(
+            f"adidtc {' '.join(args)!s} exited {result.exit_code}, "
+            f"expected {expect_exit}.\n--- output ---\n{result.output}"
+        )
+    return result
+
+
+def run_adidtc_jif(
+    args: list[str],
+    *,
+    expect_exit: int = 0,
+    catch_exceptions: bool = False,
+) -> Result:
+    """Invoke the ``adidtc jif`` subgroup; thin wrapper around :func:`run_adidtc`.
+
+    The ``jif`` group is registered on the top-level ``cli`` at module
+    import time via ``_jif.register(cli)`` (see ``adidt/cli/main.py``),
+    so a single :class:`CliRunner` against ``cli`` reaches it — but this
+    wrapper makes the call site read like ``adidtc jif clock ...``.
+    """
+    return run_adidtc(
+        ["jif", *args], expect_exit=expect_exit, catch_exceptions=catch_exceptions
+    )
+
+
+def discover_board_ipv4(shell) -> str:
+    """Return the first usable IPv4 reported by *shell*.
+
+    Wraps :meth:`ADIShellDriver.get_ip_addresses` (already used by
+    :func:`test.hw.hw_helpers.open_iio_context`).  The CLI's ``--ip``
+    option needs a bare address; this strips any trailing ``/<prefix>``
+    that labgrid hands back from ``ip addr show``.
+    """
+    addresses = shell.get_ip_addresses()
+    assert addresses, "ADIShellDriver could not report a board IP address"
+    return str(addresses[0].ip).split("/")[0]
+
+
+def wait_for_ssh(
+    ip: str,
+    *,
+    user: str = KUIPER_USER,
+    password: str = KUIPER_PASSWORD,
+    timeout: float = 180.0,
+    poll_interval: float = 2.0,
+) -> None:
+    """Block until SSH login succeeds against *ip* or *timeout* elapses.
+
+    Used after CLI commands that issue ``--reboot``: the labgrid serial
+    shell becomes stale, so subsequent verification has to ride on a
+    fresh :class:`fabric.Connection`.  Failure raises
+    ``TimeoutError`` with the last underlying exception's message so
+    the test report points at the actual SSH error.
+    """
+    from fabric import Connection
+
+    deadline = time.monotonic() + timeout
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with Connection(
+                f"{user}@{ip}:22",
+                connect_kwargs={"password": password},
+            ) as c:
+                c.run("uname -r", hide=True, warn=False)
+            return
+        except Exception as exc:  # noqa: BLE001 — any connect failure → keep polling
+            last_exc = exc
+            time.sleep(poll_interval)
+    raise TimeoutError(
+        f"SSH to {user}@{ip} did not succeed within {timeout:.0f}s; "
+        f"last error: {last_exc!r}"
+    )
+
+
+@contextlib.contextmanager
+def sd_marker_cleanup(
+    ip: str,
+    marker_basenames: list[str],
+    *,
+    user: str = KUIPER_USER,
+    password: str = KUIPER_PASSWORD,
+) -> Iterator[None]:
+    """Ensure named files at the SD root are removed on context exit.
+
+    Use to wrap tests that *create* a new file on the board's SD card
+    (e.g. ``sd-remote-copy`` of a marker file) so the cleanup happens
+    even if the test body raises.  The cleanup mounts
+    ``/dev/mmcblk0p1`` (the convention :meth:`adidt.dt.dt._handle_sd_mount`
+    follows), removes each named file from the SD root, and unmounts.
+
+    Note: this helper does NOT back up pre-existing files.  Tests that
+    mutate stock boot artifacts (``system.dtb``, ``BOOT.BIN``) need
+    SFTP-based backup-to-local-disk because in-target ``/tmp`` is
+    tmpfs-backed and gets wiped on reboot.  Such tests are out of
+    scope for the initial CLI hw test set.
+    """
+    from fabric import Connection
+
+    mount_dir = "/tmp/adidt_cli_test_sd_mount"
+
+    try:
+        yield
+    finally:
+        with Connection(f"{user}@{ip}:22", connect_kwargs={"password": password}) as c:
+            c.run(f"mkdir -p {mount_dir}", hide=True, warn=True)
+            c.run(f"umount {mount_dir}", hide=True, warn=True)
+            c.run("umount /dev/mmcblk0p1", hide=True, warn=True)
+            mount_res = c.run(f"mount /dev/mmcblk0p1 {mount_dir}", hide=True, warn=True)
+            if mount_res.return_code != 0:
+                return
+            try:
+                for name in marker_basenames:
+                    c.run(
+                        f"rm -f {mount_dir}/{Path(name).name}",
+                        hide=True,
+                        warn=True,
+                    )
+            finally:
+                c.run(f"umount {mount_dir}", hide=True, warn=True)

--- a/test/hw/_cli_base.py
+++ b/test/hw/_cli_base.py
@@ -108,6 +108,8 @@ def wait_for_ssh(
     password: str = KUIPER_PASSWORD,
     timeout: float = 180.0,
     poll_interval: float = 2.0,
+    wait_for_down: bool = False,
+    down_timeout: float = 60.0,
 ) -> None:
     """Block until SSH login succeeds against *ip* or *timeout* elapses.
 
@@ -116,17 +118,37 @@ def wait_for_ssh(
     fresh :class:`fabric.Connection`.  Failure raises
     ``TimeoutError`` with the last underlying exception's message so
     the test report points at the actual SSH error.
+
+    When ``wait_for_down=True`` (the default for post-reboot use), the
+    function first waits up to *down_timeout* seconds for SSH to *fail*
+    — proof that the kernel actually started rebooting — before
+    polling for SSH to come back.  Without this, the very first poll
+    can race the kernel and succeed against the still-running pre-
+    reboot SSH, returning immediately and producing a misleading
+    success.  If SSH never goes down within *down_timeout* the function
+    proceeds to the up-poll anyway (the reboot may have happened
+    extremely fast or before our first probe).
     """
     from fabric import Connection
+
+    address = f"{user}@{ip}:22"
+    connect_kwargs = {"password": password}
+
+    if wait_for_down:
+        down_deadline = time.monotonic() + down_timeout
+        while time.monotonic() < down_deadline:
+            try:
+                with Connection(address, connect_kwargs=connect_kwargs) as c:
+                    c.run("true", hide=True, warn=False)
+            except Exception:  # noqa: BLE001 — failure is the success condition here
+                break
+            time.sleep(poll_interval)
 
     deadline = time.monotonic() + timeout
     last_exc: Exception | None = None
     while time.monotonic() < deadline:
         try:
-            with Connection(
-                f"{user}@{ip}:22",
-                connect_kwargs={"password": password},
-            ) as c:
+            with Connection(address, connect_kwargs=connect_kwargs) as c:
                 c.run("uname -r", hide=True, warn=False)
             return
         except Exception as exc:  # noqa: BLE001 — any connect failure → keep polling

--- a/test/hw/test_cli_dts_gen_ad9081_zcu102_hw.py
+++ b/test/hw/test_cli_dts_gen_ad9081_zcu102_hw.py
@@ -1,0 +1,159 @@
+"""AD9081 + ZCU102 hardware tests for the DTS-generation CLI commands.
+
+Drives ``adidtc xsa2dt`` and ``adidtc gen-dts`` as a user would (via
+:class:`click.testing.CliRunner`) and validates that the produced
+artifacts are usable end-to-end:
+
+* ``xsa2dt`` — runs the full 5-stage XSA pipeline through the CLI
+  surface, then hands the merged DTS to the standard
+  :func:`boot_and_verify_from_merged_dts` path so the same boot + IIO
+  + JESD checks the python-API test runs are exercised against
+  CLI-produced output.
+* ``gen-dts`` — composes via the declarative ``System`` API; the CLI
+  emits an overlay-style DTS that is not bootable on its own (no base
+  platform DTS), so the CLI's own ``--compile`` flag is asserted to
+  succeed.  The bootable path for the System API is already covered
+  by :mod:`test.hw.test_ad9081_zcu102_system_hw`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from test.hw._cli_base import run_adidtc
+from test.hw._system_base import (
+    BoardSystemProfile,
+    acquire_or_local_xsa,
+    boot_and_verify_from_merged_dts,
+    requires_lg,
+)
+from test.hw.hw_helpers import DEFAULT_OUT_DIR
+from test.hw.test_ad9081_zcu102_xsa_hw import _solve_ad9081_config, _topology_assert
+
+
+DEFAULT_KUIPER_RELEASE = "2023_r2"
+DEFAULT_KUIPER_PROJECT = "zynqmp-zcu102-rev10-ad9081"
+
+
+SPEC = BoardSystemProfile(
+    lg_features=("ad9081", "zcu102"),
+    cfg_builder=_solve_ad9081_config,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_ad9081_zcu102.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    sdtgen_profile="ad9081_zcu102",
+    topology_assert=_topology_assert,
+    boot_mode="sd",
+    kernel_fixture_name="built_kernel_image_zynqmp",
+    out_label="ad9081_cli_xsa2dt",
+    dmesg_grep_pattern="ad9081|hmc7044|jesd204|probe|failed|error",
+    merged_dts_must_contain=(
+        'compatible = "adi,ad9081"',
+        'compatible = "adi,hmc7044"',
+    ),
+    probe_signature_any=("AD9081 Rev.", "probed ADC AD9081"),
+    probe_signature_message="AD9081 probe signature not found in dmesg",
+    iio_required_all=("hmc7044",),
+    iio_required_any_groups=(
+        ("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+        ("axi-ad9081-tx-hpc", "ad_ip_jesd204_tpl_dac"),
+    ),
+    jesd_rx_glob="84a90000.axi[_-]jesd204[_-]rx",
+    jesd_tx_glob="84b90000.axi[_-]jesd204[_-]tx",
+    rx_capture_target_names=("axi-ad9081-rx-hpc", "ad_ip_jesd204_tpl_adc"),
+)
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_xsa2dt_cli_produces_bootable_dtb(board, tmp_path, request):
+    """``adidtc xsa2dt`` -> merged DTS -> dtc -> labgrid boot + verify."""
+    xsa_path = SPEC.xsa_resolver(tmp_path)
+    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
+
+    cfg_path = tmp_path / "ad9081_cli_cfg.json"
+    cfg_path.write_text(json.dumps(SPEC.cfg_builder()))
+
+    out_dir = tmp_path / "xsa2dt_out"
+    result = run_adidtc(
+        [
+            "xsa2dt",
+            "--xsa",
+            str(xsa_path),
+            "--config",
+            str(cfg_path),
+            "--output",
+            str(out_dir),
+            "--profile",
+            SPEC.sdtgen_profile,
+            "--timeout",
+            str(SPEC.sdtgen_timeout),
+        ],
+    )
+    print(result.output)
+
+    merged_candidates = sorted(out_dir.glob("*.dts"))
+    assert merged_candidates, f"xsa2dt produced no DTS in {out_dir}"
+    merged_dts = merged_candidates[0]
+
+    merged_text = merged_dts.read_text()
+    for needle in SPEC.merged_dts_must_contain:
+        assert needle in merged_text, (
+            f"Required substring {needle!r} missing from CLI-produced DTS "
+            f"({merged_dts})"
+        )
+
+    boot_out = DEFAULT_OUT_DIR
+    boot_out.mkdir(parents=True, exist_ok=True)
+    boot_and_verify_from_merged_dts(
+        SPEC,
+        merged_dts,
+        board=board,
+        request=request,
+        out_dir=boot_out,
+    )
+
+
+def test_gen_dts_cli_compiles_to_dtb(tmp_path: Path):
+    """``adidtc gen-dts --compile`` for ad9081_fmc+zcu102 emits a valid DTB.
+
+    The System-API CLI path produces an overlay-style DTS without a
+    platform base, so booting it standalone is not meaningful; the
+    bootable composition is validated elsewhere by
+    :mod:`test.hw.test_ad9081_zcu102_system_hw`.  This test asserts the
+    CLI flow itself (argument parsing, ``System.generate_dts`` ->
+    ``dtc`` invocation) succeeds and produces a non-empty DTB.
+    """
+    cfg_path = tmp_path / "gen_dts_cfg.json"
+    cfg_path.write_text("{}")
+    out_dts = tmp_path / "ad9081_zcu102.dts"
+    out_dtb = out_dts.with_suffix(".dtb")
+
+    result = run_adidtc(
+        [
+            "gen-dts",
+            "--board",
+            "ad9081_fmc",
+            "--platform",
+            "zcu102",
+            "--config",
+            str(cfg_path),
+            "--output",
+            str(out_dts),
+            "--compile",
+        ],
+    )
+    print(result.output)
+
+    assert out_dts.exists(), f"gen-dts did not write DTS to {out_dts}"
+    dts_text = out_dts.read_text()
+    assert "/dts-v1/;" in dts_text
+    assert "ad9081" in dts_text.lower()
+
+    assert out_dtb.exists(), f"--compile did not produce DTB at {out_dtb}"
+    assert out_dtb.stat().st_size > 0, f"DTB is empty: {out_dtb}"

--- a/test/hw/test_cli_dts_gen_adrv9009_zc706_hw.py
+++ b/test/hw/test_cli_dts_gen_adrv9009_zc706_hw.py
@@ -1,0 +1,138 @@
+"""ADRV9009 + ZC706 hardware tests for the DTS-generation CLI commands.
+
+Mirrors :mod:`test.hw.test_cli_dts_gen_ad9081_zcu102_hw` for the
+Zynq-7000 + TFTP-boot path.  Only ``xsa2dt`` is tested end-to-end:
+``gen-dts`` does not yet support the ``adrv9009_fmc`` + ``zc706``
+combination (see :data:`adidt.cli.gen_dts.BUILDERS`), so that test
+asserts the CLI rejects the unsupported combo with a clear error.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from test.hw._cli_base import run_adidtc
+from test.hw._system_base import (
+    BoardSystemProfile,
+    acquire_or_local_xsa,
+    boot_and_verify_from_merged_dts,
+    requires_lg,
+)
+from test.hw.hw_helpers import DEFAULT_OUT_DIR
+from test.hw.test_adrv9009_zc706_hw import (
+    _adrv9009_cfg,
+    _filter_si570_probe_noise,
+    _topology_assert,
+)
+
+
+DEFAULT_KUIPER_RELEASE = "2023_r2"
+DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv9009"
+
+
+SPEC = BoardSystemProfile(
+    lg_features=("adrv9009", "zc706"),
+    cfg_builder=_adrv9009_cfg,
+    xsa_resolver=acquire_or_local_xsa(
+        "system_top_adrv9009_zc706.xsa",
+        DEFAULT_KUIPER_RELEASE,
+        DEFAULT_KUIPER_PROJECT,
+    ),
+    sdtgen_profile="adrv9009_zc706",
+    topology_assert=_topology_assert,
+    boot_mode="tftp",
+    kernel_fixture_name="built_kernel_image_zynq",
+    out_label="adrv9009_cli_xsa2dt",
+    dmesg_grep_pattern="adrv9009|hmc7044|ad9528|jesd204|talise|probe|failed|error",
+    dmesg_filter=_filter_si570_probe_noise,
+    merged_dts_must_contain=('compatible = "adi,adrv9009"',),
+    probe_signature_any=("adrv9009", "talise"),
+    probe_signature_message="ADRV9009 driver probe signature not found in dmesg",
+    iio_required_any_groups=(
+        ("adrv9009-phy", "talise"),
+        ("ad9528-1", "hmc7044"),
+    ),
+)
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_xsa2dt_cli_produces_bootable_dtb(board, tmp_path, request):
+    """``adidtc xsa2dt`` for ADRV9009+ZC706 -> merged DTS -> TFTP boot + verify."""
+    xsa_path = SPEC.xsa_resolver(tmp_path)
+    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
+
+    cfg_path = tmp_path / "adrv9009_cli_cfg.json"
+    cfg_path.write_text(json.dumps(SPEC.cfg_builder()))
+
+    out_dir = tmp_path / "xsa2dt_out"
+    result = run_adidtc(
+        [
+            "xsa2dt",
+            "--xsa",
+            str(xsa_path),
+            "--config",
+            str(cfg_path),
+            "--output",
+            str(out_dir),
+            "--profile",
+            SPEC.sdtgen_profile,
+            "--timeout",
+            str(SPEC.sdtgen_timeout),
+        ],
+    )
+    print(result.output)
+
+    merged_candidates = sorted(out_dir.glob("*.dts"))
+    assert merged_candidates, f"xsa2dt produced no DTS in {out_dir}"
+    merged_dts = merged_candidates[0]
+
+    merged_text = merged_dts.read_text()
+    for needle in SPEC.merged_dts_must_contain:
+        assert needle in merged_text, (
+            f"Required substring {needle!r} missing from CLI-produced DTS "
+            f"({merged_dts})"
+        )
+
+    boot_out = DEFAULT_OUT_DIR
+    boot_out.mkdir(parents=True, exist_ok=True)
+    boot_and_verify_from_merged_dts(
+        SPEC,
+        merged_dts,
+        board=board,
+        request=request,
+        out_dir=boot_out,
+    )
+
+
+def test_gen_dts_cli_rejects_unsupported_combo(tmp_path: Path):
+    """``adidtc gen-dts -b adrv9009_fmc -p zc706`` errors clearly.
+
+    The declarative ``System`` API path only registers builders for
+    ``ad9081_fmc + zcu102`` and ``ad9084_fmc + vpk180``.  Confirm the
+    CLI surface produces a usable error message rather than a stack
+    trace when run against this board.
+    """
+    cfg_path = tmp_path / "gen_dts_cfg.json"
+    cfg_path.write_text("{}")
+    out_dts = tmp_path / "should_not_exist.dts"
+
+    result = run_adidtc(
+        [
+            "gen-dts",
+            "--board",
+            "adrv9009_fmc",
+            "--platform",
+            "zc706",
+            "--config",
+            str(cfg_path),
+            "--output",
+            str(out_dts),
+        ],
+        expect_exit=2,
+    )
+    assert "Supported combos" in result.output
+    assert not out_dts.exists()

--- a/test/hw/test_cli_live_ad9081_zcu102_hw.py
+++ b/test/hw/test_cli_live_ad9081_zcu102_hw.py
@@ -1,0 +1,318 @@
+"""Live-board ``adidtc`` hardware tests for AD9081 + ZCU102.
+
+Boots the AD9081+ZCU102 board through the standard XSA-pipeline path
+(see :mod:`test.hw.test_ad9081_zcu102_xsa_hw`) once per module, then
+exercises the hardware-touching CLI commands against the live target.
+
+Test ordering matters: read-only and ``--dry-run`` tests come first
+while the labgrid serial shell is still valid; reboot variants come
+last because they invalidate the labgrid shell handle (subsequent
+verification has to ride on a fresh :mod:`fabric` SSH session).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+from fabric import Connection
+
+from test.hw._cli_base import (
+    KUIPER_PASSWORD,
+    KUIPER_USER,
+    discover_board_ipv4,
+    run_adidtc,
+    sd_marker_cleanup,
+    wait_for_ssh,
+)
+from test.hw._system_base import requires_lg, run_xsa_boot_and_verify
+from test.hw.test_ad9081_zcu102_xsa_hw import SPEC as XSA_SPEC
+
+
+# Reuse the boot SPEC verbatim but override out_label so dmesg logs do
+# not collide with the python-API XSA test.
+SPEC = dataclasses.replace(XSA_SPEC, out_label="ad9081_cli_live")
+
+
+@pytest.fixture(scope="module")
+def booted(board, tmp_path_factory, request):
+    """Boot the board once per module; expose ``(shell, ip)`` to all tests.
+
+    Reuses :func:`run_xsa_boot_and_verify` so the same boot/probe
+    invariants the standard hw tests assert apply here too.  IP
+    discovery mirrors the pattern used by
+    :func:`test.hw.hw_helpers.open_iio_context`.
+    """
+    tmp_path = tmp_path_factory.mktemp("cli_live")
+    shell, _ctx, _dmesg = run_xsa_boot_and_verify(
+        SPEC, board=board, request=request, tmp_path=tmp_path
+    )
+    ip = discover_board_ipv4(shell)
+    print(f"booted board, SSH IP: {ip}")
+    yield shell, ip
+
+
+# ---------------------------------------------------------------------------
+# Read-only tests
+# ---------------------------------------------------------------------------
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_prop_read_compatible(booted):
+    """``adidtc prop -cp adi,ad9081 compatible`` reads the live AD9081 node."""
+    _shell, ip = booted
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sysfs",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "prop",
+            "-cp",
+            "adi,ad9081",
+            "compatible",
+        ],
+    )
+    assert "adi,ad9081" in result.output, result.output
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_props_read_amba(booted):
+    """``adidtc props amba`` lists nodes under amba on the live board."""
+    _shell, ip = booted
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sysfs",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "props",
+            "amba",
+        ],
+    )
+    assert result.output.strip(), "props produced no output"
+
+
+# ---------------------------------------------------------------------------
+# --dry-run tests
+# ---------------------------------------------------------------------------
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_sd_remote_copy_dry_run(booted, tmp_path: Path):
+    """``adidtc sd-remote-copy --dry-run --show`` prints the planned scp; no copy."""
+    _shell, ip = booted
+    marker = tmp_path / "cli_dryrun_marker.txt"
+    marker.write_text("dryrun")
+
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sd",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "sd-remote-copy",
+            str(marker),
+            "--dry-run",
+            "--show",
+        ],
+    )
+    assert "scp" in result.output, result.output
+    assert marker.name in result.output
+
+    # Confirm via SFTP that the marker did NOT land on the SD root.
+    with Connection(
+        f"{KUIPER_USER}@{ip}:22", connect_kwargs={"password": KUIPER_PASSWORD}
+    ) as c:
+        mount = "/tmp/adidt_cli_dryrun_check"
+        c.run(f"mkdir -p {mount}", hide=True)
+        c.run(f"umount {mount}", hide=True, warn=True)
+        c.run("umount /dev/mmcblk0p1", hide=True, warn=True)
+        c.run(f"mount /dev/mmcblk0p1 {mount}", hide=True)
+        try:
+            present = c.run(
+                f"test -f {mount}/{marker.name}", hide=True, warn=True
+            ).return_code
+        finally:
+            c.run(f"umount {mount}", hide=True, warn=True)
+        assert present != 0, f"--dry-run unexpectedly copied {marker.name} to SD"
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_jif_clock_dry_run(booted, tmp_path: Path):
+    """``adidtc jif clock --dry-run`` prints planned dividers, writes nothing."""
+    _shell, ip = booted
+
+    # A minimal solver-style JSON; the exact divider values are
+    # irrelevant under --dry-run because update_current_dt is skipped.
+    solver = tmp_path / "solved.json"
+    solver.write_text(json.dumps({"out_dividers": [12, 12, 12, 12]}))
+
+    # jif is registered as a sub-group on the top-level cli; global
+    # options (-c/-i/-u/-w) must come before "jif", not after.
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sd",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "jif",
+            "clock",
+            "-f",
+            str(solver),
+            "--dry-run",
+        ],
+    )
+    assert "dry-run: no changes written." in result.output, result.output
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_sd_move_dry_run(booted):
+    """``adidtc sd-move <bogus> --dry-run --show`` runs without raising; SD untouched.
+
+    On stock Kuiper images the AD9081+ZCU102 SD card carries reference
+    designs that are listed by :meth:`adidt.sd.sd.update_existing_boot_files`
+    when invoked.  A bogus design name causes the helper to print the
+    available list and return cleanly (exit 0); ``--dry-run`` keeps
+    the SD untouched either way.
+    """
+    _shell, ip = booted
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sd",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "sd-move",
+            "definitely-not-a-real-design",
+            "--dry-run",
+            "--show",
+        ],
+    )
+    # Either we got the "design not found" listing or no-op success; in
+    # both cases exit 0 and no SD mutation.
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# Reboot tests (slow; invalidate the labgrid serial shell)
+# ---------------------------------------------------------------------------
+
+
+@requires_lg
+@pytest.mark.slow
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_sd_remote_copy_with_reboot(booted, tmp_path: Path):
+    """``sd-remote-copy --reboot`` lands the file and the board returns to SSH."""
+    _shell, ip = booted
+    marker = tmp_path / "adidt_cli_marker.txt"
+    marker.write_text("hello from the cli hw test")
+
+    with sd_marker_cleanup(ip, [marker.name]):
+        run_adidtc(
+            [
+                "-c",
+                "remote_sd",
+                "-i",
+                ip,
+                "-u",
+                KUIPER_USER,
+                "-w",
+                KUIPER_PASSWORD,
+                "sd-remote-copy",
+                str(marker),
+                "--reboot",
+            ],
+        )
+        wait_for_ssh(ip)
+
+        with Connection(
+            f"{KUIPER_USER}@{ip}:22",
+            connect_kwargs={"password": KUIPER_PASSWORD},
+        ) as c:
+            mount = "/tmp/adidt_cli_reboot_check"
+            c.run(f"mkdir -p {mount}", hide=True)
+            c.run(f"umount {mount}", hide=True, warn=True)
+            c.run("umount /dev/mmcblk0p1", hide=True, warn=True)
+            c.run(f"mount /dev/mmcblk0p1 {mount}", hide=True)
+            try:
+                landed = c.run(
+                    f"test -f {mount}/{marker.name}", hide=True, warn=True
+                ).return_code
+                contents = c.run(
+                    f"cat {mount}/{marker.name}", hide=True, warn=True
+                ).stdout
+            finally:
+                c.run(f"umount {mount}", hide=True, warn=True)
+            assert landed == 0, f"marker {marker.name} not present on SD post-reboot"
+            assert "hello from the cli hw test" in contents
+
+
+@requires_lg
+@pytest.mark.slow
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_prop_write_with_reboot(booted):
+    """Reserved for ``adidtc prop --reboot`` validation.
+
+    Skipped pending an SFTP-based backup helper for stock SD artifacts
+    (``system.dtb``).  The current ``sd_marker_cleanup`` only handles
+    test-created files; mutating ``system.dtb`` requires saving the
+    original to local disk before reboot (in-target ``/tmp`` is
+    tmpfs-backed and is wiped on reboot).
+    """
+    pytest.skip("prop --reboot needs SFTP backup of SD system.dtb; not yet implemented")
+
+
+@requires_lg
+@pytest.mark.slow
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_jif_clock_with_reboot(booted):
+    """Reserved for ``adidtc jif clock --reboot`` validation.
+
+    Same constraint as :func:`test_prop_write_with_reboot`: the jif
+    write path mutates ``system.dtb`` on the SD card, which would
+    require an SFTP-based backup helper to be safely reversible.
+    """
+    pytest.skip(
+        "jif clock --reboot needs SFTP backup of SD system.dtb; not yet implemented"
+    )
+
+
+@requires_lg
+@pytest.mark.slow
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_sd_move_with_reboot(booted):
+    """Reserved for ``adidtc sd-move --reboot`` validation.
+
+    Skipped because a meaningful test requires the SD to carry at
+    least two reference designs and a reliable way to restore the
+    original active design afterwards.  Lab-image-dependent.
+    """
+    pytest.skip("sd-move --reboot requires multi-design SD layout + safe restore")

--- a/test/hw/test_cli_live_ad9081_zcu102_hw.py
+++ b/test/hw/test_cli_live_ad9081_zcu102_hw.py
@@ -251,7 +251,7 @@ def test_sd_remote_copy_with_reboot(booted, tmp_path: Path):
                 "--reboot",
             ],
         )
-        wait_for_ssh(ip)
+        wait_for_ssh(ip, wait_for_down=True)
 
         with Connection(
             f"{KUIPER_USER}@{ip}:22",

--- a/test/hw/test_cli_live_adrv9009_zc706_hw.py
+++ b/test/hw/test_cli_live_adrv9009_zc706_hw.py
@@ -1,0 +1,290 @@
+"""Live-board ``adidtc`` hardware tests for ADRV9009 + ZC706.
+
+Mirrors :mod:`test.hw.test_cli_live_ad9081_zcu102_hw` for the
+Zynq-7000 + TFTP-boot path.  Boots through
+:mod:`test.hw.test_adrv9009_zc706_hw`'s SPEC, then exercises the
+hardware-touching CLI commands against the live target.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+from fabric import Connection
+
+from test.hw._cli_base import (
+    KUIPER_PASSWORD,
+    KUIPER_USER,
+    discover_board_ipv4,
+    run_adidtc,
+    sd_marker_cleanup,
+    wait_for_ssh,
+)
+from test.hw._system_base import requires_lg, run_xsa_boot_and_verify
+from test.hw.test_adrv9009_zc706_hw import SPEC as XSA_SPEC
+
+
+SPEC = dataclasses.replace(XSA_SPEC, out_label="adrv9009_cli_live")
+
+
+@pytest.fixture(scope="module")
+def booted(board, tmp_path_factory, request):
+    """Boot the board once per module; expose ``(shell, ip)`` to all tests."""
+    tmp_path = tmp_path_factory.mktemp("cli_live")
+    shell, _ctx, _dmesg = run_xsa_boot_and_verify(
+        SPEC, board=board, request=request, tmp_path=tmp_path
+    )
+    ip = discover_board_ipv4(shell)
+    print(f"booted board, SSH IP: {ip}")
+    yield shell, ip
+
+
+# ---------------------------------------------------------------------------
+# Read-only tests
+# ---------------------------------------------------------------------------
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_prop_read_compatible(booted):
+    """``adidtc prop -cp adi,adrv9009 compatible`` reads the live ADRV9009 node."""
+    _shell, ip = booted
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sysfs",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "prop",
+            "-cp",
+            "adi,adrv9009",
+            "compatible",
+        ],
+    )
+    assert "adi,adrv9009" in result.output, result.output
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_props_read_amba(booted):
+    """``adidtc props amba`` lists nodes under amba on the live board."""
+    _shell, ip = booted
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sysfs",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "props",
+            "amba",
+        ],
+    )
+    assert result.output.strip(), "props produced no output"
+
+
+# ---------------------------------------------------------------------------
+# --dry-run tests
+# ---------------------------------------------------------------------------
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_sd_remote_copy_dry_run(booted, tmp_path: Path):
+    """``adidtc sd-remote-copy --dry-run --show`` prints planned scp; no copy."""
+    _shell, ip = booted
+    marker = tmp_path / "cli_dryrun_marker.txt"
+    marker.write_text("dryrun")
+
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sd",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "sd-remote-copy",
+            str(marker),
+            "--dry-run",
+            "--show",
+        ],
+    )
+    assert "scp" in result.output, result.output
+    assert marker.name in result.output
+
+    with Connection(
+        f"{KUIPER_USER}@{ip}:22", connect_kwargs={"password": KUIPER_PASSWORD}
+    ) as c:
+        mount = "/tmp/adidt_cli_dryrun_check"
+        c.run(f"mkdir -p {mount}", hide=True)
+        c.run(f"umount {mount}", hide=True, warn=True)
+        c.run("umount /dev/mmcblk0p1", hide=True, warn=True)
+        c.run(f"mount /dev/mmcblk0p1 {mount}", hide=True)
+        try:
+            present = c.run(
+                f"test -f {mount}/{marker.name}", hide=True, warn=True
+            ).return_code
+        finally:
+            c.run(f"umount {mount}", hide=True, warn=True)
+        assert present != 0, f"--dry-run unexpectedly copied {marker.name} to SD"
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_jif_clock_dry_run(booted, tmp_path: Path):
+    """``adidtc jif clock --dry-run`` prints planned dividers, writes nothing."""
+    _shell, ip = booted
+
+    solver = tmp_path / "solved.json"
+    solver.write_text(json.dumps({"out_dividers": [12, 12, 12, 12]}))
+
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sd",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "jif",
+            "clock",
+            "-f",
+            str(solver),
+            "--dry-run",
+        ],
+    )
+    assert "dry-run: no changes written." in result.output, result.output
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_sd_move_dry_run(booted):
+    """``adidtc sd-move <bogus> --dry-run --show`` runs without raising; SD untouched."""
+    _shell, ip = booted
+    result = run_adidtc(
+        [
+            "-c",
+            "remote_sd",
+            "-i",
+            ip,
+            "-u",
+            KUIPER_USER,
+            "-w",
+            KUIPER_PASSWORD,
+            "sd-move",
+            "definitely-not-a-real-design",
+            "--dry-run",
+            "--show",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# Reboot tests (slow; invalidate the labgrid serial shell)
+# ---------------------------------------------------------------------------
+
+
+@requires_lg
+@pytest.mark.slow
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_sd_remote_copy_with_reboot(booted, tmp_path: Path):
+    """``sd-remote-copy --reboot`` lands the file and the board returns to SSH."""
+    _shell, ip = booted
+    marker = tmp_path / "adidt_cli_marker.txt"
+    marker.write_text("hello from the cli hw test")
+
+    with sd_marker_cleanup(ip, [marker.name]):
+        run_adidtc(
+            [
+                "-c",
+                "remote_sd",
+                "-i",
+                ip,
+                "-u",
+                KUIPER_USER,
+                "-w",
+                KUIPER_PASSWORD,
+                "sd-remote-copy",
+                str(marker),
+                "--reboot",
+            ],
+        )
+        wait_for_ssh(ip)
+
+        with Connection(
+            f"{KUIPER_USER}@{ip}:22",
+            connect_kwargs={"password": KUIPER_PASSWORD},
+        ) as c:
+            mount = "/tmp/adidt_cli_reboot_check"
+            c.run(f"mkdir -p {mount}", hide=True)
+            c.run(f"umount {mount}", hide=True, warn=True)
+            c.run("umount /dev/mmcblk0p1", hide=True, warn=True)
+            c.run(f"mount /dev/mmcblk0p1 {mount}", hide=True)
+            try:
+                landed = c.run(
+                    f"test -f {mount}/{marker.name}", hide=True, warn=True
+                ).return_code
+                contents = c.run(
+                    f"cat {mount}/{marker.name}", hide=True, warn=True
+                ).stdout
+            finally:
+                c.run(f"umount {mount}", hide=True, warn=True)
+            assert landed == 0, f"marker {marker.name} not present on SD post-reboot"
+            assert "hello from the cli hw test" in contents
+
+
+@requires_lg
+@pytest.mark.slow
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_prop_write_with_reboot(booted):
+    """Reserved for ``adidtc prop --reboot`` validation.
+
+    Skipped pending an SFTP-based backup helper for stock SD artifacts
+    (``devicetree.dtb`` on Zynq-7000).  In-target ``/tmp`` is
+    tmpfs-backed and is wiped on reboot.
+    """
+    pytest.skip(
+        "prop --reboot needs SFTP backup of SD devicetree.dtb; not yet implemented"
+    )
+
+
+@requires_lg
+@pytest.mark.slow
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_jif_clock_with_reboot(booted):
+    """Reserved for ``adidtc jif clock --reboot`` validation.
+
+    Same constraint as :func:`test_prop_write_with_reboot`.
+    """
+    pytest.skip(
+        "jif clock --reboot needs SFTP backup of SD devicetree.dtb; not yet implemented"
+    )
+
+
+@requires_lg
+@pytest.mark.slow
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_sd_move_with_reboot(booted):
+    """Reserved for ``adidtc sd-move --reboot`` validation.
+
+    Skipped because a meaningful test requires the SD to carry at
+    least two reference designs and a reliable way to restore the
+    original active design afterwards.  Lab-image-dependent.
+    """
+    pytest.skip("sd-move --reboot requires multi-design SD layout + safe restore")

--- a/test/hw/test_cli_live_adrv9009_zc706_hw.py
+++ b/test/hw/test_cli_live_adrv9009_zc706_hw.py
@@ -225,7 +225,7 @@ def test_sd_remote_copy_with_reboot(booted, tmp_path: Path):
                 "--reboot",
             ],
         )
-        wait_for_ssh(ip)
+        wait_for_ssh(ip, wait_for_down=True)
 
         with Connection(
             f"{KUIPER_USER}@{ip}:22",

--- a/test/hw/test_cli_mcp_ad9081_zcu102_hw.py
+++ b/test/hw/test_cli_mcp_ad9081_zcu102_hw.py
@@ -1,0 +1,76 @@
+"""``adidt-mcp`` end-to-end hardware test for AD9081 + ZCU102.
+
+Calls :func:`adidt.mcp_server.generate_devicetree` in-process — the
+same entry point the FastMCP server exposes to MCP clients — and
+boots the resulting merged DTS on real hardware.  Verifies the MCP
+path (separate from the ``adidtc`` Click CLI) produces a bootable
+artifact end-to-end.
+
+The other four MCP tools (``list_xsa_profiles``, ``show_xsa_profile``,
+``read_dt_property``, ``lint_devicetree``) are file-/local-only and
+have no hardware-dependent behavior; they are already covered by
+:mod:`test.test_mcp_server`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="fastmcp not installed")
+
+from test.hw._system_base import (
+    boot_and_verify_from_merged_dts,
+    requires_lg,
+)
+from test.hw.hw_helpers import DEFAULT_OUT_DIR
+from test.hw.test_ad9081_zcu102_xsa_hw import SPEC as XSA_SPEC
+
+
+SPEC = dataclasses.replace(XSA_SPEC, out_label="ad9081_cli_mcp")
+
+
+@requires_lg
+@pytest.mark.lg_feature(list(SPEC.lg_features))
+def test_mcp_generate_devicetree_produces_bootable_dtb(board, tmp_path: Path, request):
+    """``mcp_server.generate_devicetree`` -> merged DTS -> dtc -> boot + verify."""
+    from adidt.mcp_server import generate_devicetree
+
+    xsa_path = SPEC.xsa_resolver(tmp_path)
+    assert xsa_path.exists(), f"XSA not found: {xsa_path}"
+
+    output_dir = tmp_path / "mcp_out"
+    cfg_json = json.dumps(SPEC.cfg_builder())
+
+    data = generate_devicetree(
+        xsa_path=str(xsa_path),
+        output_dir=str(output_dir),
+        config_json=cfg_json,
+        profile=SPEC.sdtgen_profile,
+        sdtgen_timeout=SPEC.sdtgen_timeout,
+    )
+    assert "error" not in data, f"generate_devicetree returned error: {data!r}"
+    assert "merged" in data, f"no merged key in MCP result: {data!r}"
+
+    merged_dts = Path(data["merged"])
+    assert merged_dts.exists(), f"MCP-reported merged DTS missing: {merged_dts}"
+
+    merged_text = merged_dts.read_text()
+    for needle in SPEC.merged_dts_must_contain:
+        assert needle in merged_text, (
+            f"Required substring {needle!r} missing from MCP-produced DTS "
+            f"({merged_dts})"
+        )
+
+    boot_out = DEFAULT_OUT_DIR
+    boot_out.mkdir(parents=True, exist_ok=True)
+    boot_and_verify_from_merged_dts(
+        SPEC,
+        merged_dts,
+        board=board,
+        request=request,
+        out_dir=boot_out,
+    )


### PR DESCRIPTION
## Summary
- Adds end-to-end CLI hw tests for AD9081+ZCU102 and ADRV9009+ZC706 covering `xsa2dt`, `gen-dts`, `prop`/`props`, `sd-move`, `sd-remote-copy`, `jif clock`, and the `adidt-mcp` `generate_devicetree` entry point.
- New shared scaffolding at `test/hw/_cli_base.py` (CliRunner wrappers, IP discovery, SSH polling, SD-marker cleanup).
- Wires the AD9081+ZCU102 CLI tests into the existing `mini2` node in `.github/hw-nodes.json` so the Hardware Tests workflow exercises them; ADRV9009+ZC706 CI hookup is deferred until a lab place exists for that board.
- Registers a `slow` pytest marker so the reboot-heavy tests can be opted out via `-m "not slow"`.

## Test plan
- [x] `pytest -q` (default suite, hw excluded): 638 passed, 20 skipped, 4 xfailed
- [x] `nox -s lint` clean
- [x] `nox -s format -- --check` clean
- [x] `nox -s ty` clean
- [x] All six new modules import cleanly
- [x] `pytest --collect-only` discovers 12 tests across the new files
- [ ] Hardware Tests workflow on this PR (mini2 node) — verifying with this PR

## Notes
- Three reboot variants in the live test files (`test_prop_write_with_reboot`, `test_jif_clock_with_reboot`, `test_sd_move_with_reboot`) are scaffolded with `pytest.skip` and a clear reason; they need an SFTP-based local-disk backup helper for stock SD artifacts before they can run safely (in-target `/tmp` is tmpfs and is wiped on reboot).
- This branch deliberately excludes some unrelated `nox -s format` reformats and a `.gitignore` change present in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)