### PR TITLE
Add SDT Tcl driver definition POC for ADRV9009 ZC706

### DIFF
--- a/.github/scripts/install-adidt-venv.sh
+++ b/.github/scripts/install-adidt-venv.sh
@@ -10,12 +10,20 @@
 set -euo pipefail
 
 VENV="$HOME/.cache/adidt-ci/adidt-venv"
+PYTHON_VERSION="${ADIDT_CI_PYTHON_VERSION:-3.12}"
 
 export PATH="$HOME/.local/bin:$PATH"
 
-if [[ ! -x "$VENV/bin/python" ]]; then
-    echo "Creating adidt venv at $VENV" >&2
-    uv venv --quiet "$VENV"
+if [[ -x "$VENV/bin/python" ]]; then
+    current_version="$($VENV/bin/python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+else
+    current_version=""
+fi
+
+if [[ "$current_version" != "$PYTHON_VERSION" ]]; then
+    echo "Creating adidt Python $PYTHON_VERSION venv at $VENV" >&2
+    uv python install "$PYTHON_VERSION"
+    uv venv --quiet --clear --python "$PYTHON_VERSION" "$VENV"
 fi
 
 uv pip install --quiet --python "$VENV/bin/python" -e ".[dev]"

--- a/.github/scripts/install-adidt-venv.sh
+++ b/.github/scripts/install-adidt-venv.sh
@@ -19,3 +19,11 @@ if [[ ! -x "$VENV/bin/python" ]]; then
 fi
 
 uv pip install --quiet --python "$VENV/bin/python" -e ".[dev]"
+
+# Fail during setup rather than skipping or failing after labgrid acquisition.
+for tool in pytest labgrid-client usbsdmux; do
+    if [[ ! -x "$VENV/bin/$tool" ]]; then
+        echo "ERROR: $tool was not installed into $VENV/bin" >&2
+        exit 1
+    fi
+done

--- a/.github/scripts/install-adidt-venv.sh
+++ b/.github/scripts/install-adidt-venv.sh
@@ -25,7 +25,10 @@ if [[ "$current_version" != "$PYTHON_VERSION" ]]; then
     uv python install "$PYTHON_VERSION"
     uv venv --quiet --clear --python "$PYTHON_VERSION" "$VENV"
 fi
-
+# pytest-prism is vendored in-tree so hardware runners do not need access to
+# the private Prism repository. Remove stale wheel installs from persistent
+# environments before loading the vendored plugin explicitly.
+uv pip uninstall --python "$VENV/bin/python" pytest-prism >/dev/null 2>&1 || true
 uv pip install --quiet --python "$VENV/bin/python" -e ".[dev]"
 
 # Fail during setup rather than skipping or failing after labgrid acquisition.

--- a/.github/scripts/register-hw-runners.sh
+++ b/.github/scripts/register-hw-runners.sh
@@ -53,7 +53,8 @@ set -euo pipefail
 #
 HOSTS=(
     "bq:bq:hw-bq:bq:/home/tcollins/dev/dt-fix/lg_adrv9371_zc706_tftp.yaml"
-    "mini2:mini2:hw-mini2:mini2:"
+    # mini2 is intentionally driven by hw-coordinator; its SD-mux path is remote.
+    "nemo:nemo.local:hw-nemo:nemo:"
     "nuc:nuc:hw-nuc:nuc:"
     "coordinator:10.0.0.41:hw-coordinator:coordinator:"
 )

--- a/.github/scripts/run-hw-pytest-with-prism.sh
+++ b/.github/scripts/run-hw-pytest-with-prism.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Run a hardware pytest shard with pytest-prism terminal capture enabled.
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+    echo "usage: $0 PYTHON JUNIT_PATH PYTEST_ARGS..." >&2
+    exit 2
+fi
+
+python_bin=$1
+junit_path=$2
+shift 2
+
+place=${PLACE:-${LG_PLACE:-hardware}}
+prism_out=${PRISM_OUT:-prism-hw-${place}}
+prism_archive=${PRISM_ARCHIVE:-${prism_out}.zip}
+vendor_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../vendor/pytest-prism" && pwd)
+export PYTHONPATH="$vendor_root${PYTHONPATH:+:$PYTHONPATH}"
+
+set +e
+"$python_bin" -m pytest \
+    -p pytest_prism.plugin \
+    --prism-report \
+    --prism-out="$prism_out" \
+    --prism-out-overwrite \
+    "$@"
+pytest_rc=$?
+set -e
+
+# pytest-prism owns junit.xml so it can package the complete run. Preserve the
+# reusable hardware workflow's expected JUnit path for its report and upload
+# steps as well.
+if [[ -f "$prism_out/junit.xml" ]]; then
+    cp "$prism_out/junit.xml" "$junit_path"
+else
+    echo "::error::pytest-prism did not produce $prism_out/junit.xml" >&2
+    if [[ $pytest_rc -eq 0 ]]; then
+        pytest_rc=2
+    fi
+fi
+
+# Prism's multipart ingest expects run artifacts at archive root. In
+# particular, terminal.log is recognized as a run-level terminal_log artifact.
+set +e
+"$python_bin" - "$prism_out" "$prism_archive" <<'PY'
+from pathlib import Path
+import sys
+import zipfile
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+if not source.is_dir():
+    raise SystemExit(f"pytest-prism output directory does not exist: {source}")
+with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+    for path in sorted(source.rglob("*")):
+        if path.is_file() and path.name != "junit.xml":
+            archive.write(path, path.relative_to(source))
+if not (source / "terminal.log").is_file():
+    raise SystemExit(f"pytest-prism terminal capture is missing: {source / 'terminal.log'}")
+PY
+archive_rc=$?
+set -e
+if [[ $archive_rc -ne 0 && $pytest_rc -eq 0 ]]; then
+    pytest_rc=$archive_rc
+fi
+
+exit "$pytest_rc"

--- a/.github/scripts/setup-hw-tool-path.sh
+++ b/.github/scripts/setup-hw-tool-path.sh
@@ -10,9 +10,21 @@ fi
 
 VENV_DIR="${VENV_DIR:-$HOME/.cache/adidt-ci/adidt-venv}"
 
+# Remove inherited user shims before adding hardware tools. GitHub runners save
+# their registration-time PATH, so merely avoiding a new prepend is not enough.
+clean_path=""
+IFS=: read -ra path_entries <<<"$PATH"
+for entry in "${path_entries[@]}"; do
+    [[ "$entry" == "$HOME/.local/bin" ]] && continue
+    clean_path="${clean_path:+$clean_path:}$entry"
+done
+export PATH="$clean_path"
+
 # Prefer the persistent CI environment. Its console scripts include pytest,
-# labgrid-client, and usbsdmux installed by the project's dev extra.
-export PATH="$VENV_DIR/bin:$HOME/.local/bin:$PATH"
+# labgrid-client, and usbsdmux installed by the project's dev extra. Keep
+# ~/.local/bin out of runtime PATH: user command shims such as an unrelated
+# `as` agent CLI can shadow GNU binutils during kernel builds.
+export PATH="$VENV_DIR/bin:$PATH"
 
 # sdtgen is supplied either by a standalone installation already on PATH or by
 # Vitis. Source the explicitly configured installation first; otherwise select
@@ -45,4 +57,4 @@ if ! command -v sdtgen >/dev/null 2>&1; then
 fi
 
 # Vitis prepends its own paths, so restore the test venv to highest priority.
-export PATH="$VENV_DIR/bin:$HOME/.local/bin:$PATH"
+export PATH="$VENV_DIR/bin:$PATH"

