### PR TITLE
ci(hw): dynamic-mode hardware tests across coordinator hardware

### DIFF
--- a/.github/scripts/_prism_client.py
+++ b/.github/scripts/_prism_client.py
@@ -1,0 +1,190 @@
+"""Stdlib-only HTTP client for the Prism API.
+
+Shared by the other scripts in this directory (`seed_demo.py`,
+`upload_run.py`) so the login + CSRF + multipart dance lives in exactly
+one place. No external dependencies — works anywhere Python 3.10+ is
+installed (CI runners included).
+
+Session state (auth + CSRF cookies) is held in an in-memory cookie jar
+so all subsequent `self._request` calls automatically carry the login
+cookie and, for mutations, the `X-Prism-Csrf` header.
+"""
+
+from __future__ import annotations
+
+import http.cookiejar
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+__all__ = ["PrismClient"]
+
+
+class PrismClient:
+    def __init__(self, base_url: str) -> None:
+        # Reject non-http(s) schemes up front so the noqa: S310 below is true.
+        # urllib's default opener handles file://, ftp://, data://, etc., which
+        # an attacker who can set PRISM_URL could abuse for local-file
+        # disclosure / SSRF. See ruff S310. This guard must mirror the one in
+        # clients/python-pytest/src/pytest_prism/client.py since this file is
+        # the vendoring source for pyadi-iio's prism-report plugin.
+        scheme = urllib.parse.urlsplit(base_url).scheme.lower()
+        if scheme not in ("http", "https"):
+            raise ValueError(
+                f"PrismClient base_url must be http or https; got scheme {scheme!r}"
+            )
+        self.base_url = base_url.rstrip("/")
+        self.jar = http.cookiejar.CookieJar()
+        self.opener = urllib.request.build_opener(
+            urllib.request.HTTPCookieProcessor(self.jar)
+        )
+
+    # --------------------------------------------------------------------- #
+    # Low-level request plumbing
+    # --------------------------------------------------------------------- #
+
+    def _read_cookie(self, name: str) -> str | None:
+        for c in self.jar:
+            if c.name == name:
+                return c.value
+        return None
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, bytes]:
+        url = f"{self.base_url}{path}"
+        # base_url's scheme is validated to http/https in __init__, so this is safe.
+        req = urllib.request.Request(
+            url, data=body, method=method, headers=headers or {}
+        )  # noqa: S310
+        csrf = self._read_cookie("prism_csrf")
+        if csrf and method in ("POST", "PUT", "PATCH", "DELETE"):
+            req.add_header("X-Prism-Csrf", csrf)
+        try:
+            with self.opener.open(req) as resp:
+                return resp.status, resp.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read()
+
+    # --------------------------------------------------------------------- #
+    # Auth
+    # --------------------------------------------------------------------- #
+
+    def login(self, email: str, password: str) -> None:
+        payload = json.dumps({"email": email, "password": password}).encode("utf-8")
+        code, body = self._request(
+            "POST",
+            "/api/v1/auth/login",
+            body=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if code != 200:
+            raise RuntimeError(f"login failed: HTTP {code} {body!r}")
+
+    # --------------------------------------------------------------------- #
+    # Projects
+    # --------------------------------------------------------------------- #
+
+    def ensure_project(self, slug: str, name: str, description: str = "") -> None:
+        """Create the project if it doesn't exist. 409 (already exists) is fine."""
+        payload = json.dumps(
+            {"slug": slug, "name": name, "description": description}
+        ).encode("utf-8")
+        code, body = self._request(
+            "POST",
+            "/api/v1/projects",
+            body=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if code not in (201, 409):
+            raise RuntimeError(f"project create failed: HTTP {code} {body!r}")
+
+    def project_exists(self, slug: str) -> bool:
+        code, _ = self._request("GET", f"/api/v1/projects/{urllib.parse.quote(slug)}")
+        return code == 200
+
+    # --------------------------------------------------------------------- #
+    # Runs
+    # --------------------------------------------------------------------- #
+
+    def list_runs(self, project_slug: str) -> list[dict[str, object]]:
+        code, body = self._request(
+            "GET", f"/api/v1/runs?project={urllib.parse.quote(project_slug)}"
+        )
+        if code != 200:
+            raise RuntimeError(f"list runs failed: HTTP {code} {body!r}")
+        result: list[dict[str, object]] = json.loads(body)
+        return result
+
+    def get_run(self, run_id: str) -> dict[str, object]:
+        code, body = self._request("GET", f"/api/v1/runs/{urllib.parse.quote(run_id)}")
+        if code != 200:
+            raise RuntimeError(f"get run failed: HTTP {code} {body!r}")
+        result: dict[str, object] = json.loads(body)
+        return result
+
+    def delete_run(self, run_id: str) -> None:
+        code, body = self._request(
+            "DELETE", f"/api/v1/runs/{urllib.parse.quote(run_id)}"
+        )
+        if code not in (204, 404):
+            raise RuntimeError(f"delete run failed: HTTP {code} {body!r}")
+
+    def upload_run(
+        self,
+        *,
+        project_slug: str,
+        run_name: str,
+        junit_xml: bytes,
+        archive_zip: bytes | None = None,
+        tags: dict[str, str] | None = None,
+    ) -> dict[str, object]:
+        """POST /api/v1/runs with a hand-built multipart body.
+
+        Returns the parsed JSON response (includes run `id` + initial `status`).
+        Raises RuntimeError on any non-201.
+        """
+        boundary = f"----prism{uuid.uuid4().hex}"
+        parts: list[bytes] = []
+
+        def _add_field(name: str, value: str) -> None:
+            parts.append(f"--{boundary}\r\n".encode())
+            parts.append(
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode()
+            )
+            parts.append(value.encode("utf-8"))
+            parts.append(b"\r\n")
+
+        def _add_file(
+            name: str, filename: str, content_type: str, content: bytes
+        ) -> None:
+            parts.append(f"--{boundary}\r\n".encode())
+            parts.append(
+                f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode()
+            )
+            parts.append(f"Content-Type: {content_type}\r\n\r\n".encode())
+            parts.append(content)
+            parts.append(b"\r\n")
+
+        metadata = {"project_slug": project_slug, "name": run_name, "tags": tags or {}}
+        _add_field("metadata", json.dumps(metadata))
+        _add_file("junit", "junit.xml", "application/xml", junit_xml)
+        if archive_zip is not None:
+            _add_file("archive", "archive.zip", "application/zip", archive_zip)
+        parts.append(f"--{boundary}--\r\n".encode())
+        body = b"".join(parts)
+        headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+        code, resp_body = self._request(
+            "POST", "/api/v1/runs", body=body, headers=headers
+        )
+        if code != 201:
+            raise RuntimeError(f"upload {run_name!r} failed: HTTP {code} {resp_body!r}")
+        result: dict[str, object] = json.loads(resp_body)
+        return result

--- a/.github/scripts/prism_upload_run.py
+++ b/.github/scripts/prism_upload_run.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Upload a pytest JUnit XML result to a Prism server.
+
+Typical use from CI:
+
+    python3 scripts/upload_run.py results.xml \\
+      --project my-service --run-name "$CI_JOB_ID" \\
+      --tag branch=$GIT_BRANCH --tag sha=$GIT_SHA --wait
+
+All `--foo` flags fall back to `PRISM_FOO`-style environment variables,
+so a hardened CI pipeline can skip the command-line switches entirely:
+
+    PRISM_URL=...  PRISM_EMAIL=...  PRISM_PASSWORD=...  \\
+    PRISM_PROJECT=my-service  PRISM_RUN_NAME="$CI_JOB_ID"  \\
+      python3 scripts/upload_run.py results.xml
+
+Exit codes:
+  0  success
+  2  bad argument or input file not found
+  3  authentication failed
+  4  project not found (pass --auto-create-project to create it)
+  5  upload failed (HTTP error from the server)
+  6  --wait timed out before ingest finished
+
+Stdlib-only — works on any CI runner with Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+# The shared client lives next to this file; use a path-relative import so the
+# script works when invoked from anywhere (e.g. `python3 /repo/scripts/...`).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _prism_client import PrismClient  # noqa: E402  (import after sys.path tweak)
+
+EXIT_OK = 0
+EXIT_BAD_INPUT = 2
+EXIT_AUTH = 3
+EXIT_NO_PROJECT = 4
+EXIT_UPLOAD = 5
+EXIT_WAIT_TIMEOUT = 6
+
+
+def _parse_tag(raw: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise argparse.ArgumentTypeError(f"--tag expects key=value, got {raw!r}")
+    k, v = raw.split("=", 1)
+    k = k.strip()
+    v = v.strip()
+    if not k:
+        raise argparse.ArgumentTypeError(f"--tag key is empty in {raw!r}")
+    return k, v
+
+
+def _env(name: str, default: str | None = None) -> str | None:
+    v = os.environ.get(name)
+    return v if v else default
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="upload_run.py",
+        description="Upload a pytest JUnit XML to Prism.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Each --foo flag also accepts a PRISM_FOO environment variable "
+            "(e.g. PRISM_URL, PRISM_EMAIL, PRISM_PROJECT, PRISM_RUN_NAME)."
+        ),
+    )
+    p.add_argument("junit", type=Path, help="Path to the JUnit XML file.")
+    p.add_argument(
+        "--url",
+        default=_env("PRISM_URL", "http://localhost:8000"),
+        help="Prism API base URL (env: PRISM_URL).",
+    )
+    p.add_argument(
+        "--email", default=_env("PRISM_EMAIL"), help="Login email (env: PRISM_EMAIL)."
+    )
+    p.add_argument(
+        "--password",
+        default=_env("PRISM_PASSWORD"),
+        help="Login password (env: PRISM_PASSWORD).",
+    )
+    p.add_argument(
+        "--project",
+        default=_env("PRISM_PROJECT"),
+        help="Target project slug (env: PRISM_PROJECT).",
+    )
+    p.add_argument(
+        "--run-name",
+        dest="run_name",
+        default=_env("PRISM_RUN_NAME"),
+        help="Name for this Test Suite Run (env: PRISM_RUN_NAME).",
+    )
+    p.add_argument(
+        "--tag",
+        action="append",
+        type=_parse_tag,
+        default=[],
+        metavar="key=value",
+        help="Repeatable. Arbitrary tag on the run (branch=main, sha=abc123).",
+    )
+    p.add_argument(
+        "--archive",
+        type=Path,
+        default=None,
+        help="Optional .zip of measurement artifacts to upload alongside the JUnit.",
+    )
+    p.add_argument(
+        "--auto-create-project",
+        action="store_true",
+        help="Create the target project if it doesn't exist.",
+    )
+    p.add_argument(
+        "--wait",
+        nargs="?",
+        type=int,
+        const=60,
+        default=None,
+        metavar="SECONDS",
+        help="After upload, poll every 2s until the run is no longer "
+        "pending. Bare flag uses a 60s timeout; pass a value for longer.",
+    )
+    verbosity = p.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Only print the final result line; errors still go to stderr.",
+    )
+    verbosity.add_argument(
+        "--verbose", "-v", action="store_true", help="Print each step to stdout."
+    )
+    return p
+
+
+def _require(args: argparse.Namespace, name: str, env: str) -> str | None:
+    val: str | None = getattr(args, name, None)
+    if not val:
+        print(
+            f"error: --{name.replace('_', '-')} is required (or set {env})",
+            file=sys.stderr,
+        )
+        return None
+    return val
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # --- Validate required args ------------------------------------------- #
+    missing = []
+    for attr, env in (
+        ("email", "PRISM_EMAIL"),
+        ("password", "PRISM_PASSWORD"),
+        ("project", "PRISM_PROJECT"),
+        ("run_name", "PRISM_RUN_NAME"),
+    ):
+        if not getattr(args, attr, None):
+            missing.append(f"--{attr.replace('_', '-')} (or {env})")
+    if missing:
+        print(
+            "error: missing required argument(s): " + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return EXIT_BAD_INPUT
+
+    if not args.junit.exists() or not args.junit.is_file():
+        print(f"error: JUnit file not found: {args.junit}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+    if args.archive is not None and (
+        not args.archive.exists() or not args.archive.is_file()
+    ):
+        print(f"error: archive file not found: {args.archive}", file=sys.stderr)
+        return EXIT_BAD_INPUT
+
+    say = (lambda _m: None) if args.quiet else print
+
+    # --- Auth ------------------------------------------------------------- #
+    client = PrismClient(args.url)
+    if args.verbose:
+        say(f"→ logging in to {args.url} as {args.email}")
+    try:
+        client.login(args.email, args.password)
+    except RuntimeError as exc:
+        print(f"error: authentication failed — {exc}", file=sys.stderr)
+        return EXIT_AUTH
+
+    # --- Project ---------------------------------------------------------- #
+    if args.auto_create_project:
+        client.ensure_project(
+            args.project, args.project, description="Auto-created by upload_run.py"
+        )
+    elif not client.project_exists(args.project):
+        print(
+            f"error: project {args.project!r} not found. "
+            "Pass --auto-create-project to create it, or create it in the UI first.",
+            file=sys.stderr,
+        )
+        return EXIT_NO_PROJECT
+
+    # --- Read payloads ---------------------------------------------------- #
+    junit_bytes = args.junit.read_bytes()
+    archive_bytes = args.archive.read_bytes() if args.archive is not None else None
+    tags = dict(args.tag)
+
+    if args.verbose:
+        say(
+            f"→ uploading {args.junit.name} ({len(junit_bytes)} bytes) "
+            f"as run {args.run_name!r} in project {args.project!r}"
+            + (
+                f" with archive {args.archive.name} ({len(archive_bytes or b'')} bytes)"
+                if archive_bytes
+                else ""
+            )
+        )
+
+    # --- Upload ----------------------------------------------------------- #
+    try:
+        result = client.upload_run(
+            project_slug=args.project,
+            run_name=args.run_name,
+            junit_xml=junit_bytes,
+            archive_zip=archive_bytes,
+            tags=tags,
+        )
+    except RuntimeError as exc:
+        print(f"error: upload failed — {exc}", file=sys.stderr)
+        return EXIT_UPLOAD
+
+    run_id: str = str(result["id"])
+    status: str = str(result.get("status", "pending"))
+
+    # --- Optional wait-for-ingest ---------------------------------------- #
+    if args.wait is not None:
+        if args.verbose:
+            say(f"→ waiting up to {args.wait}s for ingest to finish …")
+        deadline = time.monotonic() + args.wait
+        while status == "pending":
+            if time.monotonic() >= deadline:
+                print(
+                    f"warning: timed out after {args.wait}s; run {run_id} is still pending",
+                    file=sys.stderr,
+                )
+                # Still print the normal success line so CI can capture the ID.
+                print(f"uploaded {args.run_name} (id={run_id}, status=pending)")
+                return EXIT_WAIT_TIMEOUT
+            time.sleep(2)
+            try:
+                detail = client.get_run(run_id)
+            except RuntimeError as exc:
+                print(f"warning: could not poll run status — {exc}", file=sys.stderr)
+                break
+            status = str(detail.get("status", status))
+
+    print(f"uploaded {args.run_name} (id={run_id}, status={status})")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/supported-boards.yml
+++ b/.github/supported-boards.yml
@@ -1,0 +1,8 @@
+# Boards (coordinator `daughter-board` tag) pyadi-dt runs HW tests against.
+# Dynamic-mode hw-matrix discovers coordinator places and keeps those whose
+# daughter-board is listed here. Each maps to test/hw/*<board>*<carrier>*_hw.py.
+boards:
+  - ad9081
+  - adrv9371
+  - adrv9009
+  - daq3

--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -1,32 +1,54 @@
 name: Hardware Tests
 
+# Triggered by:
+#   * workflow_dispatch (manual)
+#   * push to `main` — validate hardware on every landed change
+#   * PRs labeled `hw-test` — keeps every push from burning lab time
+#   * Nightly cron at 08:00 UTC
+#
+# Dynamic mode: the matrix is discovered from the coordinator at preflight
+# and gated by .github/supported-boards.yml; one leg per matching place. The
+# reusable workflow lives in tfcollins/labgrid-plugins (hw-matrix.yml).
+
 permissions:
   contents: read
   checks: write
   pull-requests: write
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
-  workflow_dispatch:
-
-concurrency:
-  group: hw-${{ github.ref }}
-  cancel-in-progress: false
+    types: [labeled, opened, synchronize, reopened]
+  schedule:
+    - cron: "0 8 * * *"
 
 jobs:
-  hw:
-    # Thin caller; the real workflow lives in tfcollins/labgrid-plugins.
-    # See its docs/source/user-guide/hw-ci.md for the contract.
-    # Rollback path: rename hardware-test.legacy.yml.disabled back to .yml
-    # and disable this file.
-    uses: tfcollins/labgrid-plugins/.github/workflows/hw-matrix.yml@v1
+  hardware:
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'hw-test')
+    uses: tfcollins/labgrid-plugins/.github/workflows/hw-matrix.yml@main
     with:
