### PR TITLE
ci: prepare pyadi-dt v0.0.1 release

### DIFF
--- a/.github/scripts/create_debian.sh
+++ b/.github/scripts/create_debian.sh
@@ -1,12 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 version=$1
 architecture=$2
 
-sudo apt update && sudo apt install -y libffi-dev python3-dev build-essential ruby
+sudo apt update && sudo apt install -y libffi-dev python3-dev python3-venv build-essential ruby
 sudo gem install fpm
-python3 -m venv myenv
+python3 -m venv --system-site-packages myenv
 . myenv/bin/activate
 python3 -m pip install --upgrade pip
-pip install -r requirements/requirements_dev.txt
+python3 - <<'PY'
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+dependencies = tomllib.loads(Path("pyproject.toml").read_text())["project"]["dependencies"]
+subprocess.run([sys.executable, "-m", "pip", "install", *dependencies], check=True)
+PY
 deactivate
 
 fpm -s python -t deb \

--- a/.github/scripts/create_debian.sh
+++ b/.github/scripts/create_debian.sh
@@ -14,10 +14,10 @@ fpm -s python -t deb \
     --url "https://github.com/analogdevicesinc/pyadi-dt" \
     --version "$version-1" \
     --maintainer "Engineerzone <https://ez.analog.com/sw-interface-tools>" \
-    --license "" \
+    --license "EPL-2.0" \
     --no-auto-depends \
     --python-package-name-prefix python3 \
     --after-install .github/scripts/postinstall.sh \
     --description "Device tree management tools for ADI hardware
         Documentation at 
-        https://analogdevicesinc.github.io/pyadi-dt/main/" .
+        https://analogdevicesinc.github.io/pyadi-dt/" .

--- a/.github/scripts/verify_install.sh
+++ b/.github/scripts/verify_install.sh
@@ -1,3 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 . myenv/bin/activate
-pytest -vs
+dpkg -L python3-adidt | grep -E '/bin/adidtc$|/adidt/__init__\.py$|dist-info/METADATA$'
+(
+    cd /tmp
+    PYTHONPATH= python - <<'PY'
+import importlib.metadata as metadata
+from pathlib import Path
+
+import adidt
+
+assert metadata.version("adidt") == adidt.__version__
+install_path = str(Path(adidt.__file__).resolve())
+assert "site-packages" in install_path or "dist-packages" in install_path
+print(f"verified adidt {adidt.__version__} from {adidt.__file__}")
+PY
+    # The Debian artifact is intentionally thin and its post-install hook tells
+    # users to provide Python dependencies. Exercise the installed launcher
+    # with this dependency-complete verification environment.
+    PYTHONPATH= python /usr/local/bin/adidtc --help >/dev/null
+)
 deactivate

--- a/.github/scripts/verify_install.sh
+++ b/.github/scripts/verify_install.sh
@@ -2,10 +2,14 @@
 set -euo pipefail
 
 . myenv/bin/activate
-dpkg -L python3-adidt | grep -E '/bin/adidtc$|/adidt/__init__\.py$|dist-info/METADATA$'
+package_files=$(dpkg -L python3-adidt)
+printf '%s\n' "$package_files" | grep -E '/bin/adidtc$|/adidt/__init__\.py$|dist-info/METADATA$'
+package_init=$(printf '%s\n' "$package_files" | grep '/adidt/__init__\.py$')
+package_cli=$(printf '%s\n' "$package_files" | grep '/bin/adidtc$')
+package_site=$(dirname "$(dirname "$package_init")")
 (
     cd /tmp
-    PYTHONPATH= python - <<'PY'
+    PYTHONPATH="$package_site" python - <<'PY'
 import importlib.metadata as metadata
 from pathlib import Path
 
@@ -18,7 +22,8 @@ print(f"verified adidt {adidt.__version__} from {adidt.__file__}")
 PY
     # The Debian artifact is intentionally thin and its post-install hook tells
     # users to provide Python dependencies. Exercise the installed launcher
-    # with this dependency-complete verification environment.
-    PYTHONPATH= python /usr/local/bin/adidtc --help >/dev/null
+    # with this dependency-complete verification environment. PYTHONPATH also
+    # makes the smoke test independent of the Kuiper image's /opt/venv prefix.
+    PYTHONPATH="$package_site" python "$package_cli" --help >/dev/null
 )
 deactivate

