### PR TITLE
feat(jif): define versioned pyadi-jif device-tree contract

### DIFF
--- a/adidt/jif_contract.py
+++ b/adidt/jif_contract.py
@@ -1,0 +1,197 @@
+"""Versioned interface contract between pyadi-jif and pyadi-dt.
+
+The contract carries solved electrical intent.  Physical device-tree placement
+(clock channel numbers, labels, SPI chip-selects, and GPIOs) remains owned by
+pyadi-dt and is joined through :class:`JifDtBindings`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+
+CONTRACT_NAME = "adi.jif-dt"
+CONTRACT_VERSION = "1.0"
+
+
+class ContractError(ValueError):
+    """Raised when a JIF/DT handoff is incompatible or cannot be bound."""
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class Producer(_StrictModel):
+    """Identity of the program that generated the handoff."""
+
+    name: Literal["pyadi-jif"] = "pyadi-jif"
+    version: str = Field(min_length=1)
+
+
+class JesdParameters(_StrictModel):
+    """JESD transport parameters shared by converter and FPGA endpoints."""
+
+    F: int = Field(gt=0, strict=True)
+    K: int = Field(gt=0, strict=True)
+    L: int = Field(gt=0, strict=True)
+    M: int = Field(gt=0, strict=True)
+    N: int = Field(gt=0, strict=True)
+    Np: int = Field(gt=0, strict=True)
+    S: int = Field(gt=0, strict=True)
+    HD: int = Field(ge=0, le=1, strict=True)
+    CS: int = Field(default=0, ge=0, strict=True)
+    CF: int = Field(default=0, ge=0, strict=True)
+
+    @model_validator(mode="after")
+    def validate_transport_identity(self) -> "JesdParameters":
+        # JESD204 transport identity: F = M * S * Np / (8 * L).
+        numerator = self.M * self.S * self.Np
+        denominator = 8 * self.L
+        if numerator != self.F * denominator:
+            raise ValueError(
+                "inconsistent JESD transport parameters: "
+                "M*S*Np must equal 8*L*F"
+            )
+        return self
+
+
+class JesdLink(_StrictModel):
+    """One solved unidirectional JESD link."""
+
+    id: str = Field(pattern=r"^[a-z0-9][a-z0-9_.-]*$")
+    direction: Literal["adc-to-fpga", "fpga-to-dac"]
+    converter: str = Field(min_length=1)
+    fpga: str = Field(min_length=1)
+    standard: Literal["jesd204b", "jesd204c"]
+    sample_rate_hz: int = Field(gt=0, strict=True)
+    lane_rate_hz: int = Field(gt=0, strict=True)
+    parameters: JesdParameters
+    fpga_config: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_lane_rate(self) -> "JesdLink":
+        p = self.parameters
+        encoding_ratio = (10, 8) if self.standard == "jesd204b" else (66, 64)
+        expected_num = self.sample_rate_hz * p.M * p.Np * encoding_ratio[0]
+        expected_den = p.L * encoding_ratio[1]
+        # Integer-Hz interchange allows one hertz of rounding at the boundary.
+        if abs(self.lane_rate_hz * expected_den - expected_num) > expected_den:
+            raise ValueError("lane_rate_hz is inconsistent with JESD parameters")
+        return self
+
+
+class ClockRequirement(_StrictModel):
+    """A semantic solved clock requirement, not a physical output channel."""
+
+    id: str = Field(pattern=r"^[a-z0-9][a-z0-9_.-]*$")
+    role: Literal[
+        "converter-device",
+        "converter-sysref",
+        "fpga-ref",
+        "fpga-link",
+        "pll-ref",
+        "other",
+    ]
+    sink: str = Field(min_length=1)
+    rate_hz: int = Field(gt=0, strict=True)
+    divider: int | None = Field(default=None, gt=0, strict=True)
+    source: str = Field(min_length=1)
+
+
+class JifDtContract(_StrictModel):
+    """Portable, versioned result produced by JIF and consumed by DT."""
+
+    schema_name: Literal["adi.jif-dt"] = Field(CONTRACT_NAME, alias="schema")
+    version: Literal["1.0"] = CONTRACT_VERSION
+    producer: Producer
+    jesd_links: tuple[JesdLink, ...]
+    clock_requirements: tuple[ClockRequirement, ...]
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_unique_ids(self) -> "JifDtContract":
+        for kind, entries in (
+            ("JESD link", self.jesd_links),
+            ("clock requirement", self.clock_requirements),
+        ):
+            ids = [entry.id for entry in entries]
+            duplicates = sorted({item for item in ids if ids.count(item) > 1})
+            if duplicates:
+                raise ValueError(f"duplicate {kind} ids: {duplicates}")
+        return self
+
+    @classmethod
+    def from_json_file(cls, path: str | Path) -> "JifDtContract":
+        """Load and validate a contract without mutating any DT state."""
+        try:
+            payload = json.loads(Path(path).read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ContractError(f"cannot read JIF/DT contract: {exc}") from exc
+        try:
+            return cls.model_validate(payload)
+        except ValueError as exc:
+            raise ContractError(f"invalid JIF/DT contract: {exc}") from exc
+
+    def to_json_file(self, path: str | Path) -> None:
+        """Write deterministic JSON suitable for fixtures and interchange."""
+        Path(path).write_text(self.model_dump_json(indent=2, by_alias=True) + "\n")
+
+
+class ClockBinding(_StrictModel):
+    """pyadi-dt-owned placement of one semantic clock onto a DT endpoint."""
+
+    requirement_id: str
+    dt_label: str = Field(min_length=1)
+    output_index: int = Field(ge=0, strict=True)
+
+
+class JesdBinding(_StrictModel):
+    """pyadi-dt-owned placement of one semantic JESD link onto DT nodes."""
+
+    link_id: str
+    converter_label: str = Field(min_length=1)
+    jesd_label: str = Field(min_length=1)
+    xcvr_label: str = Field(min_length=1)
+
+
+class JifDtBindings(_StrictModel):
+    """Physical pyadi-dt profile bindings for a JIF handoff."""
+
+    clocks: tuple[ClockBinding, ...]
+    jesd_links: tuple[JesdBinding, ...]
+
+    def check(self, contract: JifDtContract) -> None:
+        """Require complete, unique bindings before any DT is rendered or edited."""
+        self._check_set(
+            "clock requirement",
+            {item.id for item in contract.clock_requirements},
+            [item.requirement_id for item in self.clocks],
+        )
+        self._check_set(
+            "JESD link",
+            {item.id for item in contract.jesd_links},
+            [item.link_id for item in self.jesd_links],
+        )
+        endpoints = [(item.dt_label, item.output_index) for item in self.clocks]
+        duplicates = sorted({item for item in endpoints if endpoints.count(item) > 1})
+        if duplicates:
+            raise ContractError(f"multiple clocks bound to DT endpoints: {duplicates}")
+
+    @staticmethod
+    def _check_set(kind: str, required: set[str], supplied: list[str]) -> None:
+        duplicate = sorted({item for item in supplied if supplied.count(item) > 1})
+        missing = sorted(required - set(supplied))
+        unknown = sorted(set(supplied) - required)
+        problems = []
+        if missing:
+            problems.append(f"missing={missing}")
+        if unknown:
+            problems.append(f"unknown={unknown}")
+        if duplicate:
+            problems.append(f"duplicate={duplicate}")
+        if problems:
+            raise ContractError(f"invalid {kind} bindings: " + ", ".join(problems))

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -5,6 +5,7 @@ API Reference
    :maxdepth: 2
 
    core
+   jif_contract
    devices
    model
    xsa

--- a/doc/source/api/jif_contract.rst
+++ b/doc/source/api/jif_contract.rst
@@ -1,0 +1,15 @@
+pyadi-jif Interface Contract
+============================
+
+The :mod:`adidt.jif_contract` module provides the validated pyadi-dt
+projection of the versioned ``adi.jif-dt`` interchange format. See
+:doc:`../developer/jif_dt_contract` for the ownership rules, validation
+sequence, compatibility policy, and cross-repository test agreement.
+
+Contract model
+--------------
+
+.. automodule:: adidt.jif_contract
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/developer/index.rst
+++ b/doc/source/developer/index.rst
@@ -9,5 +9,6 @@ board builders.
    :maxdepth: 2
 
    authoring_devices
+   jif_dt_contract
    hardware_ci
    labgrid_exporter

--- a/doc/source/developer/jif_dt_contract.md
+++ b/doc/source/developer/jif_dt_contract.md
@@ -1,0 +1,322 @@
+# pyadi-jif to pyadi-dt interface contract
+
+## Status
+
+This page defines the proposed, versioned agreement between pyadi-jif and
+pyadi-dt. The executable pyadi-dt reference model is
+{mod}`adidt.jif_contract` and its focused tests are in
+`test/test_jif_contract.py`.
+
+The first contract version is intentionally introduced alongside the existing
+raw configuration paths. Pipeline and CLI integration can migrate in later,
+reviewable changes without changing the contract's ownership boundary.
+
+## Why a contract is needed
+
+pyadi-jif currently returns a solver-oriented dictionary. Keys can be assembled
+from component names, such as `jesd_AD9081_RX`, while clock outputs combine
+semantic names with positions in `out_dividers`. Existing pyadi-dt flows consume
+variants of that result by copying selected JESD keys, indexing divider lists,
+or looking up implementation-specific names.
+
+Those dictionaries are useful inside pyadi-jif, but they are not a safe public
+interface. In particular, a requested-clock position in pyadi-jif does **not**
+identify a physical HMC7044 or AD952x output. Physical placement is board wiring
+and therefore belongs to pyadi-dt.
+
+## Contract decision
+
+Use a strict, versioned JSON interchange document with typed projections in
+both projects.
+
+- Contract name: `adi.jif-dt`
+- Initial version: `1.0`
+- Units: integer hertz, named with an `_hz` suffix
+- IDs: stable lowercase semantic IDs, independent of Python class names and DT
+  labels
+- Compatibility: consumers reject unsupported major versions and unknown 1.0
+  fields
+- Safety: parse, validate, bind, and check topology before rendering or changing
+  a device tree
+
+The JSON shape is the public API. Neither project's internal class hierarchy is
+part of the agreement. A saved contract can therefore be consumed without
+installing a solver backend.
+
+## Ownership boundary
+
+### pyadi-jif owns solved electrical intent
+
+pyadi-jif produces:
+
+- JESD standard, direction, framing, sample rate, and lane rate;
+- semantic source/sink clock requirements and solved rates/dividers;
+- FPGA transceiver or PLL results needed to implement a link;
+- producer and solver provenance.
+
+### pyadi-dt owns physical topology
+
+pyadi-dt supplies:
+
+- XSA-discovered instances and direction;
+- DT labels, compatible strings, phandles, and JESD link IDs;
+- physical clock-output channel indices;
+- SPI buses and chip selects, GPIOs, interrupts, and DMA labels;
+- board/profile defaults and final DTS rendering.
+
+### Values that must not cross the boundary
+
+The contract excludes solver expressions and backend objects, arbitrary DT
+properties, SPI/GPIO placement, implicit units, and positional
+`out_dividers` treated as physical channels.
+
+## Interchange example
+
+```json
+{
+  "schema": "adi.jif-dt",
+  "version": "1.0",
+  "producer": {
+    "name": "pyadi-jif",
+    "version": "0.1.6"
+  },
+  "jesd_links": [
+    {
+      "id": "ad9680.rx",
+      "direction": "adc-to-fpga",
+      "converter": "AD9680",
+      "fpga": "zc706",
+      "standard": "jesd204b",
+      "sample_rate_hz": 1000000000,
+      "lane_rate_hz": 10000000000,
+      "parameters": {
+        "F": 1,
+        "K": 32,
+        "L": 4,
+        "M": 2,
+        "N": 16,
+        "Np": 16,
+        "S": 1,
+        "HD": 0,
+        "CS": 0,
+        "CF": 0
+      },
+      "fpga_config": {
+        "type": "qpll",
+        "sys_clk_select": "XCVR_QPLL0"
+      }
+    }
+  ],
+  "clock_requirements": [
+    {
+      "id": "ad9680.device-clock",
+      "role": "converter-device",
+      "sink": "AD9680",
+      "source": "HMC7044",
+      "rate_hz": 1000000000,
+      "divider": 3
+    },
+    {
+      "id": "ad9680.sysref",
+      "role": "converter-sysref",
+      "sink": "AD9680",
+      "source": "HMC7044",
+      "rate_hz": 7812500,
+      "divider": 384
+    }
+  ],
+  "metadata": {
+    "solver": "CPLEX"
+  }
+}
+```
+
+`fpga_config` and `metadata` are isolated extension points. A consumer must not
+require arbitrary keys from either mapping without promoting those keys into a
+later contract version.
+
+## Binding semantic intent to a board
+
+{class}`~adidt.jif_contract.JifDtContract` validates the portable result.
+{class}`~adidt.jif_contract.JifDtBindings` is a separate pyadi-dt-owned object
+that maps semantic IDs to physical endpoints:
+
+```python
+from adidt.jif_contract import (
+    ClockBinding,
+    JesdBinding,
+    JifDtBindings,
+    JifDtContract,
+)
+
+contract = JifDtContract.from_json_file("solved.jif-dt.json")
+
+bindings = JifDtBindings(
+    clocks=(
+        ClockBinding(
+            requirement_id="ad9680.device-clock",
+            dt_label="hmc7044",
+            output_index=13,
+        ),
+        ClockBinding(
+            requirement_id="ad9680.sysref",
+            dt_label="hmc7044",
+            output_index=5,
+        ),
+    ),
+    jesd_links=(
+        JesdBinding(
+            link_id="ad9680.rx",
+            converter_label="ad9680",
+            jesd_label="axi_ad9680_jesd204_rx",
+            xcvr_label="axi_ad9680_adxcvr",
+        ),
+    ),
+)
+
+bindings.check(contract)
+```
+
+The check is required before render or apply. Keeping bindings separate permits
+one electrical solution to be used with multiple carrier/profile placements
+without teaching pyadi-jif about DT labels.
+
+## Required validation
+
+### Contract checks
+
+The typed reference model performs side-effect-free checks for:
+
+- exact schema and supported version;
+- unknown fields and duplicate semantic IDs;
+- positive integer rates and dividers;
+- JESD transport identity, `M * S * Np == 8 * L * F`;
+- lane-rate consistency using 8b/10b for JESD204B or 64b/66b for JESD204C;
+- deterministic JSON serialization and validation on load.
+
+### Binding and topology checks
+
+Before generating DTS, pyadi-dt must additionally ensure:
+
+- every semantic clock and JESD link is bound exactly once;
+- bindings contain no unknown IDs;
+- independent clocks do not occupy the same physical output;
+- clock channel indices are in range for the selected device;
+- source device and compatible string agree with the board profile;
+- converter, JESD, and transceiver labels exist exactly once in the XSA;
+- direction and clock role agree with the target endpoint;
+- divider/rate and FPGA PLL selections are supported.
+
+### Apply checks
+
+Generation should first target a temporary or in-memory tree. DTS lint and
+`dtc` compilation must pass before an explicit file, SD-card, or live apply.
+Failure must not silently substitute a hard-coded configuration.
+
+## Proposed producer API
+
+pyadi-jif should add an explicit export API without initially changing the
+historical return value of `system.solve()`:
+
+```python
+solution = system.solve()
+handoff = system.export_config(
+    format="adi.jif-dt",
+    solution=solution,
+)
+handoff.to_json_file("solved.jif-dt.json")
+```
+
+The exporter should build links from converter objects rather than parsing
+computed dictionary keys. It should zip semantic clock names, rates, and solved
+dividers without exporting list position as a physical channel. The returned
+handoff should be a detached snapshot with no solver objects reachable through
+JSON.
+
+## Proposed consumer API
+
+A later pyadi-dt integration can accept the typed contract alongside existing
+raw configuration support:
+
+```python
+XsaPipeline().run(
+    xsa_path="design.xsa",
+    cfg=contract,
+    bindings=bindings,
+    output_dir="out",
+)
+```
+
+The consumer sequence is parse, validate, resolve profile, bind semantic IDs,
+check XSA topology, check capabilities, convert to internal pipeline config,
+then render and lint.
+
+The `adidtc jif clock` command should likewise migrate from positional divider
+application to contract plus profile bindings. Legacy JSON can remain behind an
+explicit compatibility option for one deprecation cycle, but it must not guess
+physical channel placement.
+
+## Errors
+
+Use narrow errors at each boundary:
+
+- `ContractError` for malformed or incompatible interchange;
+- `BindingError` for incomplete, duplicate, or impossible profile placement;
+- `TopologyMismatchError` when an expected XSA/DT endpoint is absent or has the
+  wrong direction;
+- `CapabilityError` for unsupported rates, dividers, or link modes;
+- existing rendering, compilation, and application exceptions afterward.
+
+Do not catch `Exception` around solve, export, or binding. A caller may choose a
+named fallback configuration, but it must be reported as a fallback rather than
+as the pyadi-jif solution.
+
+## Test agreement
+
+### pyadi-jif producer tests
+
+1. Golden exports for AD9680, nested ADRV9009, and one MxFE JESD204C system.
+2. Exported values match converter objects and historical solve output.
+3. Requested-clock reordering does not alter semantic identity.
+4. Exported snapshots have detached ownership and deterministic JSON.
+5. Gekko and CPLEX produce contract-equivalent fields for the same constraints.
+6. No solver/backend object is JSON reachable.
+
+### pyadi-dt consumer tests
+
+The reference suite covers valid parse/bind, unsupported versions, unknown
+fields, JESD and lane-rate inconsistencies, duplicate IDs, incomplete bindings,
+physical clock collisions, deterministic round trips, and malformed JSON.
+
+Integration tests should add contract-to-pipeline mapping, profile resolution,
+XSA mismatch without output mutation, DTS golden output plus compilation/lint,
+and CLI dry-run before any write.
+
+### Cross-repository CI
+
+pyadi-jif should own a small canonical fixture corpus and publish the generated
+JSON Schema as a release artifact. On pyadi-jif changes, generate fixtures and
+run the pyadi-dt consumer. On pyadi-dt changes, consume both canonical fixtures
+and artifacts generated by the minimum supported pyadi-jif release and current
+main. Hardware-backed configurations can run nightly.
+
+## Compatibility policy
+
+Optional additions may be made within contract 1.x without changing existing
+meaning. Required fields, unit changes, enum semantic changes, and ID-rule
+changes require contract 2.0. Producer and consumer package versions are
+provenance; compatibility is determined by the contract version.
+
+## Rollout
+
+1. Agree on names, ownership, and AD9680/ADRV9009/AD9081 canonical systems.
+2. Generate the canonical JSON Schema from the pyadi-jif producer model.
+3. Add `system.export_config(format="adi.jif-dt")` and producer tests.
+4. Add pyadi-dt profile bindings and contract-to-pipeline translation.
+5. Convert `adidtc jif clock` and require dry-run validation.
+6. Convert board helpers and remove broad solver fallback.
+7. Enable cross-repository CI, then deprecate positional/raw JSON.
+
+Acceptance requires that saved output works without solver imports, requested
+clock ordering cannot change physical placement, all endpoints bind exactly
+once, and invalid input fails before any tree mutation.

--- a/doc/source/developer/jif_dt_contract.md
+++ b/doc/source/developer/jif_dt_contract.md
@@ -181,6 +181,46 @@ The check is required before render or apply. Keeping bindings separate permits
 one electrical solution to be used with multiple carrier/profile placements
 without teaching pyadi-jif about DT labels.
 
+## Runnable examples
+
+The examples under `examples/jif_contract/` are executed by the test suite, so
+the documented API and checked-in JSON cannot drift silently.
+
+### Consume a saved AD9680 handoff
+
+This example loads solver output and board bindings from separate JSON files.
+It validates both documents and their one-to-one semantic join without
+importing pyadi-jif or a solver backend:
+
+```bash
+python examples/jif_contract/consume_ad9680.py
+```
+
+```{literalinclude} ../../../examples/jif_contract/consume_ad9680.py
+:language: python
+:caption: examples/jif_contract/consume_ad9680.py
+```
+
+The portable electrical result is
+`examples/jif_contract/ad9680.jif-dt.json`; the independent ZC706 placement is
+`examples/jif_contract/ad9680.bindings.json`. A different carrier can reuse the
+contract with a different bindings document.
+
+### Build a bidirectional ADRV9009 handoff
+
+The second example constructs RX and TX links with the typed API, binds their
+AD9528 and FPGA endpoints, and checks the whole handoff before any pipeline or
+device-tree operation:
+
+```bash
+python examples/jif_contract/adrv9009_bidirectional.py
+```
+
+```{literalinclude} ../../../examples/jif_contract/adrv9009_bidirectional.py
+:language: python
+:caption: examples/jif_contract/adrv9009_bidirectional.py
+```
+
 ## Required validation
 
 ### Contract checks

--- a/doc/source/examples/xsa_adijif_tutorial.md
+++ b/doc/source/examples/xsa_adijif_tutorial.md
@@ -3,6 +3,12 @@
 This tutorial covers deriving XSA pipeline JESD/clock inputs from `pyadi-jif`
 before passing them into the XSA conversion flow.
 
+For new integrations, use the versioned [pyadi-jif to pyadi-dt interface
+contract](../developer/jif_dt_contract.md). It keeps solved electrical intent
+separate from physical board placement and validates the complete handoff before
+DTS generation. The direct dictionary mapping below documents the current
+transitional pipeline API.
+
 ## 1) Install dependencies
 
 ```bash
@@ -23,6 +29,13 @@ The core idea is:
 4. Map values to `cfg["jesd"]`.
 5. Map clock labels/channels to `cfg["clock"]`.
 6. Call `XsaPipeline.run()`.
+
+```{warning}
+Do not interpret the position of a pyadi-jif `out_dividers` entry as a physical
+clock-chip channel. Requested-clock order is solver state; clock output channel
+placement must come from a pyadi-dt board profile or an explicit
+`JifDtBindings` mapping.
+```
 
 ### Minimal example
 

--- a/examples/jif_contract/ad9680.bindings.json
+++ b/examples/jif_contract/ad9680.bindings.json
@@ -1,0 +1,22 @@
+{
+  "clocks": [
+    {
+      "requirement_id": "ad9680.device-clock",
+      "dt_label": "hmc7044",
+      "output_index": 13
+    },
+    {
+      "requirement_id": "ad9680.sysref",
+      "dt_label": "hmc7044",
+      "output_index": 5
+    }
+  ],
+  "jesd_links": [
+    {
+      "link_id": "ad9680.rx",
+      "converter_label": "ad9680",
+      "jesd_label": "axi_ad9680_jesd204_rx",
+      "xcvr_label": "axi_ad9680_adxcvr"
+    }
+  ]
+}

--- a/examples/jif_contract/ad9680.jif-dt.json
+++ b/examples/jif_contract/ad9680.jif-dt.json
@@ -1,0 +1,57 @@
+{
+  "schema": "adi.jif-dt",
+  "version": "1.0",
+  "producer": {
+    "name": "pyadi-jif",
+    "version": "0.1.6"
+  },
+  "jesd_links": [
+    {
+      "id": "ad9680.rx",
+      "direction": "adc-to-fpga",
+      "converter": "AD9680",
+      "fpga": "zc706",
+      "standard": "jesd204b",
+      "sample_rate_hz": 1000000000,
+      "lane_rate_hz": 10000000000,
+      "parameters": {
+        "F": 1,
+        "K": 32,
+        "L": 4,
+        "M": 2,
+        "N": 14,
+        "Np": 16,
+        "S": 1,
+        "HD": 0,
+        "CS": 0,
+        "CF": 0
+      },
+      "fpga_config": {
+        "type": "qpll",
+        "sys_clk_select": "XCVR_QPLL0"
+      }
+    }
+  ],
+  "clock_requirements": [
+    {
+      "id": "ad9680.device-clock",
+      "role": "converter-device",
+      "sink": "AD9680",
+      "source": "HMC7044",
+      "rate_hz": 1000000000,
+      "divider": 3
+    },
+    {
+      "id": "ad9680.sysref",
+      "role": "converter-sysref",
+      "sink": "AD9680",
+      "source": "HMC7044",
+      "rate_hz": 7812500,
+      "divider": 384
+    }
+  ],
+  "metadata": {
+    "solver": "CPLEX",
+    "example": "AD9680 on ZC706"
+  }
+}

--- a/examples/jif_contract/adrv9009_bidirectional.py
+++ b/examples/jif_contract/adrv9009_bidirectional.py
@@ -1,0 +1,131 @@
+"""Build and bind a bidirectional ADRV9009 contract in memory."""
+
+from __future__ import annotations
+
+import json
+
+from adidt.jif_contract import (
+    ClockBinding,
+    ClockRequirement,
+    JesdBinding,
+    JesdLink,
+    JesdParameters,
+    JifDtBindings,
+    JifDtContract,
+    Producer,
+)
+
+
+def build_contract() -> JifDtContract:
+    """Return solved RX/TX electrical intent with no physical DT placement."""
+    return JifDtContract(
+        schema="adi.jif-dt",
+        producer=Producer(version="0.1.6"),
+        jesd_links=(
+            JesdLink(
+                id="adrv9009.rx",
+                direction="adc-to-fpga",
+                converter="ADRV9009_RX",
+                fpga="zcu102",
+                standard="jesd204b",
+                sample_rate_hz=245_760_000,
+                lane_rate_hz=9_830_400_000,
+                parameters=JesdParameters(
+                    F=4, K=32, L=2, M=4, N=16, Np=16, S=1, HD=0
+                ),
+                fpga_config={"type": "qpll"},
+            ),
+            JesdLink(
+                id="adrv9009.tx",
+                direction="fpga-to-dac",
+                converter="ADRV9009_TX",
+                fpga="zcu102",
+                standard="jesd204b",
+                sample_rate_hz=245_760_000,
+                lane_rate_hz=4_915_200_000,
+                parameters=JesdParameters(
+                    F=2, K=32, L=4, M=4, N=16, Np=16, S=1, HD=0
+                ),
+                fpga_config={"type": "qpll"},
+            ),
+        ),
+        clock_requirements=(
+            ClockRequirement(
+                id="adrv9009.device-clock",
+                role="converter-device",
+                sink="ADRV9009",
+                source="AD9528",
+                rate_hz=245_760_000,
+                divider=4,
+            ),
+            ClockRequirement(
+                id="adrv9009.sysref",
+                role="converter-sysref",
+                sink="ADRV9009",
+                source="AD9528",
+                rate_hz=7_680_000,
+                divider=128,
+            ),
+        ),
+        metadata={"example": "bidirectional ADRV9009 on ZCU102"},
+    )
+
+
+def build_bindings() -> JifDtBindings:
+    """Return the independent pyadi-dt board placement for the solved intent."""
+    return JifDtBindings(
+        clocks=(
+            ClockBinding(
+                requirement_id="adrv9009.device-clock",
+                dt_label="ad9528",
+                output_index=1,
+            ),
+            ClockBinding(
+                requirement_id="adrv9009.sysref",
+                dt_label="ad9528",
+                output_index=3,
+            ),
+        ),
+        jesd_links=(
+            JesdBinding(
+                link_id="adrv9009.rx",
+                converter_label="adrv9009-phy",
+                jesd_label="axi_adrv9009_rx_jesd",
+                xcvr_label="axi_adrv9009_rx_xcvr",
+            ),
+            JesdBinding(
+                link_id="adrv9009.tx",
+                converter_label="adrv9009-phy",
+                jesd_label="axi_adrv9009_tx_jesd",
+                xcvr_label="axi_adrv9009_tx_xcvr",
+            ),
+        ),
+    )
+
+
+def main() -> None:
+    """Validate both link directions before any pipeline or DT operation."""
+    contract = build_contract()
+    bindings = build_bindings()
+    bindings.check(contract)
+
+    print(
+        json.dumps(
+            {
+                "links": {
+                    link.id: {
+                        "direction": link.direction,
+                        "lane_rate_hz": link.lane_rate_hz,
+                    }
+                    for link in contract.jesd_links
+                },
+                "status": "validated",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/jif_contract/consume_ad9680.py
+++ b/examples/jif_contract/consume_ad9680.py
@@ -1,0 +1,38 @@
+"""Load and bind a saved AD9680 pyadi-jif handoff without a solver import."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from adidt.jif_contract import JifDtBindings, JifDtContract
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+
+
+def main() -> None:
+    """Validate the portable contract, then bind every semantic endpoint."""
+    contract = JifDtContract.from_json_file(EXAMPLE_DIR / "ad9680.jif-dt.json")
+    bindings = JifDtBindings.model_validate_json(
+        (EXAMPLE_DIR / "ad9680.bindings.json").read_text()
+    )
+    bindings.check(contract)
+
+    summary = {
+        "schema": contract.schema_name,
+        "version": contract.version,
+        "links": [link.id for link in contract.jesd_links],
+        "clock_bindings": {
+            binding.requirement_id: {
+                "dt_label": binding.dt_label,
+                "output_index": binding.output_index,
+            }
+            for binding in bindings.clocks
+        },
+        "status": "validated",
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_jif_contract.py
+++ b/test/test_jif_contract.py
@@ -1,0 +1,200 @@
+"""Contract tests for the pyadi-jif -> pyadi-dt handoff."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from adidt.jif_contract import (
+    ClockBinding,
+    ContractError,
+    JesdBinding,
+    JifDtBindings,
+    JifDtContract,
+)
+
+
+def _payload() -> dict:
+    return {
+        "schema": "adi.jif-dt",
+        "version": "1.0",
+        "producer": {"name": "pyadi-jif", "version": "0.1.6"},
+        "jesd_links": [
+            {
+                "id": "ad9680.rx",
+                "direction": "adc-to-fpga",
+                "converter": "AD9680",
+                "fpga": "zc706",
+                "standard": "jesd204b",
+                "sample_rate_hz": 1_000_000_000,
+                "lane_rate_hz": 10_000_000_000,
+                "parameters": {
+                    "F": 1,
+                    "K": 32,
+                    "L": 4,
+                    "M": 2,
+                    "N": 16,
+                    "Np": 16,
+                    "S": 1,
+                    "HD": 0,
+                },
+                "fpga_config": {"type": "qpll", "sys_clk_select": "XCVR_QPLL0"},
+            }
+        ],
+        "clock_requirements": [
+            {
+                "id": "ad9680.device-clock",
+                "role": "converter-device",
+                "sink": "AD9680",
+                "source": "HMC7044",
+                "rate_hz": 1_000_000_000,
+                "divider": 3,
+            },
+            {
+                "id": "ad9680.sysref",
+                "role": "converter-sysref",
+                "sink": "AD9680",
+                "source": "HMC7044",
+                "rate_hz": 7_812_500,
+                "divider": 384,
+            },
+        ],
+        "metadata": {"solver": "CPLEX"},
+    }
+
+
+def _bindings() -> JifDtBindings:
+    return JifDtBindings(
+        clocks=(
+            ClockBinding(
+                requirement_id="ad9680.device-clock",
+                dt_label="hmc7044",
+                output_index=13,
+            ),
+            ClockBinding(
+                requirement_id="ad9680.sysref",
+                dt_label="hmc7044",
+                output_index=5,
+            ),
+        ),
+        jesd_links=(
+            JesdBinding(
+                link_id="ad9680.rx",
+                converter_label="ad9680",
+                jesd_label="axi_ad9680_jesd204_rx",
+                xcvr_label="axi_ad9680_adxcvr",
+            ),
+        ),
+    )
+
+
+def test_valid_contract_binds_semantic_requirements_to_physical_dt_endpoints():
+    contract = JifDtContract.model_validate(_payload())
+    _bindings().check(contract)
+
+    assert contract.clock_requirements[0].id == "ad9680.device-clock"
+    assert _bindings().clocks[0].output_index == 13
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        (lambda p: p.update(version="2.0"), "version"),
+        (
+            lambda p: p["jesd_links"][0].update(lane_rate_hz=9_000_000_000),
+            "lane_rate_hz",
+        ),
+        (
+            lambda p: p["jesd_links"][0]["parameters"].update(F=2),
+            "transport parameters",
+        ),
+        (
+            lambda p: p["clock_requirements"][0].update(rate_hz="1000000000"),
+            "int_type",
+        ),
+        (
+            lambda p: p["clock_requirements"].append(
+                dict(p["clock_requirements"][0])
+            ),
+            "duplicate clock requirement ids",
+        ),
+        (lambda p: p.update(unexpected=True), "extra_forbidden"),
+    ],
+)
+def test_contract_rejects_incompatible_or_internally_inconsistent_data(
+    mutation, match
+):
+    payload = _payload()
+    mutation(payload)
+    with pytest.raises(ValidationError, match=match):
+        JifDtContract.model_validate(payload)
+
+
+def test_binding_check_rejects_missing_or_unknown_semantic_ids():
+    contract = JifDtContract.model_validate(_payload())
+    bindings = JifDtBindings(
+        clocks=(
+            ClockBinding(
+                requirement_id="unknown.clock", dt_label="hmc7044", output_index=0
+            ),
+        ),
+        jesd_links=_bindings().jesd_links,
+    )
+
+    with pytest.raises(ContractError, match=r"missing=.*unknown="):
+        bindings.check(contract)
+
+
+def test_binding_check_rejects_two_requirements_on_one_physical_output():
+    contract = JifDtContract.model_validate(_payload())
+    bindings = JifDtBindings(
+        clocks=(
+            ClockBinding(
+                requirement_id="ad9680.device-clock",
+                dt_label="hmc7044",
+                output_index=5,
+            ),
+            ClockBinding(
+                requirement_id="ad9680.sysref",
+                dt_label="hmc7044",
+                output_index=5,
+            ),
+        ),
+        jesd_links=_bindings().jesd_links,
+    )
+
+    with pytest.raises(ContractError, match="multiple clocks bound"):
+        bindings.check(contract)
+
+
+def test_json_round_trip_uses_public_schema_name(tmp_path):
+    path = tmp_path / "jif-dt.json"
+    contract = JifDtContract.model_validate(_payload())
+    contract.to_json_file(path)
+
+    on_disk = json.loads(path.read_text())
+    assert on_disk["schema"] == "adi.jif-dt"
+    assert "schema_name" not in on_disk
+    assert JifDtContract.from_json_file(path) == contract
+
+
+def test_json_loader_wraps_parse_and_validation_errors(tmp_path):
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{")
+    with pytest.raises(ContractError, match="cannot read"):
+        JifDtContract.from_json_file(malformed)
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"schema": "adi.jif-dt", "version": "1.0"}))
+    with pytest.raises(ContractError, match="invalid JIF/DT contract"):
+        JifDtContract.from_json_file(invalid)
+
+
+def test_contract_rejects_non_json_extension_values():
+    payload = _payload()
+    payload["metadata"]["solver_object"] = object()
+
+    with pytest.raises(ValidationError, match="metadata"):
+        JifDtContract.model_validate(payload)

--- a/test/test_jif_contract_examples.py
+++ b/test/test_jif_contract_examples.py
@@ -1,0 +1,49 @@
+"""Execute the documented pyadi-jif/pyadi-dt contract examples."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from adidt.jif_contract import JifDtBindings, JifDtContract
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "jif_contract"
+
+
+@pytest.mark.parametrize(
+    ("script", "expected_links"),
+    [
+        ("consume_ad9680.py", {"ad9680.rx"}),
+        ("adrv9009_bidirectional.py", {"adrv9009.rx", "adrv9009.tx"}),
+    ],
+)
+def test_contract_example_runs(script: str, expected_links: set[str]) -> None:
+    """Examples must execute and report every expected validated link."""
+    result = subprocess.run(
+        [sys.executable, str(EXAMPLE_DIR / script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    summary = json.loads(result.stdout)
+
+    assert summary["status"] == "validated"
+    links = summary["links"]
+    assert set(links) == expected_links
+
+
+def test_saved_ad9680_contract_and_bindings_validate_together() -> None:
+    """The checked-in JSON pair is an executable interchange fixture."""
+    contract = JifDtContract.from_json_file(EXAMPLE_DIR / "ad9680.jif-dt.json")
+    bindings = JifDtBindings.model_validate_json(
+        (EXAMPLE_DIR / "ad9680.bindings.json").read_text()
+    )
+
+    bindings.check(contract)
+    assert contract.jesd_links[0].lane_rate_hz == 10_000_000_000
+    assert {binding.output_index for binding in bindings.clocks} == {5, 13}


### PR DESCRIPTION
## Summary

- define a strict, versioned `adi.jif-dt` 1.0 interchange model for solved JESD links and semantic clock requirements
- keep pyadi-jif-owned electrical intent separate from pyadi-dt-owned physical endpoint bindings
- validate JESD transport identity, lane rate, IDs, JSON-only extension data, and complete/non-conflicting bindings before DT mutation
- add focused contract and serialization tests
- add runnable AD9680 file-based and bidirectional ADRV9009 typed examples, executed by CI
- use byte-for-byte output from pyadi-jif PR #283 as the AD9680 consumer fixture and bind all four produced semantic clocks
- add a rendered developer agreement, API reference, and migration guidance to the existing pyadi-jif/XSA tutorial

## Interface boundary

pyadi-jif owns solved JESD/clock/FPGA intent. pyadi-dt owns XSA topology, DT labels, physical clock channels, SPI/GPIO/interrupt placement, and rendering.

In particular, this contract prevents a requested-clock position in pyadi-jif's `out_dividers` from being interpreted as a physical HMC7044/AD952x output channel. Physical placement is supplied separately through `JifDtBindings`.

This PR introduces the agreement and executable pyadi-dt projection without changing the current `system.solve()`, `XsaPipeline`, or CLI behavior. Producer export and pipeline integration can follow in smaller cross-repository changes.

## Verification

- `python -m pytest -q`: 710 passed, 16 skipped, 4 xfailed
- focused contract and executable-example suite: 15 passed
- Ruff: passed
- ty: passed
- Sphinx HTML: passed
- Sphinx coverage: 100%, including `adidt.jif_contract`
- rendered HTML checked for agreement sections, executable examples, and contract API anchors
- cross-repository check: pyadi-jif's real CPLEX AD9680 output was consumed by this PR and matches the checked-in fixture byte-for-byte

The docs build retains four pre-existing warnings outside this change: optional `fastmcp` autodoc is unavailable in the base docs environment, and `doc/source/cli.rst` has three existing inline-emphasis warnings.