-      manifest_path: .github/hw-nodes.json
+      dynamic_mode: true
+      # nuc has no `runner` tag on the coordinator; default its leg to the
+      # hw-nuc runner (the nuc lab host has git creds + the board) rather than
+      # the hw-coordinator runner on lbvm, which can't fetch private git deps.
+      dynamic_runner_label_default: hw-nuc
+      supported_boards_path: .github/supported-boards.yml
       venv_install_cmd: 'bash .github/scripts/install-adidt-venv.sh'
       venv_dir: $HOME/.cache/adidt-ci/adidt-venv
+      # Dynamic mode exports $BOARD + $CARRIER (no manifest test list). Select
+      # this place's HW tests by filename convention test/hw/*<board>*<carrier>*_hw.py
+      # (e.g. daq3 matches fmcdaq3_vcu118), excluding the slow petalinux builds.
+      # The labgrid pytest plugin reads LG_ENV / LG_COORDINATOR from the env.
       pytest_cmd_template: >-
+        set -euo pipefail;
+        export PATH="$HOME/.local/bin:$PATH";
+        TESTS=$(ls test/hw/*"$BOARD"*"$CARRIER"*_hw.py 2>/dev/null | grep -v petalinux | tr '\n' ' ');
+        if [ -z "$TESTS" ]; then echo "::warning::no pyadi-dt HW tests for board=$BOARD carrier=$CARRIER"; exit 0; fi;
+        echo "Selected: $TESTS" >&2;
         "$VENV_DIR/bin/pytest" -p no:genalyzer -v -s $TESTS --junitxml="$JUNIT"
       artifact_glob: |
         test/hw/output/**/*.dts
@@ -38,4 +60,24 @@ jobs:
         uart_log_*.txt
         junit-hw-*.xml
       prism_project: pyadi-dt
-    secrets: inherit
+      prism_upload: ${{ vars.PRISM_UPLOAD_ENABLED == 'true' }}
+      # Vendored tfcollins/prism uploader (private repo; can't pip-install on
+      # the runner). The reusable workflow exports PRISM_URL/EMAIL/PASSWORD/
+      # PROJECT/JUNIT/RUN_NAME/BOARD/CARRIER/PLACE.
+      prism_upload_cmd: >-
+        python3 .github/scripts/prism_upload_run.py "$PRISM_JUNIT"
+        --url "$PRISM_URL" --project "$PRISM_PROJECT" --run-name "$PRISM_RUN_NAME"
+        --auto-create-project
+        --tag "board=$PRISM_BOARD" --tag "carrier=$PRISM_CARRIER"
+        --tag "place=$PRISM_PLACE" --tag "sha=$GITHUB_SHA"
+    # Pass Prism creds explicitly: secrets: inherit does not cross orgs
+    # (this repo is analogdevicesinc; the reusable workflow is tfcollins).
+    secrets:
+      PRISM_EMAIL: ${{ secrets.PRISM_EMAIL }}
+      PRISM_PASSWORD: ${{ secrets.PRISM_PASSWORD }}
+      # Injected as a github.com `insteadOf` credential during venv install so
+      # the credential-less hosts (nuc, lbvm) can clone the private pyadi-build /
+      # labgrid-plugins deps. MUST be a valid PAT — an expired/invalid token's
+      # insteadOf clobbers the working git creds on hosts that have their own
+      # (mini2/bq/nemo), reddening every leg.
+      PYADI_BUILD_TOKEN: ${{ secrets.PYADI_BUILD_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dev = [
     "adidt[test]",
     "adi-labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git",
     "pyadi-build @ git+https://github.com/tfcollins/pyadi-build.git",
-    "pytest-prism @ git+https://github.com/analogdevicesinc/prism.git#subdirectory=clients/python-pytest",
     "usbsdmux",
 ]
 mcp = ["fastmcp"]

--- a/test/hw/test_cli_live_adrv9009_zc706_hw.py
+++ b/test/hw/test_cli_live_adrv9009_zc706_hw.py
@@ -203,8 +203,18 @@ def test_sd_move_dry_run(booted):
 @requires_lg
 @pytest.mark.slow
 @pytest.mark.lg_feature(list(SPEC.lg_features))
-def test_sd_remote_copy_with_reboot(booted, tmp_path: Path):
+def test_sd_remote_copy_with_reboot(booted, board, tmp_path: Path):
     """``sd-remote-copy --reboot`` lands the file and the board returns to SSH."""
+    # A board whose boot-mode strap is set to JTAG (e.g. the nemo ZC706,
+    # booted via BootZynq7000JTAGRecovery) cannot recover from an OS reboot
+    # on its own: the boot ROM re-reads the JTAG strap and waits for a JTAG
+    # load that this test never performs, so SSH never returns. Autonomous
+    # reboot recovery is only meaningful on SD/QSPI-strapped boards.
+    if "JTAG" in type(board).__name__:
+        pytest.skip(
+            "board boots via JTAG bootstrap; OS reboot does not self-recover"
+            f" ({type(board).__name__})"
+        )
     _shell, ip = booted
     marker = tmp_path / "adidt_cli_marker.txt"
     marker.write_text("hello from the cli hw test")

--- a/test/hw/test_fmcdaq3_vcu118_hw.py
+++ b/test/hw/test_fmcdaq3_vcu118_hw.py
@@ -43,7 +43,7 @@ from test.hw.hw_helpers import (  # noqa: E402
 )
 
 
-@pytest.mark.lg_feature(["fmcdaq3", "vcu118"])
+@pytest.mark.lg_feature(["daq3", "vcu118"])
 def test_fmcdaq3_vcu118_boot_hw(board):
     """Boot FMCDAQ3+VCU118 with the prebuilt Kuiper image and verify IIO."""
     out_dir = DEFAULT_OUT_DIR


### PR DESCRIPTION
## Summary
Bring pyadi-dt's hardware CI up to pyadi-iio's dynamic-mode design.

- `hardware-test.yml`: static manifest `@v1` -> `dynamic_mode` on `hw-matrix@main`. Matrix is discovered from the coordinator, gated by `.github/supported-boards.yml` (ad9081/adrv9371/adrv9009/daq3), legs named by board/carrier. Per-leg test selection by `test/hw/*<board>*<carrier>*_hw.py` (excludes slow petalinux). nuc defaults to the `hw-nuc` runner.
- Relies on labgrid-plugins #30 (env_gen emits `features:[board,carrier]` so `lg_feature`-gated tests are selected; `$CARRIER` exported to the dynamic step).
- Vendored `tfcollins/prism` uploader + `prism_upload_cmd` (+ explicit Prism creds, cross-org).
- Align `test_fmcdaq3` `lg_feature` to the coordinator's `daq3` tag.
- Drop unused `pytest-prism` dep (private repo blocked the runner venv install).

## Verification
Dynamic discovery + board/carrier legs + runners confirmed across all 4 coordinator places. Passing: ad9081/zcu102, adrv9371/zc706. Follow-ups (host setup, not workflow): nemo needs `u-boot-tools` (mkimage) installed.