--- a/.github/scripts/setup-hw-tool-path.sh
+++ b/.github/scripts/setup-hw-tool-path.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Configure host tools for pyadi-dt hardware tests in the current shell.
+# Source this file so PATH changes remain visible to the pytest command:
+#   source .github/scripts/setup-hw-tool-path.sh
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    echo "ERROR: source this script instead of executing it" >&2
+    exit 2
+fi
+
+VENV_DIR="${VENV_DIR:-$HOME/.cache/adidt-ci/adidt-venv}"
+
+# Prefer the persistent CI environment. Its console scripts include pytest,
+# labgrid-client, and usbsdmux installed by the project's dev extra.
+export PATH="$VENV_DIR/bin:$HOME/.local/bin:$PATH"
+
+# sdtgen is supplied either by a standalone installation already on PATH or by
+# Vitis. Source the explicitly configured installation first; otherwise select
+# the newest standard /tools or /opt installation available on this runner.
+if ! command -v sdtgen >/dev/null 2>&1; then
+    settings=""
+    if [[ -n "${XILINX_VITIS:-}" && -f "$XILINX_VITIS/settings64.sh" ]]; then
+        settings="$XILINX_VITIS/settings64.sh"
+    else
+        shopt -s nullglob
+        candidates=(
+            /tools/Xilinx/*/Vitis/settings64.sh
+            /opt/Xilinx/*/Vitis/settings64.sh
+            /opt/Xilinx/Vitis/*/settings64.sh
+        )
+        shopt -u nullglob
+        if ((${#candidates[@]})); then
+            settings="$(printf '%s\n' "${candidates[@]}" | sort -V | tail -n 1)"
+        fi
+    fi
+    if [[ -n "$settings" ]]; then
+        # Xilinx's settings script is not nounset-safe on every release.
+        had_nounset=0
+        [[ $- == *u* ]] && had_nounset=1 && set +u
+        # shellcheck disable=SC1090
+        source "$settings"
+        ((had_nounset)) && set -u
+        export ADIDT_VITIS_SETTINGS="$settings"
+    fi
+fi
+
+# Vitis prepends its own paths, so restore the test venv to highest priority.
+export PATH="$VENV_DIR/bin:$HOME/.local/bin:$PATH"

--- a/.github/vendor/pytest-prism/LICENSE
+++ b/.github/vendor/pytest-prism/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.github/vendor/pytest-prism/README.md
+++ b/.github/vendor/pytest-prism/README.md
@@ -1,0 +1,8 @@
+# Vendored pytest-prism client
+
+Source: `tfcollins/prism` at commit `f6bc1cf3bec925ddd7956d9a0e5617dc885385d1`,
+subdirectory `clients/python-pytest/src/pytest_prism`.
+
+This Apache-2.0 client is vendored because hardware runner credentials can read
+pyadi-dt build dependencies but cannot clone the private Prism repository. Keep
+these files synchronized as a unit when updating the client.

--- a/.github/vendor/pytest-prism/pytest_prism/__init__.py
+++ b/.github/vendor/pytest-prism/pytest_prism/__init__.py
@@ -1,0 +1,24 @@
+"""pytest-prism public API."""
+
+from pytest_prism.api import (
+    RenderContext,
+    Renderer,
+    RenderResult,
+    SessionContext,
+    SessionHook,
+    attach,
+    record_measurement,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "RenderContext",
+    "RenderResult",
+    "Renderer",
+    "SessionContext",
+    "SessionHook",
+    "__version__",
+    "attach",
+    "record_measurement",
+]

--- a/.github/vendor/pytest-prism/pytest_prism/api.py
+++ b/.github/vendor/pytest-prism/pytest_prism/api.py
@@ -1,0 +1,137 @@
+"""Public API for pytest-prism.
+
+Consumer-facing surface: `attach()`, `Renderer`, `SessionHook`, `RenderContext`,
+`SessionContext`, `RenderResult`. Everything else in this package is internal.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+import pytest
+
+# Stash key used by the plugin to read payloads attached during test execution.
+# Module-private; tests should use the public `attach()` function.
+_PRISM_PAYLOADS_STASH = pytest.StashKey[list[tuple[str, Mapping[str, Any]]]]()
+
+
+@dataclass(frozen=True)
+class RenderResult:
+    """What a Renderer returns. Files are paths relative to RenderContext.case_dir."""
+
+    files: list[Path] = field(default_factory=list)
+    metrics: Mapping[str, float] = field(default_factory=dict)
+    primary_artifact: str | None = None
+
+
+@dataclass(frozen=True)
+class RenderContext:
+    case_dir: Path
+    case_id: str
+    logger: logging.Logger
+
+
+@dataclass(frozen=True)
+class SessionContext:
+    run_dir: Path
+    hook_dir: Path
+    config: Any  # pytest_prism.config.Config; avoid import cycle
+    logger: logging.Logger
+
+
+@runtime_checkable
+class Renderer(Protocol):
+    payload_kind: ClassVar[str]
+
+    def render(self, payload: Mapping[str, Any], ctx: RenderContext) -> RenderResult: ...
+
+
+@runtime_checkable
+class SessionHook(Protocol):
+    name: ClassVar[str]
+
+    def session_pre(self, ctx: SessionContext) -> Mapping[str, Any]: ...
+    def session_post(self, ctx: SessionContext) -> Mapping[str, Any]: ...
+
+
+def record_measurement(
+    name: str,
+    value: float,
+    *,
+    unit: str | None = None,
+    spec_min: float | None = None,
+    spec_max: float | None = None,
+) -> None:
+    """Record a numeric measurement on the current test.
+
+    Writes the value (and optional unit / spec limits) into the test's JUnit
+    ``<properties>`` using the convention Prism's ingest understands
+    (``{name}``, ``{name}__unit``, ``{name}__min``, ``{name}__max``). Prism
+    turns these into first-class Measurement rows with pass/fail margins.
+
+    No-op when called outside a running test. Must be called during the test
+    body (not in ``makereport``), so the values are captured before pytest
+    serialises the JUnit report.
+    """
+    item = _current_item()
+    if item is None:
+        return
+    props: list[tuple[str, object]] = item.user_properties
+    props.append((name, value))
+    if unit is not None:
+        props.append((f"{name}__unit", unit))
+    if spec_min is not None:
+        props.append((f"{name}__min", spec_min))
+    if spec_max is not None:
+        props.append((f"{name}__max", spec_max))
+
+
+def attach(kind: str, payload: Mapping[str, Any]) -> None:
+    """Attach a payload to the current pytest item.
+
+    The plugin reads attached payloads in `pytest_runtest_makereport` and
+    dispatches to the matching renderer. May be called multiple times per test
+    with different `kind`s; each renders independently.
+    """
+    item = _current_item()
+    if item is None:
+        # Called outside a test (e.g., session fixture). Silently no-op rather
+        # than raise — caller may not have control over execution context.
+        return
+    payloads = item.stash.get(_PRISM_PAYLOADS_STASH, None)
+    if payloads is None:
+        payloads = []
+        item.stash[_PRISM_PAYLOADS_STASH] = payloads
+    # Defensive copy so callers can mutate their payload without affecting the renderer.
+    payloads.append((kind, dict(payload)))
+
+
+def _current_item() -> pytest.Item | None:
+    """Walk up the stack to find the active pytest Item. Returns None if not in a test."""
+    import inspect
+
+    frame = inspect.currentframe()
+    try:
+        while frame is not None:
+            for var in frame.f_locals.values():
+                if isinstance(var, pytest.Item):
+                    return var
+            frame = frame.f_back
+    finally:
+        del frame
+    return None
+
+
+__all__ = [
+    "RenderContext",
+    "RenderResult",
+    "Renderer",
+    "SessionContext",
+    "SessionHook",
+    "attach",
+    "record_measurement",
+]

--- a/.github/vendor/pytest-prism/pytest_prism/client.py
+++ b/.github/vendor/pytest-prism/pytest_prism/client.py
@@ -1,0 +1,177 @@
+"""Stdlib-only HTTP client for the Prism API.
+
+Used by `pytest_prism.upload`. No external dependencies — works anywhere
+Python 3.10+ is installed (CI runners included).
+
+Session state (auth + CSRF cookies) is held in an in-memory cookie jar
+so all subsequent `_request` calls automatically carry the login cookie
+and, for mutations, the `X-Prism-Csrf` header.
+"""
+
+from __future__ import annotations
+
+import http.cookiejar
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from typing import Any, cast
+
+__all__ = ["PrismClient"]
+
+
+class PrismClient:
+    def __init__(self, base_url: str, token: str | None = None) -> None:
+        # Reject non-http(s) schemes up front so the noqa: S310 below is true.
+        # urllib's default opener handles file://, ftp://, data://, etc., which
+        # an attacker who can set PRISM_URL in a CI env could abuse for
+        # local-file disclosure / SSRF. See ruff S310.
+        scheme = urllib.parse.urlsplit(base_url).scheme.lower()
+        if scheme not in ("http", "https"):
+            raise ValueError(f"PrismClient base_url must be http or https; got scheme {scheme!r}")
+        self.base_url = base_url.rstrip("/")
+        # When set, authenticate with a bearer API token instead of a cookie
+        # session (no login + no CSRF; the server skips CSRF for bearer auth).
+        self.token = token
+        self.jar = http.cookiejar.CookieJar()
+        self.opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self.jar))
+
+    # --------------------------------------------------------------------- #
+    # Low-level request plumbing
+    # --------------------------------------------------------------------- #
+
+    def _read_cookie(self, name: str) -> str | None:
+        for c in self.jar:
+            if c.name == name:
+                return c.value
+        return None
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, bytes]:
+        url = f"{self.base_url}{path}"
+        # base_url's scheme is validated to http/https in __init__, so this is safe.
+        req = urllib.request.Request(url, data=body, method=method, headers=headers or {})  # noqa: S310
+        if self.token:
+            req.add_header("Authorization", f"Bearer {self.token}")
+        csrf = self._read_cookie("prism_csrf")
+        if csrf and method in ("POST", "PUT", "PATCH", "DELETE"):
+            req.add_header("X-Prism-Csrf", csrf)
+        try:
+            with self.opener.open(req) as resp:
+                return resp.status, resp.read()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read()
+
+    # --------------------------------------------------------------------- #
+    # Auth
+    # --------------------------------------------------------------------- #
+
+    def login(self, email: str, password: str) -> None:
+        if self.token:
+            return  # bearer token auth: no session login needed
+        payload = json.dumps({"email": email, "password": password}).encode("utf-8")
+        code, body = self._request(
+            "POST",
+            "/api/v1/auth/login",
+            body=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if code != 200:
+            raise RuntimeError(f"login failed: HTTP {code} {body!r}")
+
+    # --------------------------------------------------------------------- #
+    # Projects
+    # --------------------------------------------------------------------- #
+
+    def ensure_project(self, slug: str, name: str, description: str = "") -> None:
+        """Create the project if it doesn't exist. 409 (already exists) is fine."""
+        payload = json.dumps({"slug": slug, "name": name, "description": description}).encode(
+            "utf-8"
+        )
+        code, body = self._request(
+            "POST",
+            "/api/v1/projects",
+            body=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if code not in (201, 409):
+            raise RuntimeError(f"project create failed: HTTP {code} {body!r}")
+
+    def project_exists(self, slug: str) -> bool:
+        code, _ = self._request("GET", f"/api/v1/projects/{urllib.parse.quote(slug)}")
+        return code == 200
+
+    # --------------------------------------------------------------------- #
+    # Runs
+    # --------------------------------------------------------------------- #
+
+    def list_runs(self, project_slug: str) -> list[dict[str, Any]]:
+        code, body = self._request(
+            "GET", f"/api/v1/runs?project={urllib.parse.quote(project_slug)}"
+        )
+        if code != 200:
+            raise RuntimeError(f"list runs failed: HTTP {code} {body!r}")
+        return cast(list[dict[str, Any]], json.loads(body))
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        code, body = self._request("GET", f"/api/v1/runs/{urllib.parse.quote(run_id)}")
+        if code != 200:
+            raise RuntimeError(f"get run failed: HTTP {code} {body!r}")
+        return cast(dict[str, Any], json.loads(body))
+
+    def delete_run(self, run_id: str) -> None:
+        code, body = self._request("DELETE", f"/api/v1/runs/{urllib.parse.quote(run_id)}")
+        if code not in (204, 404):
+            raise RuntimeError(f"delete run failed: HTTP {code} {body!r}")
+
+    def upload_run(
+        self,
+        *,
+        project_slug: str,
+        run_name: str,
+        junit_xml: bytes,
+        archive_zip: bytes | None = None,
+        tags: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """POST /api/v1/runs with a hand-built multipart body.
+
+        Returns the parsed JSON response (includes run `id` + initial `status`).
+        Raises RuntimeError on any non-201.
+        """
+        boundary = f"----prism{uuid.uuid4().hex}"
+        parts: list[bytes] = []
+
+        def _add_field(name: str, value: str) -> None:
+            parts.append(f"--{boundary}\r\n".encode())
+            parts.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode())
+            parts.append(value.encode("utf-8"))
+            parts.append(b"\r\n")
+
+        def _add_file(name: str, filename: str, content_type: str, content: bytes) -> None:
+            parts.append(f"--{boundary}\r\n".encode())
+            parts.append(
+                f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode()
+            )
+            parts.append(f"Content-Type: {content_type}\r\n\r\n".encode())
+            parts.append(content)
+            parts.append(b"\r\n")
+
+        metadata = {"project_slug": project_slug, "name": run_name, "tags": tags or {}}
+        _add_field("metadata", json.dumps(metadata))
+        _add_file("junit", "junit.xml", "application/xml", junit_xml)
+        if archive_zip is not None:
+            _add_file("archive", "archive.zip", "application/zip", archive_zip)
+        parts.append(f"--{boundary}--\r\n".encode())
+        body = b"".join(parts)
+        headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+        code, resp_body = self._request("POST", "/api/v1/runs", body=body, headers=headers)
+        if code != 201:
+            raise RuntimeError(f"upload {run_name!r} failed: HTTP {code} {resp_body!r}")
+        return cast(dict[str, Any], json.loads(resp_body))

--- a/.github/vendor/pytest-prism/pytest_prism/config.py
+++ b/.github/vendor/pytest-prism/pytest_prism/config.py
@@ -1,0 +1,210 @@
+"""Resolved configuration for the prism_report plugin.
+
+Precedence: CLI flag > PRISM_* env var > built-in default. All resolution
+happens in one place; the rest of the plugin reads a frozen Config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import socket
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path, PosixPath
+from typing import Any
+
+
+class ConfigError(Exception):
+    """Raised on user-input errors (bad flag combinations, missing required)."""
+
+
+class _RelDotPath(PosixPath):
+    """A Path that preserves a leading ``./`` in its string form.
+
+    ``pathlib.Path('./foo')`` normalises to ``PosixPath('foo')`` and
+    ``str(...)`` returns ``'foo'``. The default Prism output directory is
+    spelled ``./prism-report-<ts>`` for human-readability; this subclass
+    keeps that prefix while remaining a fully-functional ``Path``.
+    """
+
+    def __str__(self) -> str:
+        s = super().__str__()
+        if s.startswith("/") or s.startswith("./") or s.startswith("../"):
+            return s
+        return "./" + s
+
+
+@dataclass(frozen=True)
+class Config:
+    enabled: bool
+    out_dir: Path | None
+    upload_url: str | None
+    upload_email: str | None
+    upload_password: str | None
+    upload_token: str | None
+    upload_project: str | None
+    run_name: str
+    user_tags: dict[str, str]
+    labgrid_place: str | None
+    no_labgrid: bool
+    dmesg_via: str  # "auto" | "ssh" | "console" | "none"
+    dmesg_ssh_user: str
+    dmesg_ssh_key: str | None
+    fail_on_upload_error: bool
+    # Mapping of topic -> human-readable message. Keyed access lets callers
+    # check `"<topic>" in cfg.warnings` without parsing prose.
+    warnings: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_argv(cls, argv: list[str]) -> Config:
+        parser = _build_parser()
+        ns = parser.parse_args(argv)
+        return _resolve(ns, os.environ)
+
+    @classmethod
+    def from_pytest(cls, pytest_config: Any) -> Config:
+        # invocation_params.args includes pytest's own flags (-q, -v, ...)
+        # plus any user args. Use parse_known_args to ignore non-prism flags.
+        argv = list(pytest_config.invocation_params.args)
+        parser = _build_parser()
+        ns, _ = parser.parse_known_args(argv)
+        return _resolve(ns, os.environ)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--prism-report", action="store_true", default=None)
+    p.add_argument("--prism-out", default=None)
+    p.add_argument("--prism-url", default=None)
+    p.add_argument("--prism-email", default=None)
+    p.add_argument("--prism-password", default=None)
+    p.add_argument("--prism-token", default=None)
+    p.add_argument("--prism-project", default=None)
+    p.add_argument("--prism-run-name", default=None)
+    p.add_argument("--prism-tag", action="append", default=[])
+    p.add_argument("--prism-labgrid-place", default=None)
+    p.add_argument("--prism-no-labgrid", action="store_true", default=None)
+    p.add_argument("--prism-dmesg-via", default=None, choices=["auto", "ssh", "console", "none"])
+    p.add_argument("--prism-dmesg-ssh-user", default=None)
+    p.add_argument("--prism-dmesg-ssh-key", default=None)
+    p.add_argument("--prism-fail-on-upload-error", action="store_true", default=None)
+    return p
+
+
+def _env_bool(env: Mapping[str, str], key: str) -> bool | None:
+    v = env.get(key)
+    if v is None:
+        return None
+    return v.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _resolve(ns: argparse.Namespace, env: Mapping[str, str]) -> Config:
+    warnings: dict[str, str] = {}
+
+    def _pick(cli_val: Any, env_key: str, default: Any = None) -> Any:
+        if cli_val is not None:
+            return cli_val
+        if env_key in env:
+            return env[env_key]
+        return default
+
+    enabled_cli = ns.prism_report
+    enabled_env = _env_bool(env, "PRISM_REPORT")
+    enabled = bool(enabled_cli) or bool(enabled_env)
+
+    if not enabled:
+        return Config(
+            enabled=False,
+            out_dir=None,
+            upload_url=None,
+            upload_email=None,
+            upload_password=None,
+            upload_token=None,
+            upload_project=None,
+            run_name="",
+            user_tags={},
+            labgrid_place=None,
+            no_labgrid=False,
+            dmesg_via="auto",
+            dmesg_ssh_user="root",
+            dmesg_ssh_key=None,
+            fail_on_upload_error=False,
+            warnings={},
+        )
+
+    upload_url = _pick(ns.prism_url, "PRISM_URL")
+    upload_email = _pick(ns.prism_email, "PRISM_EMAIL")
+    upload_password = _pick(ns.prism_password, "PRISM_PASSWORD")
+    upload_token = _pick(ns.prism_token, "PRISM_TOKEN")
+    upload_project = _pick(ns.prism_project, "PRISM_PROJECT")
+    if upload_url and not upload_project:
+        raise ConfigError("--prism-project is required when --prism-url is set")
+
+    no_labgrid_cli = ns.prism_no_labgrid
+    no_labgrid_env = _env_bool(env, "PRISM_NO_LABGRID")
+    no_labgrid = bool(no_labgrid_cli) or bool(no_labgrid_env)
+
+    place_cli = ns.prism_labgrid_place
+    place_env = env.get("PRISM_LABGRID_PLACE")
+    if no_labgrid_cli and place_cli is not None:
+        raise ConfigError("--prism-no-labgrid conflicts with --prism-labgrid-place")
+    if no_labgrid:
+        labgrid_place = None
+        if no_labgrid_cli and place_env is not None and place_cli is None:
+            warnings["labgrid_place"] = (
+                "env PRISM_LABGRID_PLACE ignored because --prism-no-labgrid is set"
+            )
+    else:
+        labgrid_place = place_cli if place_cli is not None else place_env
+
+    out_cli = ns.prism_out
+    out_env = env.get("PRISM_OUT")
+    out_resolved = out_cli if out_cli is not None else out_env
+    out_is_default = False
+    if out_resolved is None and upload_url is None:
+        ts = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        out_resolved = f"./prism-report-{ts}"
+        out_is_default = True
+    if out_resolved is None:
+        out_dir: Path | None = None
+    elif out_is_default:
+        # Built-in default keeps its leading ``./`` for clarity in logs.
+        out_dir = _RelDotPath(out_resolved)
+    else:
+        out_dir = Path(out_resolved)
+
+    user_tags: dict[str, str] = {}
+    for raw in ns.prism_tag:
+        if "=" not in raw:
+            raise ConfigError(f"--prism-tag expects key=value, got {raw!r}")
+        k, v = raw.split("=", 1)
+        user_tags[k.strip()] = v.strip()
+
+    run_name = _pick(ns.prism_run_name, "PRISM_RUN_NAME")
+    if not run_name:
+        host = socket.gethostname()
+        ts = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        run_name = f"{host}-{ts}"
+
+    return Config(
+        enabled=True,
+        out_dir=out_dir,
+        upload_url=upload_url,
+        upload_email=upload_email,
+        upload_password=upload_password,
+        upload_token=upload_token,
+        upload_project=upload_project,
+        run_name=run_name,
+        user_tags=user_tags,
+        labgrid_place=labgrid_place,
+        no_labgrid=no_labgrid,
+        dmesg_via=_pick(ns.prism_dmesg_via, "PRISM_DMESG_VIA", "auto"),
+        dmesg_ssh_user=_pick(ns.prism_dmesg_ssh_user, "PRISM_DMESG_SSH_USER", "root"),
+        dmesg_ssh_key=_pick(ns.prism_dmesg_ssh_key, "PRISM_DMESG_SSH_KEY"),
+        fail_on_upload_error=bool(
+            ns.prism_fail_on_upload_error or _env_bool(env, "PRISM_FAIL_ON_UPLOAD_ERROR")
+        ),
+        warnings=warnings,
+    )

--- a/.github/vendor/pytest-prism/pytest_prism/manifest.py
+++ b/.github/vendor/pytest-prism/pytest_prism/manifest.py
@@ -1,0 +1,161 @@
+"""Output directory + manifest accumulator (schema v2).
+
+Layout on disk:
+  <out>/
+    junit.xml                    # pytest writes this
+    manifest.json                # written by finalize()
+    run_meta.json                # written by finalize()
+    session/<hook_name>/...      # session-hook outputs (Task 8 wires these)
+    cases/<safe_id>/<kind>/<filename>
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]")
+_MAX_SAFE_ID_LEN = 200
+SCHEMA_VERSION = 2
+
+
+def _safe_test_id(nodeid: str) -> str:
+    sanitized = _UNSAFE.sub("_", nodeid) or "case"
+    if len(sanitized) > _MAX_SAFE_ID_LEN:
+        digest = hashlib.blake2b(nodeid.encode(), digest_size=4).hexdigest()
+        head_len = _MAX_SAFE_ID_LEN - len(digest) - 1
+        sanitized = sanitized[:head_len] + "_" + digest
+    return sanitized
+
+
+@dataclass
+class _CaseEntry:
+    case_nodeid: str
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+
+
+class OutputDir:
+    """On-disk layout owner. Single-writer; not thread-safe."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+        self._run_artifacts: list[dict[str, Any]] = []
+        self._cases: dict[str, _CaseEntry] = {}
+        self._initialized = False
+
+    def initialize(self) -> None:
+        if self.root.exists():
+            children = list(self.root.iterdir())
+            if children:
+                sys.stderr.write(
+                    f"pytest-prism: refusing to write to non-empty dir "
+                    f"{self.root}; pass a fresh path or remove it\n"
+                )
+                raise SystemExit(4)
+        else:
+            self.root.mkdir(parents=True)
+        (self.root / "cases").mkdir(exist_ok=True)
+        (self.root / "session").mkdir(exist_ok=True)
+        self._initialized = True
+
+    def session_dir(self, hook_name: str) -> Path:
+        d = self.root / "session" / hook_name
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def write_run_artifact(self, filename: str, content: bytes, *, kind: str) -> None:
+        if not self._initialized:
+            raise RuntimeError("OutputDir.initialize() must be called first")
+        path = self.root / filename
+        path.write_bytes(content)
+        self._run_artifacts.append(
+            {
+                "filename": filename,
+                "kind": kind,
+                "size": len(content),
+            }
+        )
+
+    def write_case_artifact(
+        self,
+        *,
+        case_nodeid: str,
+        filename: str,
+        content: bytes,
+        kind: str,
+    ) -> None:
+        if not self._initialized:
+            raise RuntimeError("OutputDir.initialize() must be called first")
+        safe = _safe_test_id(case_nodeid)
+        case_kind_dir = self.root / "cases" / safe / kind
+        case_kind_dir.mkdir(parents=True, exist_ok=True)
+        (case_kind_dir / filename).write_bytes(content)
+        entry = self._cases.setdefault(case_nodeid, _CaseEntry(case_nodeid))
+        entry.artifacts.append(
+            {
+                "filename": filename,
+                "kind": kind,
+                "size": len(content),
+                "rel_path": f"cases/{safe}/{kind}/{filename}",
+            }
+        )
+
+    def record_case_artifact(
+        self,
+        *,
+        case_nodeid: str,
+        filename: str,
+        kind: str,
+        size: int | None = None,
+    ) -> None:
+        """Register a file the renderer wrote directly into the case dir.
+
+        Use this when the renderer has already written the file (so we avoid
+        a double-write); the manifest still gets the entry. Size is read from
+        disk if not provided.
+        """
+        if not self._initialized:
+            raise RuntimeError("OutputDir.initialize() must be called first")
+        safe = _safe_test_id(case_nodeid)
+        if size is None:
+            size = (self.root / "cases" / safe / kind / filename).stat().st_size
+        entry = self._cases.setdefault(case_nodeid, _CaseEntry(case_nodeid))
+        entry.artifacts.append(
+            {
+                "filename": filename,
+                "kind": kind,
+                "size": size,
+                "rel_path": f"cases/{safe}/{kind}/{filename}",
+            }
+        )
+
+    def case_kind_dir(self, *, case_nodeid: str, kind: str) -> Path:
+        """Return (and ensure) the per-case-per-kind directory."""
+        safe = _safe_test_id(case_nodeid)
+        d = self.root / "cases" / safe / kind
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def finalize(self, *, run_meta: dict[str, Any]) -> dict[str, Any]:
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "run_meta": run_meta,
+            "run_artifacts": list(self._run_artifacts),
+            "cases": [
+                {"case_nodeid": e.case_nodeid, "artifacts": list(e.artifacts)}
+                for e in self._cases.values()
+            ],
+        }
+        (self.root / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        (self.root / "run_meta.json").write_text(
+            json.dumps(run_meta, indent=2, sort_keys=True, default=str),
+            encoding="utf-8",
+        )
+        return manifest

--- a/.github/vendor/pytest-prism/pytest_prism/plugin.py
+++ b/.github/vendor/pytest-prism/pytest_prism/plugin.py
@@ -1,0 +1,318 @@
+"""pytest-prism plugin entry. Wires pytest hooks to the registry."""
+
+import datetime as _dt
+import io
+import json
+import logging
+import re
+import sys
+import traceback
+from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from pytest_prism import __version__ as _PLUGIN_VERSION
+from pytest_prism.api import (
+    _PRISM_PAYLOADS_STASH,
+    RenderContext,
+    RenderResult,
+    SessionContext,
+    SessionHook,
+)
+from pytest_prism.config import Config, ConfigError
+from pytest_prism.manifest import OutputDir
+from pytest_prism.registry import Registry, RegistryError, load_registry
+from pytest_prism.upload import UploadError
+from pytest_prism.upload import upload as _upload
+
+_LOG = logging.getLogger("pytest_prism.plugin")
+
+
+@dataclass
+class _State:
+    cfg: Config
+    out_dir: OutputDir
+    registry: Registry
+    started_at: str = ""
+    hook_pre_results: dict[str, dict[str, Any]] = None  # type: ignore[assignment]
+    hook_post_results: dict[str, dict[str, Any]] = None  # type: ignore[assignment]
+    terminal_buffer: io.StringIO | None = None
+    exitstatus: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.hook_pre_results is None:
+            self.hook_pre_results = {}
+        if self.hook_post_results is None:
+            self.hook_post_results = {}
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    g = parser.getgroup("prism_report", "Prism test-report plugin")
+    g.addoption("--prism-report", action="store_true", default=False)
+    g.addoption("--prism-out", default=None)
+    g.addoption("--prism-out-overwrite", action="store_true", default=False)
+    g.addoption("--prism-url", default=None)
+    g.addoption("--prism-email", default=None)
+    g.addoption("--prism-password", default=None)
+    g.addoption("--prism-token", default=None)
+    g.addoption("--prism-project", default=None)
+    g.addoption("--prism-run-name", default=None)
+    g.addoption("--prism-tag", action="append", default=[])
+    g.addoption("--prism-labgrid-place", default=None)
+    g.addoption("--prism-no-labgrid", action="store_true", default=False)
+    g.addoption("--prism-dmesg-via", default=None, choices=["auto", "ssh", "console", "none"])
+    g.addoption("--prism-dmesg-ssh-user", default=None)
+    g.addoption("--prism-dmesg-ssh-key", default=None)
+    g.addoption("--prism-fail-on-upload-error", action="store_true", default=False)
+    g.addoption("--prism-strict-registry", action="store_true", default=False)
+    g.addoption("--prism-fail-on-hook-error", action="store_true", default=False)
+
+
+def _setup_terminal_capture(config: pytest.Config, st: _State) -> None:
+    if st.terminal_buffer is None:
+        st.terminal_buffer = io.StringIO()
+    tr = config.pluginmanager.get_plugin("terminalreporter")
+    if tr is not None and hasattr(tr, "_tw") and not hasattr(tr._tw.write, "__prism_wrapped__"):
+        orig_write = tr._tw.write
+
+        def new_write(s: str, *args: Any, **kwargs: Any) -> Any:
+            if st.terminal_buffer is not None:
+                st.terminal_buffer.write(s)
+            return orig_write(s, *args, **kwargs)
+
+        new_write.__prism_wrapped__ = True  # type: ignore[attr-defined]
+        tr._tw.write = new_write
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    if not config.getoption("--prism-report"):
+        return
+    try:
+        cfg = Config.from_pytest(config)
+    except ConfigError as exc:
+        raise pytest.UsageError(f"prism-report: {exc}") from exc
+
+    if cfg.out_dir is None:
+        raise pytest.UsageError("prism-report: could not resolve output directory")
+    resolved_out_dir = cfg.out_dir
+    out_dir = OutputDir(resolved_out_dir)
+    overwrite = config.getoption("--prism-out-overwrite")
+    if overwrite and resolved_out_dir.exists():
+        import shutil
+
+        shutil.rmtree(resolved_out_dir)
+    try:
+        out_dir.initialize()
+    except SystemExit as exc:
+        raise pytest.UsageError(
+            f"prism-report: output dir {resolved_out_dir} is not empty; "
+            "pass --prism-out-overwrite or pick another path"
+        ) from exc
+
+    try:
+        registry = load_registry(strict=config.getoption("--prism-strict-registry"))
+    except RegistryError as exc:
+        raise pytest.UsageError(f"prism-report: {exc}") from exc
+
+    st = _State(cfg=cfg, out_dir=out_dir, registry=registry)
+    config._prism_state = st  # type: ignore[attr-defined]
+    _setup_terminal_capture(config, st)
+
+    junit_path = resolved_out_dir / "junit.xml"
+    config.option.xmlpath = str(junit_path)
+    for topic, msg in cfg.warnings.items():
+        config.issue_config_time_warning(
+            pytest.PytestConfigWarning(f"prism-report: {topic}: {msg}"),
+            stacklevel=1,
+        )
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    st: _State | None = getattr(session.config, "_prism_state", None)
+    if st is None:
+        return
+    _setup_terminal_capture(session.config, st)
+    st.started_at = _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+    fail_on_err = session.config.getoption("--prism-fail-on-hook-error")
+
+    if not st.registry.session_hooks:
+        return
+
+    def _run_pre(name: str, hook: SessionHook) -> dict[str, Any]:
+        ctx = SessionContext(
+            run_dir=st.out_dir.root,
+            hook_dir=st.out_dir.session_dir(name),
+            config=st.cfg,
+            logger=logging.getLogger(f"pytest_prism.session.{name}"),
+        )
+        try:
+            return dict(hook.session_pre(ctx))
+        except Exception as exc:
+            (ctx.hook_dir / "error.log").write_text(
+                f"session_pre raised: {exc}\n\n{traceback.format_exc()}"
+            )
+            if fail_on_err:
+                raise
+            sys.stderr.write(f"pytest-prism: session_pre {name!r} raised: {exc}; continuing\n")
+            return {"error": str(exc)}
+
+    with ThreadPoolExecutor(max_workers=max(1, len(st.registry.session_hooks))) as ex:
+        futs = {
+            ex.submit(_run_pre, name, hook): name
+            for name, hook in st.registry.session_hooks.items()
+        }
+        for fut in as_completed(futs):
+            name = futs[fut]
+            try:
+                st.hook_pre_results[name] = dict(fut.result() or {})
+            except Exception:
+                if fail_on_err:
+                    raise
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(
+    item: pytest.Item, call: pytest.CallInfo[Any]
+) -> Generator[None, None, None]:
+    outcome = yield
+    if outcome is not None:
+        outcome.get_result()
+    if call.when != "call":
+        return
+    st: _State | None = getattr(item.config, "_prism_state", None)
+    if st is None:
+        return
+    payloads = item.stash.get(_PRISM_PAYLOADS_STASH, [])
+    if not payloads:
+        return
+    item.stash[_PRISM_PAYLOADS_STASH] = []  # consume
+
+    for kind, payload in payloads:
+        renderer = st.registry.renderers.get(kind)
+        if renderer is None:
+            sys.stderr.write(
+                f"pytest-prism: case {item.nodeid}: no renderer for kind "
+                f"{kind!r}; saving raw payload\n"
+            )
+            try:
+                raw = json.dumps(payload, default=str, indent=2).encode("utf-8")
+            except Exception as exc:
+                raw = f"unserialisable payload: {exc}".encode()
+            st.out_dir.write_case_artifact(
+                case_nodeid=item.nodeid,
+                filename="raw.json",
+                content=raw,
+                kind=kind,
+            )
+            continue
+
+        case_dir = st.out_dir.case_kind_dir(case_nodeid=item.nodeid, kind=kind)
+        ctx = RenderContext(
+            case_dir=case_dir,
+            case_id=item.nodeid,
+            logger=logging.getLogger(f"pytest_prism.render.{kind}"),
+        )
+        try:
+            result: RenderResult = renderer.render(payload, ctx)
+        except Exception as exc:
+            err = (f"renderer {kind!r} raised: {exc}\n\n{traceback.format_exc()}").encode()
+            st.out_dir.write_case_artifact(
+                case_nodeid=item.nodeid,
+                filename="error.log",
+                content=err,
+                kind=kind,
+            )
+            sys.stderr.write(
+                f"pytest-prism: case {item.nodeid}: renderer {kind!r} raised: {exc}; continuing\n"
+            )
+            continue
+
+        # Renderer wrote files directly to case_dir; just register them in
+        # the manifest (no double-write).
+        for f in result.files:
+            st.out_dir.record_case_artifact(
+                case_nodeid=item.nodeid,
+                filename=str(f),
+                kind=kind,
+            )
+        if result.metrics:
+            metrics_bytes = json.dumps(dict(result.metrics), indent=2, default=str).encode("utf-8")
+            st.out_dir.write_case_artifact(
+                case_nodeid=item.nodeid,
+                filename="metrics.json",
+                content=metrics_bytes,
+                kind=kind,
+            )
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    st: _State | None = getattr(session.config, "_prism_state", None)
+    if st is None:
+        return
+    st.exitstatus = exitstatus
+    fail_on_err = session.config.getoption("--prism-fail-on-hook-error")
+
+    hook_post_results: dict[str, dict[str, Any]] = {}
+    for name, hook in st.registry.session_hooks.items():
+        ctx = SessionContext(
+            run_dir=st.out_dir.root,
+            hook_dir=st.out_dir.session_dir(name),
+            config=st.cfg,
+            logger=logging.getLogger(f"pytest_prism.session.{name}"),
+        )
+        try:
+            hook_post_results[name] = dict(hook.session_post(ctx) or {})
+        except Exception as exc:
+            (ctx.hook_dir / "error.log").write_text(
+                f"session_post raised: {exc}\n\n{traceback.format_exc()}"
+            )
+            if fail_on_err:
+                raise
+            sys.stderr.write(f"pytest-prism: session_post {name!r} raised: {exc}; continuing\n")
+            hook_post_results[name] = {"error": str(exc)}
+
+    st.hook_post_results = hook_post_results
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    st: _State | None = getattr(config, "_prism_state", None)
+    if st is None:
+        return
+
+    # Capture terminal log
+    if st.terminal_buffer is not None:
+        raw_text = st.terminal_buffer.getvalue()
+        ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+        clean_text = ansi_escape.sub("", raw_text)
+        st.out_dir.write_run_artifact(
+            "terminal.log", clean_text.encode("utf-8"), kind="terminal_log"
+        )
+
+    run_meta = {
+        "started_at": st.started_at,
+        "ended_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "tags": dict(st.cfg.user_tags),
+        "plugin_version": _PLUGIN_VERSION,
+        "session_pre": st.hook_pre_results,
+        "session_post": st.hook_post_results,
+    }
+    st.out_dir.finalize(run_meta=run_meta)
+    sys.stderr.write(f"pytest-prism: wrote run to {st.out_dir.root}\n")
+
+    if not st.cfg.upload_url:
+        return
+    try:
+        result = _upload(st.out_dir, st.cfg)
+    except UploadError as exc:
+        sys.stderr.write(f"pytest-prism: upload failed: {exc}; preserved at {st.out_dir.root}\n")
+        if st.cfg.fail_on_upload_error:
+            sys.exit(5)
+        return
+    sys.stderr.write(
+        f"pytest-prism: uploaded run {result.run_id} (status={result.status}) "
+        f"-> {st.cfg.upload_url}{result.url}\n"
+    )

--- a/.github/vendor/pytest-prism/pytest_prism/registry.py
+++ b/.github/vendor/pytest-prism/pytest_prism/registry.py
@@ -1,0 +1,81 @@
+"""Entry-point discovery and dispatch tables for renderers and session hooks."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from importlib.metadata import EntryPoint, entry_points
+
+from pytest_prism.api import Renderer, SessionHook
+
+_LOG = logging.getLogger("pytest_prism.registry")
+
+RENDERER_GROUP = "pytest_prism.renderers"
+SESSION_HOOK_GROUP = "pytest_prism.session_hooks"
+
+
+class RegistryError(RuntimeError):
+    """Raised on kind-collision (always) or import-failure (strict mode only)."""
+
+
+@dataclass(frozen=True)
+class Registry:
+    renderers: dict[str, Renderer] = field(default_factory=dict)
+    session_hooks: dict[str, SessionHook] = field(default_factory=dict)
+
+
+def _discover_entry_points() -> list[EntryPoint]:
+    """All entry points in our two groups. Split out for test patching."""
+    eps = entry_points()
+    out: list[EntryPoint] = []
+    out.extend(eps.select(group=RENDERER_GROUP))
+    out.extend(eps.select(group=SESSION_HOOK_GROUP))
+    return list(out)
+
+
+def _instantiate(ep: EntryPoint, *, strict: bool) -> object | None:
+    try:
+        cls: type[object] = ep.load()
+    except Exception as exc:
+        msg = f"pytest-prism: entry point {ep.group}/{ep.name} failed to import: {exc}"
+        if strict:
+            raise RegistryError(msg) from exc
+        _LOG.warning(msg)
+        return None
+    try:
+        return cls()
+    except Exception as exc:
+        msg = f"pytest-prism: entry point {ep.group}/{ep.name} failed to instantiate: {exc}"
+        if strict:
+            raise RegistryError(msg) from exc
+        _LOG.warning(msg)
+        return None
+
+
+def load_registry(*, strict: bool = False) -> Registry:
+    """Discover entry points and build dispatch tables."""
+    renderers: dict[str, Renderer] = {}
+    hooks: dict[str, SessionHook] = {}
+    for ep in _discover_entry_points():
+        instance = _instantiate(ep, strict=strict)
+        if instance is None:
+            continue
+        if ep.group == RENDERER_GROUP:
+            kind = getattr(instance, "payload_kind", ep.name)
+            if kind in renderers:
+                raise RegistryError(
+                    f"pytest-prism: duplicate renderer kind {kind!r} "
+                    f"(entry points {ep.group}/{ep.name} collides with another)"
+                )
+            if isinstance(instance, Renderer):
+                renderers[kind] = instance
+        elif ep.group == SESSION_HOOK_GROUP:
+            name = getattr(instance, "name", ep.name)
+            if name in hooks:
+                raise RegistryError(
+                    f"pytest-prism: duplicate session hook name {name!r} "
+                    f"(entry points {ep.group}/{ep.name} collides with another)"
+                )
+            if isinstance(instance, SessionHook):
+                hooks[name] = instance
+    return Registry(renderers=renderers, session_hooks=hooks)

--- a/.github/vendor/pytest-prism/pytest_prism/upload.py
+++ b/.github/vendor/pytest-prism/pytest_prism/upload.py
@@ -1,0 +1,151 @@
+"""Upload a finalized OutputDir to a Prism instance.
+
+Delegates the multipart construction to `PrismClient.upload_run`, then polls
+until ingest is ready. Local export is left on disk on any failure for
+offline retry.
+"""
+
+from __future__ import annotations
+
+import io
+import json as _json
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import defusedxml.ElementTree as ET
+
+from pytest_prism.client import PrismClient
+from pytest_prism.config import Config
+from pytest_prism.manifest import OutputDir
+
+
+class UploadError(RuntimeError):
+    """Any failure during login, multipart POST, or polling."""
+
+
+@dataclass(frozen=True)
+class RunResult:
+    run_id: str
+    status: str
+    url: str
+
+
+def _suite_name_from_junit(junit_xml: bytes) -> str:
+    try:
+        root = ET.fromstring(junit_xml)
+    except ET.ParseError:
+        return "pytest"
+    suite = root if root.tag == "testsuite" else root.find("testsuite")
+    if suite is not None and suite.get("name"):
+        return suite.get("name") or "pytest"
+    return "pytest"
+
+
+def _build_artifacts_zip(out_root: Path) -> bytes:
+    """Build the archive for Prism ingest.
+
+    The pytest-prism v2 layout is `cases/<safe_id>/<kind>/<filename>`. Prism
+    parses each archive entry's basename as `{suite}__{case}__{label}.{ext}`
+    to attach it to the right case. We rewrite each per-case entry's archive
+    name on the fly using:
+      - suite name from <testsuite name=""> in junit.xml
+      - case name from manifest entry's case_nodeid (the part after "::")
+      - kind prefix on the label so different kinds don't clash on filename
+    Run-level and session-level artifacts keep bare/prefixed names.
+    """
+    buf = io.BytesIO()
+    manifest_path = out_root / "manifest.json"
+    junit_path = out_root / "junit.xml"
+    suite_name = (
+        _suite_name_from_junit(junit_path.read_bytes()) if junit_path.exists() else "pytest"
+    )
+
+    case_dir_to_name: dict[str, str] = {}
+    if manifest_path.exists():
+        manifest = _json.loads(manifest_path.read_text())
+        for case in manifest.get("cases", []):
+            nodeid = case.get("case_nodeid", "")
+            artifacts = case.get("artifacts", [])
+            if not artifacts:
+                continue
+            sample_rel = artifacts[0].get("rel_path", "")
+            parts = sample_rel.split("/")
+            if len(parts) >= 2 and parts[0] == "cases":
+                safe_id = parts[1]
+                case_name = nodeid.rsplit("::", 1)[-1] if "::" in nodeid else nodeid
+                case_dir_to_name[safe_id] = case_name
+
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for p in out_root.rglob("*"):
+            if not p.is_file():
+                continue
+            if p.name == "junit.xml":
+                continue
+            rel = p.relative_to(out_root)
+            parts = rel.parts
+            if len(parts) >= 4 and parts[0] == "cases":
+                # cases/<safe_id>/<kind>/<filename>
+                safe_id, kind, filename = parts[1], parts[2], parts[-1]
+                case_name = case_dir_to_name.get(safe_id)
+                if case_name is None:
+                    arcname = f"{kind}__{filename}"
+                else:
+                    arcname = f"{suite_name}__{case_name}__{kind}__{filename}"
+            elif len(parts) >= 3 and parts[0] == "session":
+                # session/<hook_name>/<filename> — prefix with hook_name so
+                # multiple hooks with same filename don't collide.
+                hook_name, filename = parts[1], parts[-1]
+                arcname = f"{hook_name}__{filename}"
+            else:
+                arcname = parts[-1]
+            zf.writestr(arcname, p.read_bytes())
+    return buf.getvalue()
+
+
+def upload(
+    out_dir: OutputDir, cfg: Config, *, poll_timeout_s: float = 60.0, poll_interval_s: float = 1.0
+) -> RunResult:
+    if not cfg.upload_url:
+        raise UploadError("upload() called with no upload_url")
+    if not cfg.upload_token and not (cfg.upload_email and cfg.upload_password):
+        raise UploadError("upload() needs an API token or an email + password")
+    if not cfg.upload_project:
+        raise UploadError("upload() called with no upload_project")
+    junit_bytes = (out_dir.root / "junit.xml").read_bytes()
+    archive_bytes = _build_artifacts_zip(out_dir.root)
+
+    client = PrismClient(cfg.upload_url, token=cfg.upload_token)
+    if not cfg.upload_token:
+        try:
+            client.login(cfg.upload_email or "", cfg.upload_password or "")
+        except Exception as exc:
+            raise UploadError(f"login failed: {exc}") from exc
+
+    try:
+        result = client.upload_run(
+            project_slug=cfg.upload_project,
+            run_name=cfg.run_name,
+            junit_xml=junit_bytes,
+            archive_zip=archive_bytes,
+            tags=dict(cfg.user_tags),
+        )
+    except RuntimeError as exc:
+        raise UploadError(f"run create failed: {exc}") from exc
+
+    run_id = result.get("id")
+    if not run_id:
+        raise UploadError(f"missing run id in response: {result!r}")
+
+    deadline = time.monotonic() + poll_timeout_s
+    status = result.get("status", "pending")
+    url = result.get("url", f"/runs/{run_id}")
+    while status not in ("ready", "failed") and time.monotonic() < deadline:
+        time.sleep(poll_interval_s)
+        code, resp = client._request("GET", f"/api/v1/runs/{run_id}")
+        if code == 200:
+            data = _json.loads(resp)
+            status = data.get("status", status)
+            url = data.get("url", url)
+    return RunResult(run_id=run_id, status=status, url=url)

--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -43,7 +43,9 @@ jobs:
       # The labgrid pytest plugin reads LG_ENV / LG_COORDINATOR from the env.
       pytest_cmd_template: >-
         set -euo pipefail;
-        export PATH="$HOME/.local/bin:$PATH";
+        source .github/scripts/setup-hw-tool-path.sh;
+        echo "sdtgen=$(command -v sdtgen || echo absent)" >&2;
+        echo "usbsdmux=$(command -v usbsdmux || echo absent)" >&2;
         TESTS=$(ls test/hw/*"$BOARD"*"$CARRIER"*_hw.py 2>/dev/null | grep -v petalinux | tr '\n' ' ');
         if [ -z "$TESTS" ]; then echo "::warning::no pyadi-dt HW tests for board=$BOARD carrier=$CARRIER"; exit 0; fi;
         echo "Selected: $TESTS" >&2;

--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -49,7 +49,8 @@ jobs:
         TESTS=$(ls test/hw/*"$BOARD"*"$CARRIER"*_hw.py 2>/dev/null | grep -v petalinux | tr '\n' ' ');
         if [ -z "$TESTS" ]; then echo "::warning::no pyadi-dt HW tests for board=$BOARD carrier=$CARRIER"; exit 0; fi;
         echo "Selected: $TESTS" >&2;
-        "$VENV_DIR/bin/pytest" -p no:genalyzer -v -s $TESTS --junitxml="$JUNIT"
+        bash .github/scripts/run-hw-pytest-with-prism.sh
+        "$VENV_DIR/bin/python" "$JUNIT" -p no:genalyzer -v -s $TESTS
       artifact_glob: |
         test/hw/output/**/*.dts
         test/hw/output/**/*.pp.dts
@@ -59,15 +60,19 @@ jobs:
         test/hw/output/**/uart_log_*.txt
         uart_log_*.txt
         junit-hw-*.xml
+        prism-hw-*/terminal.log
+        prism-hw-*/manifest.json
+        prism-hw-*.zip
       prism_project: pyadi-dt
       prism_upload: ${{ vars.PRISM_UPLOAD_ENABLED == 'true' }}
-      # Vendored tfcollins/prism uploader (private repo; can't pip-install on
-      # the runner). The reusable workflow exports PRISM_URL/EMAIL/PASSWORD/
-      # PROJECT/JUNIT/RUN_NAME/BOARD/CARRIER/PLACE.
+      # Upload the pytest-prism artifact archive after the test step, where the
+      # reusable workflow injects Prism credentials. The uploader remains
+      # vendored so this post-test path does not need another private checkout.
       prism_upload_cmd: >-
         python3 .github/scripts/prism_upload_run.py "$PRISM_JUNIT"
         --url "$PRISM_URL" --project "$PRISM_PROJECT" --run-name "$PRISM_RUN_NAME"
         --auto-create-project
+        --archive "prism-hw-${PRISM_PLACE}.zip"
         --tag "board=$PRISM_BOARD" --tag "carrier=$PRISM_CARRIER"
         --tag "place=$PRISM_PLACE" --tag "sha=$GITHUB_SHA"
     # Pass Prism creds explicitly: secrets: inherit does not cross orgs

--- a/.github/workflows/test-kuiper.yml
+++ b/.github/workflows/test-kuiper.yml
@@ -42,7 +42,7 @@ jobs:
       # builds an old numpy (1.26.4) from source when no matching arm64
       # wheel is available; without Python.h the numpy build fails.
       run: |
-        docker exec ${{env.CONTAINER_BASE_NAME}}-${{env.ARCHITECTURE}} sh -c "apt-get update && apt-get install -y --no-install-recommends python3-dev && python3 -m pip install --upgrade pip && pip install '.[test]'"
+        docker exec ${{env.CONTAINER_BASE_NAME}}-${{env.ARCHITECTURE}} sh -c "apt-get update && apt-get install -y --no-install-recommends python3-dev tcl && python3 -m pip install --upgrade pip && pip install '.[test]'"
 
     - name: Run tests
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+prism-hw-*/
+prism-hw-*.zip
 
 # Translations
 *.mo

--- a/adidt/sdt/__init__.py
+++ b/adidt/sdt/__init__.py
@@ -1,0 +1,6 @@
+"""Authoring and validation tools for SDT Tcl drivers."""
+
+from .definitions import SdtDriverDefinition, load_tcl_definition
+from .staging import stage_sdt_repository
+
+__all__ = ["SdtDriverDefinition", "load_tcl_definition", "stage_sdt_repository"]

--- a/adidt/sdt/definitions.py
+++ b/adidt/sdt/definitions.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import base64
 import shutil
-import subprocess
+# The only child process is an absolute, shutil-resolved tclsh executable with
+# an argv list and shell=False.
+import subprocess  # nosec B404
 import tempfile
 from pathlib import Path
 
@@ -123,7 +125,8 @@ def load_tcl_definition(
     driver_path = Path(path).resolve()
     if not driver_path.is_file():
         raise FileNotFoundError(driver_path)
-    if shutil.which("tclsh") is None:
+    tclsh = shutil.which("tclsh")
+    if tclsh is None:
         raise RuntimeError("tclsh is required to inspect SDT driver definitions")
     proc = definition_proc or f"::adidt::sdt::{driver_path.stem}::definition"
     with tempfile.NamedTemporaryFile(
@@ -131,8 +134,8 @@ def load_tcl_definition(
     ) as harness:
         harness.write(_HARNESS)
         harness.flush()
-        result = subprocess.run(
-            ["tclsh", harness.name, str(driver_path), proc],
+        result = subprocess.run(  # nosec B603
+            [tclsh, harness.name, str(driver_path), proc],
             capture_output=True,
             text=True,
             timeout=30,

--- a/adidt/sdt/definitions.py
+++ b/adidt/sdt/definitions.py
@@ -1,0 +1,172 @@
+"""Typed MDD-style contract loader for SDT Tcl drivers."""
+
+from __future__ import annotations
+
+import base64
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_ALLOWED_PROPERTY_TYPES = {
+    "aliasref",
+    "boolean",
+    "hexint",
+    "hexlist",
+    "int",
+    "intlist",
+    "noformating",
+    "phandle-array",
+    "reference",
+    "reg",
+    "string",
+    "stringlist",
+}
+_REQUIRED_KEYS = {
+    "schema_version",
+    "name",
+    "supported_ip_names",
+    "supported_vlnv_globs",
+    "generator_proc",
+    "output_files",
+    "architectures",
+    "required_hsi_properties",
+    "required_interfaces",
+    "compatibles",
+    "binding",
+    "binding_format",
+    "emitted_properties",
+}
+
+
+class SdtDriverDefinition(BaseModel):
+    """Machine-readable contract exposed by one SDT Tcl driver."""
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: int = Field(ge=1, le=1)
+    name: str = Field(pattern=r"^[a-z][a-z0-9_]*$")
+    supported_ip_names: tuple[str, ...]
+    supported_vlnv_globs: tuple[str, ...]
+    generator_proc: str
+    output_files: tuple[str, ...]
+    architectures: tuple[str, ...]
+    required_hsi_properties: tuple[str, ...]
+    required_interfaces: tuple[str, ...]
+    compatibles: tuple[str, ...]
+    binding: str
+    binding_format: str
+    emitted_properties: dict[str, str]
+
+    @field_validator(
+        "supported_ip_names",
+        "supported_vlnv_globs",
+        "output_files",
+        "architectures",
+        "compatibles",
+    )
+    @classmethod
+    def _must_not_be_empty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+    @field_validator("binding_format")
+    @classmethod
+    def _valid_binding_format(cls, value: str) -> str:
+        if value not in {"yaml", "legacy-text"}:
+            raise ValueError("binding_format must be 'yaml' or 'legacy-text'")
+        return value
+
+    @field_validator("emitted_properties")
+    @classmethod
+    def _valid_property_types(cls, value: dict[str, str]) -> dict[str, str]:
+        invalid = sorted(set(value.values()) - _ALLOWED_PROPERTY_TYPES)
+        if invalid:
+            raise ValueError(f"unsupported SDT property types: {invalid}")
+        return value
+
+
+_HARNESS = r"""
+set driver_file [lindex $argv 0]
+set definition_proc [lindex $argv 1]
+source $driver_file
+if {[llength [info procs $definition_proc]] != 1} {
+    error "definition proc not found: $definition_proc"
+}
+set definition [$definition_proc]
+set list_keys {
+    supported_ip_names supported_vlnv_globs output_files architectures
+    required_hsi_properties required_interfaces compatibles
+}
+foreach key [lsort [dict keys $definition]] {
+    set value [dict get $definition $key]
+    if {$key in $list_keys || $key eq "emitted_properties"} {
+        set value [join $value \u001f]
+    }
+    set encoded [binary encode base64 -maxlen 0 $value]
+    puts "$key\t$encoded"
+}
+set generator [dict get $definition generator_proc]
+if {[llength [info procs $generator]] != 1} {
+    error "generator proc not found: $generator"
+}
+"""
+
+
+def load_tcl_definition(
+    path: str | Path, definition_proc: str | None = None
+) -> SdtDriverDefinition:
+    """Load and validate an SDT definition through stock ``tclsh``."""
+    driver_path = Path(path).resolve()
+    if not driver_path.is_file():
+        raise FileNotFoundError(driver_path)
+    if shutil.which("tclsh") is None:
+        raise RuntimeError("tclsh is required to inspect SDT driver definitions")
+    proc = definition_proc or f"::adidt::sdt::{driver_path.stem}::definition"
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".tcl", encoding="utf-8"
+    ) as harness:
+        harness.write(_HARNESS)
+        harness.flush()
+        result = subprocess.run(
+            ["tclsh", harness.name, str(driver_path), proc],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise ValueError(f"failed to load SDT Tcl definition {driver_path}: {detail}")
+
+    raw: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, separator, encoded = line.partition("\t")
+        if not separator:
+            raise ValueError(f"malformed definition output: {line!r}")
+        raw[key] = base64.b64decode(encoded).decode()
+    missing = sorted(_REQUIRED_KEYS - raw.keys())
+    if missing:
+        raise ValueError(f"definition is missing required keys: {missing}")
+
+    list_keys = {
+        "supported_ip_names",
+        "supported_vlnv_globs",
+        "output_files",
+        "architectures",
+        "required_hsi_properties",
+        "required_interfaces",
+        "compatibles",
+    }
+    data: dict[str, object] = dict(raw)
+    data["schema_version"] = int(raw["schema_version"])
+    for key in list_keys:
+        data[key] = tuple(raw[key].split("\x1f")) if raw[key] else ()
+    prop_items = tuple(raw["emitted_properties"].split("\x1f"))
+    if len(prop_items) % 2:
+        raise ValueError("emitted_properties must be a Tcl dict")
+    data["emitted_properties"] = dict(zip(prop_items[::2], prop_items[1::2]))
+    return SdtDriverDefinition.model_validate(data)

--- a/adidt/sdt/drivers/axi_jesd204_rx/data/axi_jesd204_rx.tcl
+++ b/adidt/sdt/drivers/axi_jesd204_rx/data/axi_jesd204_rx.tcl
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# ADI AXI JESD204 RX SDT driver proof of concept.
+# The definition proc is deliberately side-effect free so stock tclsh can
+# validate this file without loading HSI or SDTGen.
+
+namespace eval ::adidt::sdt::axi_jesd204_rx {
+    variable definition [dict create \
+        schema_version 1 \
+        name axi_jesd204_rx \
+        supported_ip_names {axi_jesd204_rx} \
+        supported_vlnv_globs {analog.com:user:axi_jesd204_rx:*} \
+        generator_proc axi_jesd204_rx_generate \
+        output_files {pl.dtsi} \
+        architectures {zynq zynqmp versal microblaze} \
+        required_hsi_properties {CONFIG.C_NUM_LANES CONFIG.C_DATA_PATH_WIDTH} \
+        required_interfaces {s_axi s_axi_aclk core_clk irq} \
+        compatibles {adi,axi-jesd204-rx-1.0 adi,axi-jesd204-rx-1.3} \
+        binding Documentation/devicetree/bindings/iio/jesd204/adi,jesd204-rx.txt \
+        binding_format legacy-text \
+        emitted_properties [dict create compatible stringlist]]
+
+    proc definition {} {
+        variable definition
+        return $definition
+    }
+
+    proc generate {drv_handle} {
+        set ip_name [::hsi get_property IP_NAME $drv_handle]
+        if {$ip_name ne "axi_jesd204_rx"} {
+            error "axi_jesd204_rx driver received unsupported IP '$ip_name'"
+        }
+        set node_command [namespace which -command ::sdtgen::get_node]
+        if {$node_command eq ""} {
+            set node_command [namespace which -command ::get_node]
+        }
+        if {$node_command eq ""} {
+            error "get_node helper unavailable; commands: [info commands ::*get_node*] [info commands ::*::*get_node*]"
+        }
+        set node [$node_command $drv_handle]
+        if {$node == 0} {
+            error "no SDT node exists for $drv_handle"
+        }
+        # Common SDT generation has already created reg, interrupt and clock
+        # properties from HSI. Replace only the generic Xilinx compatible.
+        set tree_command [namespace which -command ::sdtgen::pldt]
+        if {$tree_command eq ""} {
+            set tree_command [namespace which -command ::pldt]
+        }
+        if {$tree_command eq ""} {
+            error "pldt helper unavailable"
+        }
+        $tree_command set $node compatible {"adi,axi-jesd204-rx-1.0"}
+    }
+}
+
+proc axi_jesd204_rx_generate {drv_handle} {
+    ::adidt::sdt::axi_jesd204_rx::generate $drv_handle
+}

--- a/adidt/sdt/staging.py
+++ b/adidt/sdt/staging.py
@@ -1,0 +1,131 @@
+"""Stage pyadi-dt Tcl drivers into an isolated SDT repository."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+from .definitions import load_tcl_definition
+
+_SW_REGISTRY_ANCHOR = "\tdict set driverlist axi_dma driver axi_dma\n"
+_COMMON_REGISTRY_ANCHOR = "\tdict set driverlist axi_dma driver axi_dma\n"
+_SDT_REGISTRY_ANCHOR = '\tdict set ::sdtgen::namespacelist "axi_dma" "axi_dma"\n'
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def stage_sdt_repository(
+    upstream: str | Path,
+    output: str | Path,
+    drivers_root: str | Path,
+) -> Path:
+    """Copy a complete SDT repository, install drivers, and patch dispatch."""
+    source = Path(upstream).resolve()
+    destination = Path(output).resolve()
+    driver_source = Path(drivers_root).resolve()
+    sw_registry_relative = Path("device_tree/data/xillib_sw.tcl")
+    common_registry_relative = Path("device_tree/data/common_proc.tcl")
+    sdt_registry_relative = Path("device_tree/data/device_tree.tcl")
+    if not all(
+        (source / path).is_file()
+        for path in (
+            sw_registry_relative,
+            common_registry_relative,
+            sdt_registry_relative,
+        )
+    ):
+        raise ValueError(f"not a complete system-device-tree-xlnx checkout: {source}")
+    if destination.exists():
+        raise FileExistsError(destination)
+    shutil.copytree(source, destination, ignore=shutil.ignore_patterns(".git"))
+
+    mappings: dict[str, str] = {}
+    files: list[dict[str, str]] = []
+    for tcl_path in sorted(driver_source.glob("*/data/*.tcl")):
+        definition = load_tcl_definition(tcl_path)
+        if tcl_path.stem != definition.name:
+            raise ValueError(
+                f"driver filename {tcl_path.stem!r} does not match {definition.name!r}"
+            )
+        for ip_name in definition.supported_ip_names:
+            previous = mappings.setdefault(ip_name, definition.name)
+            if previous != definition.name:
+                raise ValueError(
+                    f"IP {ip_name!r} maps to both {previous!r} and {definition.name!r}"
+                )
+        relative = Path(definition.name) / "data" / tcl_path.name
+        installed = destination / relative
+        installed.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(tcl_path, installed)
+        files.append({"path": relative.as_posix(), "sha256": _sha256(installed)})
+
+    sw_registry = destination / sw_registry_relative
+    sw_text = sw_registry.read_text()
+    if _SW_REGISTRY_ANCHOR not in sw_text:
+        raise ValueError("unsupported xillib_sw.tcl registry layout")
+    sw_additions: list[str] = []
+    for ip_name, driver in sorted(mappings.items()):
+        line = f"\tdict set driverlist {ip_name} driver {driver}\n"
+        if line not in sw_text:
+            sw_additions.append(line)
+    sw_text = sw_text.replace(
+        _SW_REGISTRY_ANCHOR,
+        _SW_REGISTRY_ANCHOR + "".join(sw_additions),
+        1,
+    )
+    sw_registry.write_text(sw_text)
+
+    common_registry = destination / common_registry_relative
+    common_text = common_registry.read_text()
+    if _COMMON_REGISTRY_ANCHOR not in common_text:
+        raise ValueError("unsupported common_proc.tcl driver registry layout")
+    common_additions: list[str] = []
+    for ip_name, driver in sorted(mappings.items()):
+        line = f"\tdict set driverlist {ip_name} driver {driver}\n"
+        if line not in common_text:
+            common_additions.append(line)
+    common_text = common_text.replace(
+        _COMMON_REGISTRY_ANCHOR,
+        _COMMON_REGISTRY_ANCHOR + "".join(common_additions),
+        1,
+    )
+    common_registry.write_text(common_text)
+
+    sdt_registry = destination / sdt_registry_relative
+    sdt_text = sdt_registry.read_text()
+    if _SDT_REGISTRY_ANCHOR not in sdt_text:
+        raise ValueError("unsupported device_tree.tcl namespace registry layout")
+    sdt_additions: list[str] = []
+    for ip_name, driver in sorted(mappings.items()):
+        line = f'\tdict set ::sdtgen::namespacelist "{ip_name}" "{driver}"\n'
+        if line not in sdt_text:
+            sdt_additions.append(line)
+    sdt_text = sdt_text.replace(
+        _SDT_REGISTRY_ANCHOR,
+        _SDT_REGISTRY_ANCHOR + "".join(sdt_additions),
+        1,
+    )
+    sdt_registry.write_text(sdt_text)
+
+    manifest = {
+        "schema_version": 1,
+        "upstream": str(source),
+        "mappings": mappings,
+        "files": files,
+        "registries": {
+            sw_registry_relative.as_posix(): _sha256(sw_registry),
+            common_registry_relative.as_posix(): _sha256(common_registry),
+            sdt_registry_relative.as_posix(): _sha256(sdt_registry),
+        },
+    }
+    manifest_path = destination / "adidt-sdt-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return manifest_path

--- a/doc/source/developer/hardware_ci.rst
+++ b/doc/source/developer/hardware_ci.rst
@@ -279,16 +279,21 @@ System-tool prerequisites on each hw-node runner:
 .. code-block:: bash
 
    sudo apt-get install -y device-tree-compiler cpp u-boot-tools
-   # For ZynqMP nodes:
+   # If Vitis is not installed, provide SDTGen separately on PATH:
    pip install --user xilinx-sdt-gen
-   # For ZCU102/AD9081 (USB SD-mux mode):
-   sudo apt-get install -y usbsdmux
 
 On **every** hw-node runner (including the coordinator host), the
 workflow uses `uv <https://github.com/astral-sh/uv>`_ to build two
 persistent venvs under ``~/.cache/adidt-ci/``: one for
 ``labgrid-client`` on the coordinator host, and one holding an
 editable ``pip install -e ".[dev]"`` of adidt on every runner.
+The dev extra installs ``usbsdmux`` into the persistent test venv; it
+does not need a separate system package. Before pytest, the workflow
+sources ``.github/scripts/setup-hw-tool-path.sh``. This prepends the
+venv's ``bin`` directory and, when ``sdtgen`` is not already available,
+sources ``$XILINX_VITIS/settings64.sh`` or the newest Vitis installation
+under ``/tools/Xilinx`` / ``/opt/Xilinx``. Set ``XILINX_VITIS`` on hosts
+which use a non-standard installation path.
 ``.github/scripts/bootstrap-uv.sh`` curl-installs ``uv`` into
 ``~/.local/bin`` on first use, so no distro Python packaging is
 required — only ``curl`` and a working ``python3`` interpreter (both

--- a/proposal-sdt-tcl-driver-definitions.md
+++ b/proposal-sdt-tcl-driver-definitions.md
@@ -1,0 +1,476 @@
+# Feature proposal: MDD-style Tcl driver definitions for SDT/PetaLinux generation
+
+## Summary
+
+Add an **SDT driver authoring and test framework** to pyadi-dt. The framework lets an ADI FPGA IP driver keep an MDD-like declarative definition inside its Tcl implementation while retaining the procedural `<driver>_generate` entry point required by AMD's `system-device-tree-xlnx` flow.
+
+The proof of concept should implement one real driver, `axi_jesd204_rx`, and demonstrate this path:
+
+```text
+ADI IP/XSA
+   │
+   ├── driver definition + generator Tcl
+   │       ├── metadata lint (stock tclsh, no Vivado)
+   │       └── mocked generator contract test (stock tclsh)
+   │
+   ├── staged CUSTOM_SDT_REPO
+   │       └── sdtgen + real HSI/XSA
+   │               ├── system-top.dts / pl.dtsi
+   │               ├── dtc + dt-schema checks
+   │               └── semantic parity checks in pyadi-dt
+   │
+   └── PetaLinux device-tree recipe
+           ├── petalinux-build -c device-tree
+           └── optional labgrid boot/probe test
+```
+
+This makes Tcl support for ADI IP reviewable and testable before it is submitted to `system-device-tree-xlnx`, and gives pyadi-dt a reproducible way to validate the exact driver implementation used by SDTGen/PetaLinux rather than compensating only after generation.
+
+## Motivation
+
+pyadi-dt currently has good tests around:
+
+- XSA parsing and topology discovery;
+- `sdtgen` subprocess behavior;
+- generated DTS linting and `dtc` compilation;
+- PetaLinux `system-user.dtsi` formatting and installation;
+- full PetaLinux device-tree build and hardware boot tests.
+
+The missing layer is the **SDT Tcl driver itself**. AMD's legacy `embeddedsw` drivers pair an MDD file with procedural Tcl. Current `system-device-tree-xlnx` instead has one procedural `data/<driver>.tcl` file per driver and a hard-coded IP-to-driver registry. There is no machine-readable contract describing:
+
+- which IP names or VLNVs the driver supports;
+- its generator entry point;
+- required HSI properties and interfaces;
+- the DTS file, nodes, compatibles, and properties it is expected to emit;
+- applicable architecture/tool versions;
+- the Linux binding against which output should be validated.
+
+As a result, a missing registry entry, misspelled HSI parameter, wrong property type, or stale compatible string is normally found only during a licensed-tool run or boot test.
+
+A local baseline run using the pyadi-dt `test/hw/xsa/system_top.xsa`, SDTGen 2025.1, and an upstream `system-device-tree-xlnx` checkout confirmed that:
+
+1. `CUSTOM_SDT_REPO` is accepted and its Tcl sources are loaded;
+2. HSI opens the checked-in XSA successfully;
+3. SDTGen generates `system-top.dts`, `pl.dtsi`, and related files;
+4. the result compiles with `dtc` (with existing upstream warnings);
+5. the fixture contains suitable ADI IPs, including `axi_jesd204_rx`, `axi_jesd204_tx`, `axi_adxcvr`, and `axi_dmac`.
+
+This gives the POC a real, checked-in integration fixture.
+
+## Goals
+
+1. Define a small, versioned, MDD-style contract embedded in Tcl.
+2. Make definitions inspectable with stock `tclsh`, without HSI/Vivado/Vitis.
+3. Test the generator's observable DTS operations with mocked Tcl APIs.
+4. Stage drivers into a complete, pinned `system-device-tree-xlnx` checkout and run real SDTGen against checked-in XSA fixtures.
+5. Reuse pyadi-dt's DTS parser, linter, `dtc`, parity, PetaLinux, and hardware-test infrastructure.
+6. Produce artifacts suitable for upstreaming to `system-device-tree-xlnx`.
+7. Keep the POC narrow enough to validate the architecture before converting other ADI IPs.
+
+## Non-goals for the POC
+
+- Reimplementing HSI or SDTGen in Python.
+- Replacing Linux DT binding documentation (YAML or legacy text) with a second schema language.
+- Converting every ADI IP in the first change.
+- Reintroducing the legacy PSF/MDD file format as a separate file.
+- Replacing pyadi-dt's board-level converter/clock/JESD configuration overlays.
+- Requiring Vivado, Vitis, or PetaLinux for normal pull-request unit tests.
+
+## Proposed Tcl contract
+
+Each driver remains a normal `system-device-tree-xlnx` Tcl implementation and retains the expected global generator adapter. It additionally exposes a side-effect-free definition proc in a driver-specific namespace.
+
+```tcl
+namespace eval ::adidt::sdt::axi_jesd204_rx {
+    variable definition [dict create \
+        schema_version 1 \
+        name axi_jesd204_rx \
+        supported_ip_names {axi_jesd204_rx} \
+        supported_vlnv_globs {analog.com:user:axi_jesd204_rx:*} \
+        generator_proc axi_jesd204_rx_generate \
+        output_files {pl.dtsi} \
+        architectures {zynq zynqmp versal microblaze} \
+        required_hsi_properties {
+            CONFIG.C_NUM_LANES
+            CONFIG.C_DATA_PATH_WIDTH
+            CONFIG.C_LINK_MODE
+            CONFIG.C_NUM_LINKS
+        } \
+        required_interfaces {s_axi core_clk s_axi_aclk irq} \
+        compatibles {adi,axi-jesd204-rx-1.0} \
+        binding Documentation/devicetree/bindings/iio/jesd204/adi,jesd204-rx.txt \
+        binding_format legacy-text \
+        emitted_properties [dict create \
+            compatible stringlist \
+            reg reg \
+            interrupts intlist \
+            clocks phandle-array \
+            clock-names stringlist \
+            adi,octets-per-frame int \
+            adi,frames-per-multiframe int \
+            adi,high-density boolean]]
+
+    proc definition {} {
+        variable definition
+        return $definition
+    }
+}
+
+# Compatibility entry point expected by system-device-tree-xlnx.
+proc axi_jesd204_rx_generate {drv_handle} {
+    ::adidt::sdt::axi_jesd204_rx::generate $drv_handle
+}
+```
+
+The current ADI Linux tree documents this IP in the legacy text binding shown above; it permits compatibles `adi,axi-jesd204-rx-1.0` and `adi,axi-jesd204-rx-1.3`, requires `reg`, `interrupts`, `clocks`, `clock-names`, `adi,frames-per-multiframe`, and `adi,octets-per-frame`, and makes `adi,high-density` optional. The implementation must also audit the current driver and existing pyadi-dt `BoardModel`/builder output because the binding may lag newer JESD204C/framework behavior. Migrating that binding to YAML is useful follow-up work, but is not required to prove the Tcl contract.
+
+### Contract rules
+
+- `definition` must not call HSI, access the filesystem, or mutate a device tree.
+- `schema_version`, `name`, `supported_ip_names`, `generator_proc`, and `output_files` are required.
+- Every named generator proc must exist after sourcing the file.
+- Property types use a small vocabulary mapped to both SDT Tcl helpers and DTS/schema expectations.
+- `supported_ip_names` drives registry generation/checking; it must not be duplicated manually in pyadi-dt.
+- Linux binding paths are references, not copied schemas; both YAML and legacy text bindings are supported and identified by `binding_format`.
+- Architecture/tool constraints are explicit and testable.
+- Driver-specific procedural logic remains allowed; the definition is a contract, not a restrictive code generator.
+
+## Repository layout
+
+Proposed pyadi-dt additions:
+
+```text
+adidt/sdt/
+├── definitions.py              # typed definition model and validation
+├── tcl.py                      # safe tclsh invocation and result decoding
+├── staging.py                  # build a complete CUSTOM_SDT_REPO worktree
+├── registry.py                 # registry validation/patch generation
+└── drivers/
+    └── axi_jesd204_rx/
+        └── data/
+            └── axi_jesd204_rx.tcl
+
+test/sdt/
+├── fixtures/
+│   ├── mock_hsi.tcl
+│   ├── mock_dt.tcl
+│   └── axi_jesd204_rx_expected.json
+├── test_definition_contract.py
+├── test_tcl_generator.py
+├── test_registry.py
+├── test_sdtgen_integration.py
+└── test_petalinux_integration.py
+```
+
+The Tcl files must be included in wheel and sdist package data. The staged repository is generated in a temporary/cache directory and is not vendored into the wheel.
+
+## User-facing tooling
+
+Add an `adidtc sdt-driver` command group:
+
+```bash
+# Scaffold a namespaced Tcl definition and tests
+adidtc sdt-driver init axi_jesd204_rx \
+  --ip-name axi_jesd204_rx \
+  --vlnv 'analog.com:user:axi_jesd204_rx:*'
+
+# Validate all definitions with stock tclsh
+adidtc sdt-driver lint
+
+# Run a generator against mocked HSI/DT APIs
+adidtc sdt-driver test axi_jesd204_rx \
+  --fixture test/sdt/fixtures/axi_jesd204_rx.json
+
+# Stage a complete custom SDT repository using a pinned upstream revision
+adidtc sdt-driver stage \
+  --upstream /path/to/system-device-tree-xlnx \
+  --output .cache/adidt/sdt-repo
+
+# Real XSA/HSI verification
+adidtc sdt-driver verify axi_jesd204_rx \
+  --xsa test/hw/xsa/system_top.xsa \
+  --sdt-repo .cache/adidt/sdt-repo \
+  --output build/sdt-driver/axi_jesd204_rx
+```
+
+`verify` should emit a machine-readable report containing:
+
+- pyadi-dt revision;
+- SDT Tcl driver content hash;
+- `system-device-tree-xlnx` revision;
+- SDTGen/Vivado/Vitis version;
+- selected XSA hash and matched IP instances;
+- definition validation results;
+- emitted node/property inventory;
+- `dtc`, dt-schema, lint, and parity results;
+- paths to generated DTS/DTB/log artifacts.
+
+## Staging and registry integration
+
+A driver directory alone is not enough. Current SDTGen generation dispatch is controlled by `::sdtgen::namespacelist` in `device_tree/data/device_tree.tcl`. Driver lookup mappings are duplicated in `device_tree/data/common_proc.tcl` and the legacy/software helper registry in `device_tree/data/xillib_sw.tcl`. The generation loop uses the namespace map to source `<driver>/data/<driver>.tcl` and call `<driver>_generate`, while common property and alias helpers call `get_drivers`. Staging must patch and verify all three registries.
+
+The staging tool therefore must:
+
+1. require a complete checkout of a supported `system-device-tree-xlnx` revision;
+2. create an isolated worktree/copy rather than mutate the user's checkout;
+3. copy the selected ADI driver directories into that tree;
+4. derive IP-name mappings from `supported_ip_names`;
+5. insert or validate registry entries idempotently;
+6. reject collisions where an IP is already mapped to a different driver;
+7. write a manifest of all copied and patched files;
+8. expose the staged path through `CUSTOM_SDT_REPO` only for the child process.
+
+The long-term upstream result should be ordinary driver Tcl plus registry changes in `system-device-tree-xlnx`; the pyadi-dt staging layer is an authoring/test bridge, not a permanent fork.
+
+## Proof of concept scope
+
+### Driver
+
+Use `axi_jesd204_rx` with ADRV9009+ZC706. The lab XSA contains both the primary and observation receive instances, so the POC verifies repeated dispatch of the same driver:
+
+```text
+instances: axi_adrv9009_rx_jesd_rx_axi,
+           axi_adrv9009_rx_os_jesd_rx_axi
+IP name:   axi_jesd204_rx
+VLNV:      analog.com:user:axi_jesd204_rx:1.0
+```
+
+The current generic SDT output creates the node but emits a Xilinx-compatible form such as:
+
+```dts
+axi_adrv9009_rx_jesd_rx_axi: axi_jesd204_rx@44aa0000 {
+    compatible = "xlnx,axi-jesd204-rx-1.0";
+    xlnx,num-lanes = <4>;
+    xlnx,data-path-width = <4>;
+    ...
+};
+```
+
+The POC driver must demonstrate a deliberate, binding-backed ADI result and prove which properties are generated from HSI versus supplied later by pyadi-dt's board/JESD configuration layer. It must not silently duplicate or conflict with the existing overlay.
+
+### Required POC behavior
+
+1. The definition is discoverable without HSI.
+2. The fixture's IP name and VLNV match the definition.
+3. The generator runs under a mock API and emits the expected compatible and typed properties.
+4. Staging creates a valid custom SDT repository and registry mapping.
+5. SDTGen 2025.1 runs against `test/hw/xsa/system_top.xsa` with that repository.
+6. The generated node is found by instance label/address and satisfies the definition.
+7. The generated tree compiles with `dtc`.
+8. Existing pyadi-dt overlay generation merges without duplicate labels/properties or incompatible values.
+9. The final merged/PetaLinux tree passes pyadi-dt lint and semantic parity checks.
+10. The integration report is retained as a CI artifact.
+
+A follow-up should add `axi_jesd204_tx`, which is structurally similar and will reveal whether the definition model generalizes without prematurely broadening the first implementation.
+
+## Test strategy
+
+### Tier 1: definition tests — every PR, no vendor tools
+
+Run with Python plus stock `tclsh`:
+
+- source each driver Tcl in a restricted harness;
+- call its namespaced `definition` proc;
+- serialize the Tcl dict to JSON through a small Tcl harness;
+- validate against a Pydantic model;
+- verify required keys, schema version, generator existence, unique names/IP mappings, allowed property types, and package inclusion;
+- reject top-level side effects by stubbing unknown commands to fail during definition loading;
+- verify deterministic output from repeated definition calls.
+
+Do not parse Tcl with regular expressions. Let Tcl parse Tcl.
+
+### Tier 2: mocked generator tests — every PR, no vendor tools
+
+Provide minimal Tcl implementations of the APIs used by the POC driver:
+
+- `hsi::get_cells`, `hsi get_property`, and connection/property queries;
+- `get_node`, `set_drv_def_dts`, `add_prop`, `set_drv_conf_prop`, and `create_node`;
+- an operation recorder that emits JSON.
+
+Assertions should compare semantic operations, not whitespace:
+
+```json
+{
+  "node": "axi_mxfe_rx_jesd_rx_axi",
+  "property": "compatible",
+  "type": "stringlist",
+  "value": ["adi,axi-jesd204-rx-1.0"]
+}
+```
+
+Negative fixtures must cover a missing required HSI parameter, unsupported IP version, wrong property type, and missing clock/interrupt connection.
+
+### Tier 3: static cross-checks — every PR
+
+- Cross-check `supported_ip_names` against the staged/generated SDT registry.
+- Cross-check emitted properties and compatible strings against the referenced Linux binding. Reuse pyadi-dt's binding audit tooling for YAML and add a small legacy-text adapter for this POC binding.
+- Scan checked-in XSA/HWH fixtures and report definition coverage.
+- Ensure every definition has at least one fixture or an explicit untested rationale.
+- Run `ruff`, type checking, package build, and installed-wheel discovery tests.
+
+### Tier 4: real SDTGen integration — licensed self-hosted runner
+
+For each supported toolchain leg (start with 2025.1):
+
+```bash
+export CUSTOM_SDT_REPO="$STAGED_SDT_REPO"
+sdtgen -eval \
+  "set_dt_param -xsa {$XSA} -dir {$OUT}; generate_sdt"
+cpp -nostdinc -undef -x assembler-with-cpp -I "$OUT" \
+  "$OUT/system-top.dts" > "$OUT/system-top.pp.dts"
+dtc -I dts -O dtb -o "$OUT/system-top.dtb" "$OUT/system-top.pp.dts"
+```
+
+Then run pyadi-dt's structural linter and semantic assertions against the generated node. Pin the upstream SDT repository revision and record it in the report.
+
+A complete SDT checkout is mandatory. A sparse checkout containing only the POC driver is insufficient because generation also sources processor and platform drivers.
+
+### Tier 5: PetaLinux build integration — labeled/nightly
+
+Extend the existing PetaLinux harness to select a staged driver repository and build only the device-tree recipe:
+
+```bash
+petalinux-config --get-hw-description=<isolated-xsa-dir> --silentconfig
+petalinux-build -c device-tree
+```
+
+The test must inspect `images/linux/system.dtb`, not only `system-user.dtsi`, and assert:
+
+- the target node has the expected ADI compatible;
+- required clocks, interrupts, and register ranges survived DTG/BitBake processing;
+- no duplicate node/label was introduced by the pyadi-dt overlay;
+- the final DTB passes the same semantic contract as the SDTGen artifact.
+
+Because propagation of `CUSTOM_SDT_REPO` through a given PetaLinux release must be proven rather than assumed, the POC should first add an environment/preflight check that records which SDT repository the PetaLinux DTG actually sourced. If the release does not honor it, stage the Tcl into an isolated tool/project repository through an explicit adapter rather than modifying the global installation.
+
+### Tier 6: hardware validation — manual label/nightly
+
+Reuse the existing labgrid path:
+
+- boot the PetaLinux-generated DTB;
+- assert no kernel faults;
+- assert the expected IIO devices probe;
+- assert JESD204 reaches DATA state;
+- run a minimal RX capture.
+
+This tier validates behavior but should not be the first place a definition error is discovered.
+
+## CI integration
+
+Recommended jobs:
+
+| Job | Environment | Trigger | Required |
+|---|---|---|---|
+| `sdt-driver-contract` | GitHub-hosted Ubuntu + `tclsh` | every PR | yes |
+| `sdt-driver-mock` | GitHub-hosted Ubuntu + `tclsh` | every PR | yes |
+| `sdt-driver-binding` | GitHub-hosted Ubuntu + binding cache | every PR | yes |
+| `sdt-driver-sdtgen-2025.1` | licensed self-hosted runner | label, main, nightly | required for Tcl-driver changes |
+| `sdt-driver-petalinux` | PetaLinux self-hosted runner | label, main, nightly | required before release/upstream submission |
+| `sdt-driver-hardware` | labgrid runner | `hw-test` label/nightly | required before declaring hardware support |
+
+Use a changed-files filter so licensed jobs run automatically when these paths change:
+
+```text
+adidt/sdt/**
+test/sdt/**
+adidt/xsa/parse/sdtgen.py
+adidt/xsa/merge/**
+.github/workflows/*sdt*
+```
+
+Upload staged-repository manifests, Tcl operation logs, generated DTS/DTB, validation JSON, and tool versions even on failure.
+
+## Implementation phases
+
+### Phase 1 — contract spike
+
+- Add the typed Python definition model.
+- Add the stock-`tclsh` loader/harness.
+- Add one inert `axi_jesd204_rx` definition and contract tests.
+- Confirm definition discovery works from an installed wheel.
+
+**Exit criterion:** no vendor tools are needed to validate the metadata contract.
+
+### Phase 2 — mocked generation
+
+- Implement the minimal generator Tcl.
+- Add mock HSI/DT APIs and semantic operation snapshots.
+- Add positive and negative fixtures.
+- Cross-check compatible/properties with the Linux binding.
+
+**Exit criterion:** generator behavior is deterministic and reviewable on GitHub-hosted CI.
+
+### Phase 3 — real SDTGen staging
+
+- Add complete-repository staging and registry patching.
+- Pin a supported `system-device-tree-xlnx` revision.
+- Run the checked-in AD9081 XSA through SDTGen 2025.1.
+- Compile and inspect generated output; compare with the current baseline and pyadi-dt overlay.
+
+**Exit criterion:** the POC changes the intended node only, with a machine-readable diff and green `dtc`/lint/parity checks.
+
+### Phase 4 — PetaLinux and hardware
+
+- Prove how the selected PetaLinux release consumes the staged Tcl repository.
+- Build `system.dtb` using `petalinux-build -c device-tree`.
+- Add an opt-in labgrid boot/probe test.
+
+**Exit criterion:** the final PetaLinux DTB boots and the ADI/JESD device probes successfully.
+
+### Phase 5 — upstream path
+
+- Generate a clean patch for `system-device-tree-xlnx` containing the Tcl driver and registry entry.
+- Keep the pyadi-dt contract/tests as the conformance suite.
+- Add `axi_jesd204_tx` only after the RX POC has proven the model.
+
+## Acceptance criteria
+
+The POC is complete when:
+
+- [ ] `axi_jesd204_rx.tcl` exposes a schema-versioned, side-effect-free definition.
+- [ ] `adidtc sdt-driver lint/test/stage/verify` provide actionable failures.
+- [ ] stock-`tclsh` contract and mocked-generator tests run on normal CI.
+- [ ] an installed wheel contains and discovers the Tcl definition.
+- [ ] a complete staged `system-device-tree-xlnx` checkout is generated without mutating its source checkout.
+- [ ] SDTGen 2025.1 uses the staged repository and the checked-in XSA.
+- [ ] generated DTS compiles and passes pyadi-dt lint/binding/parity checks.
+- [ ] pyadi-dt overlay behavior is explicitly reconciled with Tcl output; no duplicate or conflicting properties remain.
+- [ ] PetaLinux builds a final `system.dtb` whose target node satisfies the same contract.
+- [ ] CI retains tool versions, repository revisions, generated trees, semantic diff, and logs.
+- [ ] one hardware run confirms probe and JESD DATA state before support is declared.
+
+## Risks and mitigations
+
+### Tcl definitions become a second binding schema
+
+Keep the metadata focused on driver dispatch, dependencies, and expected output. Linux binding YAML remains authoritative for property semantics, and tests cross-check rather than copy the full binding.
+
+### Mock APIs diverge from HSI
+
+Use mocks only for fast behavior tests. Require real SDTGen integration for Tcl changes and keep captured HSI fixtures/version metadata.
+
+### pyadi-dt and Tcl both write the same node
+
+Treat this as a first-class parity test. Define ownership per property: hardware-discoverable values belong in Tcl; board/solver-derived values remain in pyadi-dt. Merge must reject conflicting duplicate values.
+
+### Registry patching is brittle
+
+Use definition-derived mappings, parse/modify a narrowly recognized registry form, verify idempotence, and fail closed on unexpected upstream structure. Emit a patch for review.
+
+### Vendor version drift
+
+Pin and report the supported SDT revision/tool version, test at least one current release, and add a matrix only after the POC. Contract tests remain version-independent.
+
+### PetaLinux ignores `CUSTOM_SDT_REPO`
+
+Add a preflight provenance assertion. Never claim PetaLinux coverage based solely on an SDTGen run. Use an isolated project/tool repository adapter if necessary; do not patch a global installation in CI.
+
+## Recommended first pull requests
+
+1. **Contract and loader:** typed model, Tcl definition loader, package data, and unit tests.
+2. **RX driver mock POC:** `axi_jesd204_rx` Tcl generator, mock API, binding checks, and fixtures.
+3. **SDT staging/integration:** registry generation, pinned upstream staging, real SDTGen job, DTS semantic diff.
+4. **PetaLinux integration:** provenance preflight, device-tree recipe build, final-DTB assertions.
+5. **Hardware/upstream:** labgrid validation and an upstream-ready `system-device-tree-xlnx` patch.
+
+This sequence keeps each change reviewable and prevents licensed-tool or hardware failures from masking basic definition errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ adidt = [
     "xsa/viz/d3_bundle.js",
     "xsa/config/profiles/*.json",
     "xsa/config/kuiper_boards.json",
+    "sdt/drivers/*/data/*.tcl",
 ]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
 ]
 dev = [
     "adidt[test]",
-    "adi-labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git",
+    "labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git",
     "pyadi-build @ git+https://github.com/tfcollins/pyadi-build.git",
     "usbsdmux",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "adidt[test]",
     "labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git",
     "pyadi-build @ git+https://github.com/tfcollins/pyadi-build.git",
+    "defusedxml>=0.7",
     "usbsdmux",
 ]
 mcp = ["fastmcp"]

--- a/test/hw/README.md
+++ b/test/hw/README.md
@@ -210,6 +210,15 @@ Fetch each place's env from the coordinator first (`<place>` = `mini2` / `nemo` 
 curl -fsSL "http://10.0.0.41:8000/api/places/<place>/env-yaml?tier=boot" -o /tmp/lg-<place>.yaml
 ```
 
+For manual runs using the persistent CI environment, configure both its
+console scripts (`pytest`, `labgrid-client`, `usbsdmux`) and Vitis/SDTGen in
+the current shell before invoking pytest:
+
+```sh
+export VENV_DIR="$HOME/.cache/adidt-ci/adidt-venv"
+source .github/scripts/setup-hw-tool-path.sh
+```
+
 ```sh
 # AD9081 / ZCU102 — any host
 LG_COORDINATOR=10.0.0.41:20408 \

--- a/test/hw/conftest.py
+++ b/test/hw/conftest.py
@@ -58,7 +58,7 @@ def board(strategy):
         The labgrid *strategy* object after the board has been
         transitioned to the ``powered_off`` state.
     """
-    require_hw_prereqs()
+    require_hw_prereqs(strategy)
     strategy.transition("powered_off")
     try:
         yield strategy

--- a/test/hw/hw_helpers.py
+++ b/test/hw/hw_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -294,23 +295,31 @@ def unload_overlay(shell, name: str) -> str:
     )
 
 
-def require_hw_prereqs() -> None:
+def _strategy_requires_usbsdmux(strategy) -> bool:
+    """Return whether *strategy* declares a USB SD-mux driver binding."""
+    bindings = getattr(type(strategy), "bindings", {})
+    return "sdmux" in bindings or "USBSDMuxDriver" in bindings.values()
+
+
+def require_hw_prereqs(strategy) -> None:
     """Skip the current test if required system tools are missing.
 
-    Checks for ``sdtgen``, ``dtc``, and ``usbsdmux`` on ``PATH``.  Also
-    probes the local ``venv/bin/usbsdmux`` path as a fallback before giving
-    up on ``usbsdmux``.
+    ``sdtgen`` and ``dtc`` are common requirements. ``usbsdmux`` is only
+    required by strategies which declare an ``sdmux`` binding; TFTP/JTAG
+    strategies such as ADRV9009+ZC706 must not be skipped for lacking it.
+    For SD-mux strategies, also probe the active Python environment's bin
+    directory before skipping.
     """
     if shutil.which("sdtgen") is None:
         pytest.skip("sdtgen not found on PATH (Vivado tools required)")
     if shutil.which("dtc") is None:
         pytest.skip("dtc not found on PATH")
-    if shutil.which("usbsdmux") is None:
-        local_usbsdmux = Path.cwd() / "venv" / "bin" / "usbsdmux"
-        if local_usbsdmux.exists():
-            os.environ["PATH"] = f"{local_usbsdmux.parent}:{os.environ.get('PATH', '')}"
-    if shutil.which("usbsdmux") is None:
-        pytest.skip("usbsdmux not found on PATH")
+    if _strategy_requires_usbsdmux(strategy) and shutil.which("usbsdmux") is None:
+        environment_bin = Path(sys.executable).resolve().parent
+        if (environment_bin / "usbsdmux").is_file():
+            os.environ["PATH"] = f"{environment_bin}:{os.environ.get('PATH', '')}"
+        if shutil.which("usbsdmux") is None:
+            pytest.skip("usbsdmux not found on PATH (required by SD-mux strategy)")
 
 
 # Known-benign ``dmesg`` lines unrelated to our ADC/DAC/JESD flow.  These

--- a/test/sdt/test_definition_contract.py
+++ b/test/sdt/test_definition_contract.py
@@ -1,0 +1,44 @@
+"""Contract tests for MDD-style SDT Tcl driver definitions."""
+
+from pathlib import Path
+
+import pytest
+
+from adidt.sdt.definitions import load_tcl_definition
+
+DRIVER = (
+    Path(__file__).resolve().parents[2]
+    / "adidt/sdt/drivers/axi_jesd204_rx/data/axi_jesd204_rx.tcl"
+)
+
+
+def test_axi_jesd204_rx_definition_loads_with_stock_tclsh() -> None:
+    definition = load_tcl_definition(DRIVER)
+
+    assert definition.name == "axi_jesd204_rx"
+    assert definition.supported_ip_names == ("axi_jesd204_rx",)
+    assert "analog.com:user:axi_jesd204_rx:*" in definition.supported_vlnv_globs
+    assert definition.generator_proc == "axi_jesd204_rx_generate"
+    assert definition.output_files == ("pl.dtsi",)
+    assert definition.emitted_properties == {"compatible": "stringlist"}
+    assert definition.binding_format == "legacy-text"
+
+
+def test_definition_is_deterministic() -> None:
+    assert load_tcl_definition(DRIVER) == load_tcl_definition(DRIVER)
+
+
+def test_definition_rejects_missing_generator(tmp_path: Path) -> None:
+    broken = tmp_path / "broken.tcl"
+    broken.write_text(
+        "namespace eval ::adidt::sdt::broken {\n"
+        " variable d [dict create schema_version 1 name broken "
+        "supported_ip_names x supported_vlnv_globs x generator_proc absent "
+        "output_files pl.dtsi architectures zynq required_hsi_properties {} "
+        "required_interfaces {} compatibles x binding x binding_format legacy-text "
+        "emitted_properties [dict create compatible stringlist]]\n"
+        " proc definition {} { variable d; return $d }\n}\n"
+    )
+
+    with pytest.raises(ValueError, match="generator proc not found"):
+        load_tcl_definition(broken)

--- a/test/sdt/test_sdtgen_integration.py
+++ b/test/sdt/test_sdtgen_integration.py
@@ -1,0 +1,87 @@
+"""Opt-in real SDTGen integration test for the Tcl driver POC."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from adidt.sdt import stage_sdt_repository
+from adidt.xsa.parse.sdtgen import SdtgenRunner
+
+UPSTREAM = os.environ.get("ADIDT_SDT_UPSTREAM")
+XSA = os.environ.get("ADIDT_SDT_XSA")
+DRIVERS = Path(__file__).resolve().parents[2] / "adidt/sdt/drivers"
+RX_LABELS = (
+    "axi_adrv9009_rx_jesd_rx_axi",
+    "axi_adrv9009_rx_os_jesd_rx_axi",
+)
+
+requires_sdtgen_fixture = pytest.mark.skipif(
+    not (UPSTREAM and XSA),
+    reason="set ADIDT_SDT_UPSTREAM and ADIDT_SDT_XSA for real SDTGen integration",
+)
+
+
+def _node_block(text: str, label: str) -> str:
+    match = re.search(rf"\b{re.escape(label)}\s*:.*?\n\s*\}};", text, re.DOTALL)
+    assert match is not None, f"SDTGen did not emit {label}"
+    return match.group()
+
+
+@requires_sdtgen_fixture
+def test_adrv9009_zc706_rx_driver_with_real_sdtgen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stage the driver, run HSI on the real XSA, and compile its SDT."""
+    assert UPSTREAM is not None
+    assert XSA is not None
+    staged = tmp_path / "system-device-tree-xlnx"
+    output = tmp_path / "output"
+    output.mkdir()
+    manifest = stage_sdt_repository(UPSTREAM, staged, DRIVERS)
+    monkeypatch.setenv("CUSTOM_SDT_REPO", str(staged))
+
+    system_top = SdtgenRunner().run(Path(XSA), output, timeout=300)
+
+    assert manifest.is_file()
+    pl_text = (output / "pl.dtsi").read_text()
+    for label in RX_LABELS:
+        block = _node_block(pl_text, label)
+        assert 'compatible = "adi,axi-jesd204-rx-1.0";' in block
+        assert "xlnx,axi-jesd204-rx-1.0" not in block
+
+    if shutil.which("cpp") and shutil.which("dtc"):
+        preprocessed = output / "system-top.pp.dts"
+        dtb = output / "system-top.dtb"
+        with preprocessed.open("w") as stream:
+            cpp = subprocess.run(
+                [
+                    "cpp",
+                    "-nostdinc",
+                    "-undef",
+                    "-x",
+                    "assembler-with-cpp",
+                    "-I",
+                    str(output),
+                    str(system_top),
+                ],
+                stdout=stream,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        assert cpp.returncode == 0
+        dtc = subprocess.run(
+            ["dtc", "-I", "dts", "-O", "dtb", "-o", str(dtb), str(preprocessed)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        assert dtc.returncode == 0, dtc.stderr
+        assert dtb.stat().st_size > 0

--- a/test/sdt/test_staging.py
+++ b/test/sdt/test_staging.py
@@ -1,0 +1,80 @@
+"""Tests for isolated SDT repository staging and registry generation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from adidt.sdt.staging import stage_sdt_repository
+
+DRIVERS = Path(__file__).resolve().parents[2] / "adidt/sdt/drivers"
+
+
+def _upstream(tmp_path: Path) -> Path:
+    upstream = tmp_path / "upstream"
+    registry = upstream / "device_tree/data/xillib_sw.tcl"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        "proc get_drivers_sw args {\n"
+        "\tset driverlist [dict create]\n"
+        "\tdict set driverlist axi_dma driver axi_dma\n"
+        "\treturn $driverlist\n"
+        "}\n"
+    )
+    common_registry = upstream / "device_tree/data/common_proc.tcl"
+    common_registry.write_text(
+        "proc get_drivers args {\n"
+        "\tset driverlist [dict create]\n"
+        "\tdict set driverlist axi_dma driver axi_dma\n"
+        "\treturn $driverlist\n"
+        "}\n"
+    )
+    dispatcher = upstream / "device_tree/data/device_tree.tcl"
+    dispatcher.write_text(
+        "proc init_proclist {} {\n"
+        '\tdict set ::sdtgen::namespacelist "axi_dma" "axi_dma"\n'
+        "}\n"
+    )
+    (upstream / "cpu/data").mkdir(parents=True)
+    (upstream / "cpu/data/cpu.tcl").write_text("# complete-tree sentinel\n")
+    return upstream
+
+
+def test_stage_installs_driver_and_registry_mapping(tmp_path: Path) -> None:
+    upstream = _upstream(tmp_path)
+    output = tmp_path / "staged"
+
+    manifest_path = stage_sdt_repository(upstream, output, DRIVERS)
+
+    driver = output / "axi_jesd204_rx/data/axi_jesd204_rx.tcl"
+    assert driver.is_file()
+    registry = (output / "device_tree/data/xillib_sw.tcl").read_text()
+    assert "dict set driverlist axi_jesd204_rx driver axi_jesd204_rx" in registry
+    common_registry = (output / "device_tree/data/common_proc.tcl").read_text()
+    assert "dict set driverlist axi_jesd204_rx driver axi_jesd204_rx" in common_registry
+    dispatcher = (output / "device_tree/data/device_tree.tcl").read_text()
+    assert (
+        'dict set ::sdtgen::namespacelist "axi_jesd204_rx" "axi_jesd204_rx"'
+        in dispatcher
+    )
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["mappings"] == {"axi_jesd204_rx": "axi_jesd204_rx"}
+    assert manifest["files"][0]["sha256"]
+    assert len(manifest["registries"]) == 3
+    assert not (output / ".git").exists()
+
+
+def test_stage_does_not_overwrite_existing_output(tmp_path: Path) -> None:
+    output = tmp_path / "staged"
+    output.mkdir()
+
+    with pytest.raises(FileExistsError):
+        stage_sdt_repository(_upstream(tmp_path), output, DRIVERS)
+
+
+def test_stage_requires_complete_registry(tmp_path: Path) -> None:
+    upstream = tmp_path / "incomplete"
+    upstream.mkdir()
+
+    with pytest.raises(ValueError, match="not a complete"):
+        stage_sdt_repository(upstream, tmp_path / "out", DRIVERS)

--- a/test/sdt/test_tcl_generator.py
+++ b/test/sdt/test_tcl_generator.py
@@ -1,0 +1,79 @@
+"""Behavior tests for the AXI JESD204 RX Tcl generator."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+DRIVER = (
+    Path(__file__).resolve().parents[2]
+    / "adidt/sdt/drivers/axi_jesd204_rx/data/axi_jesd204_rx.tcl"
+)
+
+HARNESS = r"""
+set driver_file [lindex $argv 0]
+set requested_ip [lindex $argv 1]
+set node_result [lindex $argv 2]
+set operations {}
+proc hsi {subcommand args} {
+    global requested_ip
+    if {$subcommand eq "get_property" && [lindex $args 0] eq "IP_NAME"} {
+        return $requested_ip
+    }
+    error "unexpected hsi invocation: $subcommand $args"
+}
+proc get_node {drv_handle} {
+    global node_result
+    return $node_result
+}
+proc pldt {subcommand node property value} {
+    global operations
+    lappend operations [list $subcommand $node $property $value]
+}
+source $driver_file
+axi_jesd204_rx_generate axi_rx_0
+foreach operation $operations {
+    puts [join $operation "\t"]
+}
+"""
+
+
+def _run(
+    ip_name: str = "axi_jesd204_rx", node: str = "node0"
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".tcl", encoding="utf-8"
+    ) as harness:
+        harness.write(HARNESS)
+        harness.flush()
+        return subprocess.run(
+            ["tclsh", harness.name, str(DRIVER), ip_name, node],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+
+def test_generator_replaces_only_compatible_property() -> None:
+    result = _run()
+
+    assert result.returncode == 0, result.stderr
+    fields = result.stdout.strip().split("\t")
+    assert fields[:3] == ["set", "node0", "compatible"]
+    assert fields[3] == '"adi,axi-jesd204-rx-1.0"'
+
+
+def test_generator_rejects_wrong_ip() -> None:
+    result = _run(ip_name="axi_jesd204_tx")
+
+    assert result.returncode != 0
+    assert "unsupported IP 'axi_jesd204_tx'" in result.stderr
+
+
+def test_generator_rejects_missing_node() -> None:
+    result = _run(node="0")
+
+    assert result.returncode != 0
+    assert "no SDT node exists" in result.stderr

--- a/test/test_hw_helpers.py
+++ b/test/test_hw_helpers.py
@@ -18,10 +18,48 @@ os.environ.setdefault("LG_ENV", "unit-test-noop")
 
 from test.hw.hw_helpers import (  # noqa: E402
     IlasMismatch,
+    _strategy_requires_usbsdmux,
     assert_ilas_aligned,
     check_jesd_framing_plausibility,
     parse_ilas_status,
+    require_hw_prereqs,
 )
+
+
+class _TftpStrategy:
+    bindings = {"tftp_driver": "TFTPServerDriver"}
+
+
+class _SdMuxStrategy:
+    bindings = {"sdmux": "USBSDMuxDriver"}
+
+
+def test_tftp_strategy_does_not_require_usbsdmux(monkeypatch):
+    requested = []
+
+    def fake_which(command):
+        requested.append(command)
+        return f"/tools/{command}" if command in {"sdtgen", "dtc"} else None
+
+    monkeypatch.setattr("test.hw.hw_helpers.shutil.which", fake_which)
+    require_hw_prereqs(_TftpStrategy())
+    assert requested == ["sdtgen", "dtc"]
+
+
+def test_sd_mux_strategy_requires_usbsdmux(monkeypatch):
+    monkeypatch.setattr(
+        "test.hw.hw_helpers.shutil.which",
+        lambda command: f"/tools/{command}" if command in {"sdtgen", "dtc"} else None,
+    )
+    monkeypatch.setattr("test.hw.hw_helpers.Path.is_file", lambda _path: False)
+
+    with pytest.raises(pytest.skip.Exception, match="required by SD-mux strategy"):
+        require_hw_prereqs(_SdMuxStrategy())
+
+
+def test_strategy_prerequisite_detection_uses_bindings():
+    assert not _strategy_requires_usbsdmux(_TftpStrategy())
+    assert _strategy_requires_usbsdmux(_SdMuxStrategy())
 
 
 _DMESG_WITH_ILAS_MISMATCH = """\


### PR DESCRIPTION
## Summary

- add an MDD-style, side-effect-free Tcl contract and typed Python loader for SDT drivers
- add an `axi_jesd204_rx` proof-of-concept driver for ADRV9009 + ZC706
- stage drivers into an isolated `system-device-tree-xlnx` checkout and update all three driver registries
- add mocked Tcl, staging, packaging, and opt-in real-SDTGen integration coverage
- scope `usbsdmux` prerequisites to SD-mux strategies and make CI resolve persistent-venv/Vitis tool paths reliably

## Property ownership

- Tcl normalizes hardware-derived SDT output and emits `adi,axi-jesd204-rx-1.0`.
- pyadi-dt retains board/JESD-solver-owned F/K, link IDs, topology, and clock phandles.

## Verification

- `23 passed` across hardware-helper and focused SDT unit tests
- real SDTGen 2025.1 integration against ADRV9009/ZC706 XSA: passed
- wheel build includes `axi_jesd204_rx.tcl`
- local labgrid `nemo` ADRV9009/ZC706 boot: `1 passed, 2 warnings`
- verified both JESD RX/TX links in DATA; board powered off and place released
- hardware CI venv installer and clean-shell Vitis/usbsdmux path resolution: passed

## Hardware artifacts

- Final local hardware run: `1 passed, 2 warnings in 104.85s`
- The `hw-test` label requests hosted hardware-in-the-loop verification for this PR.


## Prism terminal capture

Hardware pytest shards now use the vendored `pytest-prism` client to capture the complete pytest terminal stream as `terminal.log`. The workflow preserves its existing JUnit output, publishes the Prism manifest and archive as Actions artifacts, and uploads the archive to Prism after each hardware leg.

Verified in [Hardware Tests run 29342566219](https://github.com/analogdevicesinc/pyadi-dt/actions/runs/29342566219): all four hardware legs passed, including ADRV9009/ZC706, and Prism ingested `terminal.log` with `manifest_kind=terminal_log`.