--- a/.github/workflows/binding-audit.yml
+++ b/.github/workflows/binding-audit.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Post audit report to PR
       if: github.event_name == 'pull_request' || steps.find-pr.outputs.number != ''
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
         header: binding-audit
         number: ${{ github.event_name == 'pull_request' && github.event.number || steps.find-pr.outputs.number }}

--- a/.github/workflows/build_debian.yaml
+++ b/.github/workflows/build_debian.yaml
@@ -1,7 +1,7 @@
 name: Build and Deploy adidt (debian)
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   APP_NAME: adidt
@@ -31,40 +31,27 @@ jobs:
     - name: Set app version
       id: set_version
       run: |
-        # Regex to match semantic versioning (from semver.org)
-        # Regex will match valid version number https://regex101.com/r/jPSdnV/1
-        regex='^(v|)((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?)$'
-        app_version=""
-        latest_released_tag=$(curl "https://api.github.com/repos/${{github.repository}}/releases/latest" | jq -r .tag_name)
-
-        if [[ "${{github.ref_type}}" == "tag" ]]; then
-            pushed_tag="${{github.ref_name}}"
-            if [[ "$pushed_tag" =~ $regex  ]]; then
-                app_version="${BASH_REMATCH[2]}"
-                if [[ "$latest_released_tag" =~ $regex  ]]; then
-                    IFS='.' read -r major minor patch <<< "${BASH_REMATCH[2]}"
-                    next_patch="$major.$minor.$((patch + 1))"
-                    next_minor="$major.$((minor + 1)).0"
-                    next_major="$((major + 1)).0.0"
-                    if ! [[ "$app_version" == "$next_patch" || "$app_version" == "$next_minor" || "$app_version" == "$next_major" ]]; then
-                      echo "Valid tag, but invalid version incrementation, release will NOT be created"
-                    fi
-                else
-                    echo "Invalid relesed version, skip incrementation validation! Release will be created"
-                fi
-            else
-                echo "Invalid tag format, release will NOT be created"
-                app_version=0.0.1+${{ github.sha }}
-            fi
-        else 
-            if [[ "$latest_released_tag" =~ $regex  ]]; then
-                app_version=${BASH_REMATCH[2]}+${{ github.sha }}
-            else
-                echo "Invalid relesed version. Setting default version"
-                app_version=0.0.1+${{ github.sha }}
-            fi
+        set -euo pipefail
+        package_version=$(python3 - <<'PY'
+        import tomllib
+        from pathlib import Path
+        print(tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"])
+        PY
+        )
+        if [[ "${{ github.ref_type }}" == "tag" ]]; then
+          if [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: ${{ github.ref_name }}" >&2
+            exit 1
+          fi
+          app_version="${{ github.ref_name }}"
+          app_version="${app_version#v}"
+          if [[ "$app_version" != "$package_version" ]]; then
+            echo "Tag version $app_version does not match package version $package_version" >&2
+            exit 1
+          fi
+        else
+          app_version="${package_version}+${GITHUB_SHA}"
         fi
-        
         echo "Version to use $app_version"
         echo "version=$app_version" >> "$GITHUB_OUTPUT"
   build_and_deploy_for_kuiper:
@@ -127,6 +114,20 @@ jobs:
         path: python3-${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{matrix.architecture}}.deb
         if-no-files-found: error
 
+    - name: Attach .deb to tagged GitHub release
+      if: github.ref_type == 'tag'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        for attempt in {1..30}; do
+          gh release view "${{ github.ref_name }}" >/dev/null 2>&1 && break
+          if [[ "$attempt" == 30 ]]; then echo "Release was not created in time" >&2; exit 1; fi
+          sleep 10
+        done
+        gh release upload "${{ github.ref_name }}" \
+          python3-${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{matrix.architecture}}.deb \
+          --clobber
+
   build_and_deploy_for_ubuntu:
     runs-on: ubuntu-latest
     needs: identify_version
@@ -161,3 +162,17 @@ jobs:
         name: ${{env.APP_NAME}}-ubuntu
         path: ${{env.APP_NAME}}/python3-${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb
         if-no-files-found: error
+
+    - name: Attach .deb to tagged GitHub release
+      if: github.ref_type == 'tag'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        for attempt in {1..30}; do
+          gh release view "${{ github.ref_name }}" >/dev/null 2>&1 && break
+          if [[ "$attempt" == 30 ]]; then echo "Release was not created in time" >&2; exit 1; fi
+          sleep 10
+        done
+        gh release upload "${{ github.ref_name }}" \
+          ${{env.APP_NAME}}/python3-${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb \
+          --clobber

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/requirements_doc.txt
-          pip install -e .
+          pip install -e ".[mcp]"
 
       - name: Install pyd2lang-native
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Build documentation
         run: |
           cd doc
-          make html
+          make SPHINXOPTS="-W --keep-going" html
 
       - name: Check documentation coverage
         run: |
@@ -51,8 +51,7 @@ jobs:
       - name: Check links
         run: |
           cd doc
-          make linkcheck
-        continue-on-error: true
+          make SPHINXOPTS="-W --keep-going" linkcheck
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,186 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v-prefixed tag to validate and publish
+        required: true
+        type: string
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate tag and package versions
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          python - <<'PY'
+          import ast
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          tag = os.environ["RELEASE_TAG"]
+          if not re.fullmatch(r"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?", tag):
+              raise SystemExit(f"invalid release tag: {tag!r}")
+          project_version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          tree = ast.parse(Path("adidt/__init__.py").read_text())
+          import_version = next(
+              ast.literal_eval(node.value)
+              for node in tree.body
+              if isinstance(node, ast.Assign)
+              and any(
+                  isinstance(target, ast.Name) and target.id == "__version__"
+                  for target in node.targets
+              )
+          )
+          tag_version = tag.removeprefix("v")
+          if len({tag_version, project_version, import_version}) != 1:
+              raise SystemExit(
+                  f"version mismatch: tag={tag_version}, pyproject={project_version}, "
+                  f"adidt.__version__={import_version}"
+              )
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              output.write(f"tag={tag}\nversion={tag_version}\n")
+          PY
+
+      - name: Verify tag belongs to main
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch origin main --tags
+          TAG_SHA=$(git rev-list -n 1 "$RELEASE_TAG")
+          git merge-base --is-ancestor "$TAG_SHA" origin/main
+
+  test:
+    name: Test Python ${{ matrix.python-version }}
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install ".[test]"
+      - run: pytest -q
+
+  build:
+    name: Build and inspect distributions
+    needs: [validate, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install build twine
+      - run: python -m build
+      - run: twine check dist/*
+      - name: Verify wheel in a clean environment
+        run: |
+          python -m venv /tmp/adidt-release-smoke
+          /tmp/adidt-release-smoke/bin/pip install dist/*.whl
+          cd /tmp
+          /tmp/adidt-release-smoke/bin/python -c \
+            'import importlib.metadata as m, adidt; assert m.version("adidt") == adidt.__version__'
+          /tmp/adidt-release-smoke/bin/adidtc --help >/dev/null
+      - uses: actions/upload-artifact@v7
+        with:
+          name: python-distributions
+          path: dist/
+          if-no-files-found: error
+
+  github-release:
+    name: Create GitHub release
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: python-distributions
+          path: dist
+      - name: Extract release notes
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          version = re.escape(os.environ["VERSION"])
+          changelog = Path("CHANGELOG.md").read_text()
+          match = re.search(
+              rf"^## \[{version}\].*?\n(?P<body>.*?)(?=^## \[|^\[Unreleased\]:)",
+              changelog,
+              re.MULTILINE | re.DOTALL,
+          )
+          if not match:
+              raise SystemExit(f"CHANGELOG.md has no section for {os.environ['VERSION']}")
+          Path("release-notes.md").write_text(match.group("body").strip() + "\n")
+          PY
+      - name: Create release and attach Python artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" dist/* --clobber
+          else
+            gh release create "$RELEASE_TAG" dist/* \
+              --verify-tag --title "$RELEASE_TAG" --notes-file release-notes.md
+          fi
+
+  pypi:
+    name: Publish to PyPI
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/adidt
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: python-distributions
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/test-kuiper.yml
+++ b/.github/workflows/test-kuiper.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Upload JUnit XML
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: junit-kuiper64
         path: ${{env.APP_NAME}}/junit-kuiper64.xml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Publish test results to PR
       if: always()
-      uses: dorny/test-reporter@v1
+      uses: dorny/test-reporter@v3
       with:
         name: Tests (Kuiper64)
         # working-directory tells the reporter where to run git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Upload JUnit XML
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: junit-py${{ matrix.python-version }}
         path: junit-py${{ matrix.python-version }}.xml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Publish test results to PR
       if: always()
-      uses: dorny/test-reporter@v1
+      uses: dorny/test-reporter@v3
       with:
         name: Tests (Python ${{ matrix.python-version }})
         path: junit-py${{ matrix.python-version }}.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     name: Test Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -32,9 +32,8 @@ jobs:
         pip install ty
 
     - name: Run ty type checker
-      continue-on-error: true
       run: |
-        ty check adidt/model/ adidt/xsa/builders/ adidt/devices/ adidt/system.py adidt/tools/ 2>&1 | tee ty_report.txt
+        ty check adidt/model/ adidt/xsa/build/builders/ adidt/devices/ adidt/system.py adidt/tools/ 2>&1 | tee ty_report.txt
         echo "## Type Check Report (ty)" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         tail -5 ty_report.txt >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ First public alpha release.
 - XSA support requires Lopper/SDTGen and board-specific profiles.
 - PetaLinux and hardware workflows depend on external AMD/ADI toolchains and
   lab resources that are not installed by the core Python package.
+- Debian artifacts are thin packages: Python runtime dependencies listed in
+  `pyproject.toml` must be supplied separately. They are not standalone
+  application bundles.
 
 [Unreleased]: https://github.com/analogdevicesinc/pyadi-dt/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/analogdevicesinc/pyadi-dt/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to pyadi-dt are documented here. The project follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2026-07-23
+
+First public alpha release.
+
+### Added
+
+- Device-centric Python API for composing ADI converters, clocks, transceivers,
+  evaluation boards, FPGA platforms, SPI connections, and JESD204 links.
+- XSA-to-DTS pipeline with board profiles, structural validation, reference-DTS
+  comparison, PetaLinux output, and interactive visualization reports.
+- `adidtc` command-line workflows for XSA conversion, declarative DTS
+  generation, Kuiper board discovery, live-tree inspection, and pyadi-jif clock
+  updates.
+- Versioned `adi.jif-dt` consumer contract and executable pyadi-jif handoff
+  examples.
+- Model Context Protocol server through the optional `mcp` dependency extra.
+- Hardware CI coverage for AD9081/ZCU102, ADRV9009/ZC706,
+  ADRV9371/ZC706, and FMCDAQ3/VCU118 labgrid targets.
+- Pure-Python wheel, source distribution, and Debian packaging for amd64,
+  arm64, and armhf.
+
+### Known limitations
+
+- The public API remains alpha and may change before a stable 1.0 release.
+- XSA support requires Lopper/SDTGen and board-specific profiles.
+- PetaLinux and hardware workflows depend on external AMD/ADI toolchains and
+  lab resources that are not installed by the core Python package.
+
+[Unreleased]: https://github.com/analogdevicesinc/pyadi-dt/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/analogdevicesinc/pyadi-dt/releases/tag/v0.0.1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 <h3 align="center">Device Tree Generation for Analog Devices Hardware</h3>
 
 <p align="center">
-<a href="https://github.com/analogdevicesinc/pyadi-dt/actions/workflows/build_pip.yml"><img src="https://github.com/analogdevicesinc/pyadi-dt/actions/workflows/build_pip.yml/badge.svg" alt="CI"></a>
+<a href="https://github.com/analogdevicesinc/pyadi-dt/actions/workflows/test.yml"><img src="https://github.com/analogdevicesinc/pyadi-dt/actions/workflows/test.yml/badge.svg" alt="CI"></a>
 <a href="https://analogdevicesinc.github.io/pyadi-dt/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg" alt="Docs"></a>
 <a href="https://github.com/analogdevicesinc/pyadi-dt/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-EPL--2.0-green.svg" alt="License"></a>
-<a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python 3.10+"></a>
+<a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10--3.13-blue.svg" alt="Python 3.10 through 3.13"></a>
 </p>
 
 ---
@@ -29,13 +29,13 @@
 ## Quick Install
 
 ```bash
-pip install git+https://github.com/analogdevicesinc/pyadi-dt.git
+pip install adidt
 ```
 
 With XSA pipeline support (requires Vivado `sdtgen`):
 
 ```bash
-pip install "git+https://github.com/analogdevicesinc/pyadi-dt.git#egg=adidt[xsa]"
+pip install "adidt[xsa]"
 ```
 
 ## Quick Examples
@@ -121,10 +121,10 @@ adidtc -c remote_sysfs -i 192.168.2.1 prop -cp adi,ad9361 clock-output-names
 ## Documentation
 
 - [Quick Start](https://analogdevicesinc.github.io/pyadi-dt/quickstart.html)
-- [Device Tree Generation (non-XSA)](https://analogdevicesinc.github.io/pyadi-dt/board_class_workflow.html)
+- [Device-centric API](https://analogdevicesinc.github.io/pyadi-dt/api/devices.html)
 - [XSA Pipeline Guide](https://analogdevicesinc.github.io/pyadi-dt/xsa.html)
 - [BoardModel API Reference](https://analogdevicesinc.github.io/pyadi-dt/api/model.html)
-- [Creating Templates from Bindings](https://analogdevicesinc.github.io/pyadi-dt/creating_templates.html)
+- [Authoring Devices](https://analogdevicesinc.github.io/pyadi-dt/developer/authoring_devices.html)
 - [Visualization & Diagnostics](https://analogdevicesinc.github.io/pyadi-dt/visualization.html)
 - [Developer Guide](https://analogdevicesinc.github.io/pyadi-dt/xsa_developer.html)
 

--- a/adidt/cli/main.py
+++ b/adidt/cli/main.py
@@ -798,9 +798,9 @@ def xsa2dt(
 
     \b
     Output artifacts (written to -o directory):
-      *.dtso          — Generated overlay
-      *.dts           — Merged device tree source
-      *_report.html   — Interactive visualization report
+      ``*.dtso``        — Generated overlay
+      ``*.dts``         — Merged device tree source
+      ``*_report.html`` — Interactive visualization report
 
     \b
     Examples:

--- a/adidt/mcp_server.py
+++ b/adidt/mcp_server.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 
 from fastmcp import FastMCP
 
+from adidt.dt import dt as _load_dt
 from adidt.xsa.pipeline import XsaPipeline
 from adidt.xsa.config.profiles import ProfileManager
 
@@ -145,12 +146,10 @@ def read_dt_property(
         Dict with property values, or an error dict if the node/property is not found.
     """
     try:
-        from adidt.dt import dt
-
         if filepath:
-            d = dt(dt_source="local_file", local_dt_filepath=filepath)
+            d = _load_dt(dt_source="local_file", local_dt_filepath=filepath)
         else:
-            d = dt(dt_source="local_sysfs")
+            d = _load_dt(dt_source="local_sysfs")
 
         # Use fdt-based lookup: find node by name in the parsed tree
         node = None

--- a/adidt/system.py
+++ b/adidt/system.py
@@ -10,6 +10,7 @@ device-centric API share one rendering path.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Iterable
 
 from ._naming import jesd_labels, out_clk_select, sys_clk_select
@@ -499,9 +500,9 @@ class System:
 
     def generate_wiring_graph(
         self,
-        output_dir: "Path",
+        output_dir: Path,
         name: str | None = None,
-    ) -> "dict[str, Path]":
+    ) -> dict[str, Path]:
         """Render the SPI/JESD/GPIO control-plane wiring to DOT + D2 files.
 
         Returns the artifact dict described by
@@ -509,11 +510,9 @@ class System:
         ``wiring_dot`` and ``wiring_d2`` (always), plus ``wiring_dot_svg``
         / ``wiring_d2_svg`` when the corresponding renderer is on PATH.
         """
-        from pathlib import Path as _Path
-
         from .xsa.viz.wiring_graph import WiringGraph, WiringGraphGenerator
 
         graph = WiringGraph.from_system(self)
         return WiringGraphGenerator().generate(
-            graph, _Path(output_dir), name or self.name
+            graph, Path(output_dir), name or self.name
         )

--- a/doc/source/cli.rst
+++ b/doc/source/cli.rst
@@ -15,8 +15,8 @@ Command Overview
 
 Commands are grouped into three workflows:
 
-Inspect device trees
-~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Inspect device trees
+
 Read, search, and modify device tree properties on live hardware (local or
 remote over SSH) or from a ``.dtb`` file.
 
@@ -47,8 +47,8 @@ remote over SSH) or from a ``.dtb`` file.
       adidtc deps overlay.dts
       adidtc deps overlay.dts --format dot -o deps.dot
 
-Generate device trees
-~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Generate device trees
+
 Produce ``.dts`` files from Vivado XSA designs, board class + solver configs,
 or profile wizard exports.
 
@@ -85,8 +85,8 @@ or profile wizard exports.
       adidtc -c local_file -f devicetree.dtb -a arm64 jif clock -f solved.json
       adidtc -c remote_sd -i 192.168.2.1 jif clock -f solved.json --reboot
 
-Manage boards and profiles
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Manage boards and profiles
+
 List supported boards, browse XSA profiles, and deploy boot files.
 
 ``kuiper-boards``

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -81,6 +81,12 @@ myst_enable_extensions = [
 
 # -- Autodoc configuration ---------------------------------------------------
 
+# Importing FastMCP has process-wide logging side effects and Sphinx 9's
+# autodoc reload pass can re-evaluate MCP's Pydantic models with incomplete
+# module globals. The API page documents pyadi-dt's wrappers, so mock only the
+# optional framework dependency while importing ``adidt.mcp_server``.
+autodoc_mock_imports = ["fastmcp"]
+
 autodoc_default_options = {
     "members": True,
     "member-order": "bysource",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -63,6 +63,8 @@ coverage_show_missing_items = True
 # Link check configuration
 linkcheck_ignore = [
     r"https://ez.analog.com.*",
+    # Prism is an internal deployment and its repository is intentionally private.
+    r"https://github.com/tfcollins/prism",
 ]
 
 # -- MyST-Parser configuration -----------------------------------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,7 +10,7 @@ clock distribution ICs, RF transceivers, and FPGA-based JESD204 data paths.
 
 .. code-block:: bash
 
-   pip install git+https://github.com/analogdevicesinc/pyadi-dt.git
+   pip install adidt
 
 Key capabilities
 ----------------

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ import nox
 
 nox.options.default_venv_backend = "uv"
 
-PYTHON_VERSIONS = ["3.10"]
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 
 
 def _install_local_pyd2lang(session):
@@ -80,8 +80,16 @@ def docs(session):
         "linkify-it-py",
         "pyd2lang-native>=0.1.1",
     )
-    session.install(".")
-    session.run("sphinx-build", "-vv", "-b", "html", "doc/source", "doc/build/html")
+    session.install(".[mcp]")
+    session.run(
+        "sphinx-build",
+        "-W",
+        "--keep-going",
+        "-b",
+        "html",
+        "doc/source",
+        "doc/build/html",
+    )
 
 
 @nox.session(python="3.11")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,20 +7,21 @@ name = "adidt"
 version = "0.0.1"
 description = "Device tree management tools for ADI hardware"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "EPL-2.0"
+license-files = ["LICENSE"]
 authors = [
     {name = "Analog Devices Inc."}
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "Click",
     "fdt",
@@ -46,11 +47,16 @@ test = [
 ]
 dev = [
     "adidt[test]",
-    "adi-labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git",
+    "labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git",
     "pyadi-build @ git+https://github.com/tfcollins/pyadi-build.git",
     "usbsdmux",
 ]
 mcp = ["fastmcp"]
+
+[project.urls]
+Documentation = "https://analogdevicesinc.github.io/pyadi-dt/"
+Issues = "https://github.com/analogdevicesinc/pyadi-dt/issues"
+Repository = "https://github.com/analogdevicesinc/pyadi-dt"
 
 #[tool.uv.sources]
 #pyadi-build = { path = "./pyadi-build", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "rich",
     "numpy",
     "xmltodict",
-    "pydantic>=2",
+    # MCP 1.x currently fails to import with Pydantic 2.13.
+    "pydantic>=2,<2.13",
 ]
 
 [project.optional-dependencies]

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,5 +1,5 @@
 # Core Sphinx
-sphinx>=5.0
+sphinx>=8.1.3
 
 # Markdown support
 myst-parser

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -401,7 +401,7 @@ def test_read_dt_property_returns_specific_property():
         "ad9081", {"compatible": "adi,ad9081", "reg": "<0 0 0 0x10000>"}
     )
 
-    with patch("adidt.dt.dt", return_value=fake_dt):
+    with patch("adidt.mcp_server._load_dt", return_value=fake_dt):
         tool = asyncio.run(mcp.get_tool("read_dt_property"))
         result = asyncio.run(
             tool.run(
@@ -423,7 +423,7 @@ def test_read_dt_property_returns_all_properties_when_property_omitted():
         "ad9081", {"compatible": "adi,ad9081", "reg": "<0 0 0 0x10000>"}
     )
 
-    with patch("adidt.dt.dt", return_value=fake_dt):
+    with patch("adidt.mcp_server._load_dt", return_value=fake_dt):
         tool = asyncio.run(mcp.get_tool("read_dt_property"))
         result = asyncio.run(
             tool.run({"node_name": "ad9081", "filepath": "/tmp/fake.dtb"})
@@ -439,7 +439,7 @@ def test_read_dt_property_unknown_node_returns_error():
     fake_dt.fdt.walk.return_value = []
     fake_dt.get_node_by_compatible.return_value = None
 
-    with patch("adidt.dt.dt", return_value=fake_dt):
+    with patch("adidt.mcp_server._load_dt", return_value=fake_dt):
         tool = asyncio.run(mcp.get_tool("read_dt_property"))
         result = asyncio.run(
             tool.run({"node_name": "missing_node", "filepath": "/tmp/fake.dtb"})
@@ -457,7 +457,7 @@ def test_read_dt_property_invalid_filepath_returns_error():
     def _raise(*args, **kwargs):
         raise FileNotFoundError("no such DTB on disk")
 
-    with patch("adidt.dt.dt", side_effect=_raise):
+    with patch("adidt.mcp_server._load_dt", side_effect=_raise):
         tool = asyncio.run(mcp.get_tool("read_dt_property"))
         result = asyncio.run(
             tool.run(

--- a/test/test_release_metadata.py
+++ b/test/test_release_metadata.py
@@ -1,0 +1,10 @@
+"""Release metadata consistency tests."""
+
+from importlib.metadata import version
+
+import adidt
+
+
+def test_package_and_distribution_versions_match():
+    """Keep the importable and built-distribution versions synchronized."""
+    assert adidt.__version__ == version("adidt")


### PR DESCRIPTION
## Summary

Prepare pyadi-dt for its first tagged release (`v0.0.1`) and turn advisory release checks into enforced gates.

### Hardware and quality fixes

- correct the `labgrid-plugins` distribution name used by `.[dev]`, fixing modern `uv` installs on every hardware runner
- make `ty` blocking, fix its builders path, and resolve the undefined `Path` diagnostic
- build Sphinx HTML and linkcheck with warnings as errors
- install the MCP extra in docs CI and repair MCP test patching
- fix generated Click RST wildcard warnings and dead README/docs links
- test the supported Python 3.10-3.13 matrix; explicitly exclude 3.14 until its NumPy dependency chain is compatible

### Release automation

- add `CHANGELOG.md` and package/distribution version consistency coverage
- add SPDX license metadata and project URLs
- include the changelog in the sdist
- add tag validation, clean wheel smoke tests, GitHub Release creation, and PyPI Trusted Publishing
- attach amd64/arm64/armhf Debian artifacts to tagged GitHub releases
- fail tag builds when the tag and package versions differ
- harden Debian scripts and verify the installed payload outside the source checkout

### CI maintenance

- update upload-artifact to v7, test-reporter to v3, sticky-comment to v3, and require Sphinx 8.1.3

## Validation

- Python 3.10 full suite: 730 passed, 15 skipped, 4 xfailed
- Python 3.13 full suite: 730 passed, 15 skipped, 4 xfailed
- Ruff: passed
- ty: passed
- strict Sphinx HTML: passed
- strict Sphinx linkcheck: passed
- wheel/sdist build and twine check: passed
- clean installed-wheel import and `adidtc --help`: passed
- clean `.[dev]` install on BQ and Nemo: passed
- amd64 Debian build, metadata, installed-payload import, and CLI smoke: passed in Ubuntu 24.04
- actionlint and shell syntax: passed
- hosted branch checks: Python 3.10-3.13, type check, and ADI binding audit passed
- dynamic hardware matrix: passed on the release branch candidate ([run 30014569443](https://github.com/analogdevicesinc/pyadi-dt/actions/runs/30014569443))

## Open-PR release triage

- #73, #74, #75, #68 are absorbed here and can close after merge
- #81 is superseded by the merged dynamic coordinator workflow and can close
- #83 is substantial SDT prototype work and should be deferred until after v0.0.1
- #25 and #18 are large feature branches and should be rebased/reviewed after v0.0.1 rather than entering the release freeze

## Before tagging

- configure the `pypi` GitHub environment and PyPI Trusted Publisher for `analogdevicesinc/pyadi-dt` / workflow `release.yml`
- require a green release-candidate SHA including the hardware matrix
- create annotated tag `v0.0.1` on the verified merged `main` SHA
