### PR TITLE
ci: harden release dry-run and operator workflow

### DIFF
--- a/.github/scripts/release_preflight.py
+++ b/.github/scripts/release_preflight.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Release preflight validation script for adidt.
+
+Validates release tag format, matches version numbers across pyproject.toml and
+adidt/__init__.py, and extracts release notes from CHANGELOG.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10 CI
+    tomllib = None
+
+TAG_REGEX = re.compile(
+    r"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?$"
+)
+
+
+def validate_tag_format(tag: str) -> str:
+    """Validate v-prefixed tag format and return the bare version string."""
+    if not TAG_REGEX.fullmatch(tag):
+        raise ValueError(f"invalid release tag format: {tag!r}")
+    return tag.removeprefix("v")
+
+
+def get_pyproject_version(repo_dir: Path) -> str:
+    """Extract project version from pyproject.toml."""
+    pyproject_path = repo_dir / "pyproject.toml"
+    if not pyproject_path.exists():
+        raise FileNotFoundError(f"pyproject.toml not found at {pyproject_path}")
+    content = pyproject_path.read_text(encoding="utf-8")
+    if tomllib is not None:
+        return tomllib.loads(content)["project"]["version"]
+
+    project_match = re.search(
+        r"^\[project\]\s*$\n(?P<body>.*?)(?=^\[|\Z)",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not project_match:
+        raise ValueError("pyproject.toml has no [project] table")
+    version_match = re.search(
+        r'^version\s*=\s*["\'](?P<version>[^"\']+)["\']\s*$',
+        project_match.group("body"),
+        re.MULTILINE,
+    )
+    if not version_match:
+        raise ValueError("pyproject.toml [project] table has no static version")
+    return version_match.group("version")
+
+
+def get_init_version(repo_dir: Path) -> str:
+    """Extract __version__ from adidt/__init__.py using AST parsing."""
+    init_path = repo_dir / "adidt" / "__init__.py"
+    if not init_path.exists():
+        raise FileNotFoundError(f"adidt/__init__.py not found at {init_path}")
+    tree = ast.parse(init_path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__version__":
+                    return ast.literal_eval(node.value)
+    raise ValueError("adidt/__init__.py does not define __version__")
+
+
+def extract_changelog_notes(repo_dir: Path, version: str) -> str:
+    """Extract release notes for version from CHANGELOG.md."""
+    changelog_path = repo_dir / "CHANGELOG.md"
+    if not changelog_path.exists():
+        raise FileNotFoundError(f"CHANGELOG.md not found at {changelog_path}")
+    content = changelog_path.read_text(encoding="utf-8")
+    escaped_ver = re.escape(version)
+    pattern = rf"^## \[{escaped_ver}\].*?\n(?P<body>.*?)(?=^## \[|^\[Unreleased\]:|\Z)"
+    match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise ValueError(f"CHANGELOG.md has no section for version {version!r}")
+    body = match.group("body").strip()
+    if not body:
+        raise ValueError(f"CHANGELOG.md section for version {version!r} is empty")
+    return body + "\n"
+
+
+def run_preflight(tag: str, repo_dir: Path) -> tuple[str, str, str]:
+    """Run full preflight validation.
+
+    Returns:
+        (tag, version, release_notes)
+    """
+    version = validate_tag_format(tag)
+    pyproject_ver = get_pyproject_version(repo_dir)
+    init_ver = get_init_version(repo_dir)
+
+    if len({version, pyproject_ver, init_ver}) != 1:
+        raise ValueError(
+            f"version mismatch: tag={version!r}, pyproject.toml={pyproject_ver!r}, "
+            f"adidt.__version__={init_ver!r}"
+        )
+
+    notes = extract_changelog_notes(repo_dir, version)
+    return tag, version, notes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Release preflight validation")
+    parser.add_argument("--tag", required=True, help="Release tag (e.g. v0.1.0)")
+    parser.add_argument(
+        "--repo-dir",
+        type=Path,
+        default=Path("."),
+        help="Path to repository root (default: current directory)",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Path to write GITHUB_OUTPUT key-value pairs",
+    )
+    parser.add_argument(
+        "--notes-output",
+        type=Path,
+        help="Path to write extracted release notes markdown file",
+    )
+
+    args = parser.parse_args(argv)
+    repo_dir = args.repo_dir.resolve()
+
+    try:
+        tag, version, notes = run_preflight(args.tag, repo_dir)
+    except Exception as exc:
+        print(f"ERROR: release preflight failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Preflight validation SUCCESS: tag={tag}, version={version}")
+
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as f:
+            f.write(f"tag={tag}\n")
+            f.write(f"version={version}\n")
+
+    if args.notes_output:
+        args.notes_output.write_text(notes, encoding="utf-8")
+        print(f"Wrote release notes to {args.notes_output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing v-prefixed tag to validate and publish
+        description: Candidate v-prefixed tag to validate and dry-run from main
         required: true
         type: string
   push:
     tags:
       - "v*"
+
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -25,7 +29,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.ref }}
 
       - uses: actions/setup-python@v6
         with:
@@ -36,44 +40,28 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
-          python - <<'PY'
-          import ast
-          import os
-          import re
-          import tomllib
-          from pathlib import Path
+          python .github/scripts/release_preflight.py --tag "$RELEASE_TAG" --github-output "$GITHUB_OUTPUT"
 
-          tag = os.environ["RELEASE_TAG"]
-          if not re.fullmatch(r"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?", tag):
-              raise SystemExit(f"invalid release tag: {tag!r}")
-          project_version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
-          tree = ast.parse(Path("adidt/__init__.py").read_text())
-          import_version = next(
-              ast.literal_eval(node.value)
-              for node in tree.body
-              if isinstance(node, ast.Assign)
-              and any(
-                  isinstance(target, ast.Name) and target.id == "__version__"
-                  for target in node.targets
-              )
-          )
-          tag_version = tag.removeprefix("v")
-          if len({tag_version, project_version, import_version}) != 1:
-              raise SystemExit(
-                  f"version mismatch: tag={tag_version}, pyproject={project_version}, "
-                  f"adidt.__version__={import_version}"
-              )
-          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
-              output.write(f"tag={tag}\nversion={tag_version}\n")
-          PY
-
-      - name: Verify tag belongs to main
+      - name: Verify release source belongs to main
         env:
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
+          set -euo pipefail
           git fetch origin main --tags
-          TAG_SHA=$(git rev-list -n 1 "$RELEASE_TAG")
-          git merge-base --is-ancestor "$TAG_SHA" origin/main
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+              echo "Manual release dry runs must be dispatched from main" >&2
+              exit 1
+            }
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          else
+            [[ "$(git cat-file -t "refs/tags/$RELEASE_TAG")" == "tag" ]] || {
+              echo "Release tags must be annotated tags" >&2
+              exit 1
+            }
+            TAG_SHA=$(git rev-list -n 1 "$RELEASE_TAG")
+            git merge-base --is-ancestor "$TAG_SHA" origin/main
+          fi
 
   test:
     name: Test Python ${{ matrix.python-version }}
@@ -86,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.validate.outputs.tag }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.validate.outputs.tag }}
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -100,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.validate.outputs.tag }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.validate.outputs.tag }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -123,6 +111,7 @@ jobs:
 
   github-release:
     name: Create GitHub release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [validate, build]
     runs-on: ubuntu-latest
     permissions:
@@ -137,24 +126,9 @@ jobs:
           path: dist
       - name: Extract release notes
         env:
-          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          python - <<'PY'
-          import os
-          import re
-          from pathlib import Path
-
-          version = re.escape(os.environ["VERSION"])
-          changelog = Path("CHANGELOG.md").read_text()
-          match = re.search(
-              rf"^## \[{version}\].*?\n(?P<body>.*?)(?=^## \[|^\[Unreleased\]:)",
-              changelog,
-              re.MULTILINE | re.DOTALL,
-          )
-          if not match:
-              raise SystemExit(f"CHANGELOG.md has no section for {os.environ['VERSION']}")
-          Path("release-notes.md").write_text(match.group("body").strip() + "\n")
-          PY
+          python .github/scripts/release_preflight.py --tag "$RELEASE_TAG" --notes-output release-notes.md
       - name: Create release and attach Python artifacts
         env:
           GH_TOKEN: ${{ github.token }}
@@ -169,6 +143,7 @@ jobs:
 
   pypi:
     name: Publish to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [validate, build]
     runs-on: ubuntu-latest
     environment:

--- a/doc/source/developer/index.rst
+++ b/doc/source/developer/index.rst
@@ -12,3 +12,4 @@ board builders.
    jif_dt_contract
    hardware_ci
    labgrid_exporter
+   release_runbook

--- a/doc/source/developer/release_runbook.md
+++ b/doc/source/developer/release_runbook.md
@@ -1,0 +1,118 @@
+# Release Operator Runbook
+
+This runbook covers validation, publication, verification, and recovery for an
+`adidt` release. The **Publish Release** workflow builds on manual dispatch but
+publishes only when an annotated `v*` tag is pushed.
+
+## One-time setup
+
+### PyPI trusted publisher
+
+Before the first release, sign in to PyPI and add a **pending trusted
+publisher** with these exact values:
+
+- PyPI project name: `adidt`
+- Owner: `analogdevicesinc`
+- Repository: `pyadi-dt`
+- Workflow: `release.yml`
+- Environment: `pypi`
+
+After the first successful upload, verify that the pending publisher became a
+publisher for the newly created project.
+
+### GitHub environment
+
+Create a GitHub environment named `pypi`. Require a release reviewer and limit
+deployment refs to tags matching `v*`. The PyPI job requests OIDC only inside
+this environment; no PyPI API token is required.
+
+## Prepare and validate
+
+1. Confirm the target version agrees in `pyproject.toml` and
+   `adidt/__init__.py` and has a non-empty `## [X.Y.Z]` section in
+   `CHANGELOG.md`.
+2. Run the local contract and package checks from a clean checkout:
+
+   ```bash
+   git fetch origin --tags
+   git switch main
+   git pull --ff-only origin main
+   test -z "$(git status --porcelain)"
+   python .github/scripts/release_preflight.py --tag vX.Y.Z
+   pytest
+   rm -rf build dist
+   python -m build
+   twine check dist/*
+   ```
+
+3. Run the hosted dry run from `main`. The candidate tag does **not** need to
+   exist yet:
+
+   ```bash
+   gh workflow run release.yml --ref main -f tag=vX.Y.Z
+   gh run watch --exit-status
+   ```
+
+   Confirm the validation, Python 3.10–3.13, build, wheel-install, and CLI
+   smoke-test jobs pass. The GitHub Release and PyPI jobs must be skipped.
+4. Confirm all required `main` workflows—including hardware and Debian—are
+   green for the exact commit to be tagged.
+
+## Tag and publish
+
+Record and inspect the exact release commit before tagging:
+
+```bash
+git switch main
+git pull --ff-only origin main
+test -z "$(git status --porcelain)"
+RELEASE_SHA=$(git rev-parse HEAD)
+git show --stat "$RELEASE_SHA"
+git tag -a vX.Y.Z "$RELEASE_SHA" -m "Release vX.Y.Z"
+test "$(git cat-file -t refs/tags/vX.Y.Z)" = tag
+git push origin refs/tags/vX.Y.Z
+```
+
+The tag push is the only event that permits the workflow's GitHub Release and
+PyPI jobs to run. Approve the `pypi` environment deployment only after checking
+that the run's tag, commit SHA, version, changelog, tests, and built artifacts
+are correct.
+
+## Verify the published release
+
+1. Confirm **Publish Release** completed successfully for the tagged SHA.
+2. Confirm the Debian workflow completed for the same tag and attached its
+   `.deb` artifacts to the GitHub Release.
+3. Verify the GitHub Release contains the wheel, source distribution, release
+   notes, and Debian artifacts.
+4. Verify PyPI and smoke-test the immutable published package:
+
+   ```bash
+   python -m venv /tmp/adidt-release-verify
+   /tmp/adidt-release-verify/bin/python -m pip install --no-cache-dir adidt==X.Y.Z
+   /tmp/adidt-release-verify/bin/python -c \
+     'import adidt, importlib.metadata as m; assert adidt.__version__ == m.version("adidt") == "X.Y.Z"'
+   /tmp/adidt-release-verify/bin/adidtc --help
+   ```
+
+5. Verify the public documentation still serves successfully.
+
+## Recover from partial failure
+
+Release files on PyPI are immutable. Never move or reuse a version after any
+artifact for it has been accepted by PyPI.
+
+- **Validation/build failed before publication:** fix `main`, delete the failed
+  remote tag only if neither PyPI nor a release artifact was published, rerun
+  the dry run, and create a new annotated tag on the corrected commit.
+- **PyPI upload partially succeeded:** rerun the failed jobs. Publishing uses
+  `skip-existing`, so accepted files are retained and missing files can resume.
+  Do not rebuild different bytes for the same version.
+- **GitHub Release failed after PyPI succeeded:** rerun the failed job. The
+  workflow creates a missing release or uploads artifacts to an existing one
+  with `--clobber`.
+- **Debian attachment failed:** rerun the Debian workflow for the original tag;
+  do not retag.
+- **A bad package was fully published:** keep the tag and release as an audit
+  record, document the problem, bump to a new version, and publish a corrective
+  release. PyPI versions cannot be replaced safely.

--- a/test/test_release_preflight.py
+++ b/test/test_release_preflight.py
@@ -1,0 +1,128 @@
+"""Tests for release preflight script."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure .github/scripts is importable
+repo_root = Path(__file__).parent.parent
+sys.path.insert(0, str(repo_root / ".github" / "scripts"))
+
+from release_preflight import (
+    extract_changelog_notes,
+    get_init_version,
+    get_pyproject_version,
+    main,
+    run_preflight,
+    validate_tag_format,
+)
+
+
+def test_validate_tag_format():
+    assert validate_tag_format("v0.1.0") == "0.1.0"
+    assert validate_tag_format("v1.2.3-rc1") == "1.2.3-rc1"
+    assert validate_tag_format("v2.0.0+2026") == "2.0.0+2026"
+
+    with pytest.raises(ValueError, match="invalid release tag format"):
+        validate_tag_format("0.1.0")
+
+    with pytest.raises(ValueError, match="invalid release tag format"):
+        validate_tag_format("v1.0")
+
+    with pytest.raises(ValueError, match="invalid release tag format"):
+        validate_tag_format("invalid")
+
+
+def test_run_preflight_success(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "adidt"\nversion = "1.2.3"\n'
+    )
+    init_dir = tmp_path / "adidt"
+    init_dir.mkdir()
+    (init_dir / "__init__.py").write_text('__version__ = "1.2.3"\n')
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [1.2.3] - 2026-07-23\n- Initial release notes\n\n## [1.2.2]\n"
+    )
+
+    tag, version, notes = run_preflight("v1.2.3", tmp_path)
+    assert tag == "v1.2.3"
+    assert version == "1.2.3"
+    assert notes == "- Initial release notes\n"
+
+
+def test_version_mismatch(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "adidt"\nversion = "1.2.3"\n'
+    )
+    init_dir = tmp_path / "adidt"
+    init_dir.mkdir()
+    (init_dir / "__init__.py").write_text('__version__ = "1.2.4"\n')
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [1.2.3]\n- Notes\n")
+
+    with pytest.raises(ValueError, match="version mismatch"):
+        run_preflight("v1.2.3", tmp_path)
+
+
+def test_missing_changelog_section(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "adidt"\nversion = "1.2.3"\n'
+    )
+    init_dir = tmp_path / "adidt"
+    init_dir.mkdir()
+    (init_dir / "__init__.py").write_text('__version__ = "1.2.3"\n')
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [1.2.2]\n- Old notes\n")
+
+    with pytest.raises(ValueError, match="CHANGELOG.md has no section"):
+        run_preflight("v1.2.3", tmp_path)
+
+
+def test_cli_main(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "adidt"\nversion = "0.5.0"\n'
+    )
+    init_dir = tmp_path / "adidt"
+    init_dir.mkdir()
+    (init_dir / "__init__.py").write_text('__version__ = "0.5.0"\n')
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [0.5.0]\n- Feature X\n")
+
+    gh_out = tmp_path / "gh_output.txt"
+    notes_out = tmp_path / "notes.md"
+
+    ret = main(
+        [
+            "--tag",
+            "v0.5.0",
+            "--repo-dir",
+            str(tmp_path),
+            "--github-output",
+            str(gh_out),
+            "--notes-output",
+            str(notes_out),
+        ]
+    )
+
+    assert ret == 0
+    assert gh_out.read_text() == "tag=v0.5.0\nversion=0.5.0\n"
+    assert notes_out.read_text() == "- Feature X\n"
+
+
+def test_repository_release_contract():
+    tag, version, notes = run_preflight("v0.0.1", repo_root)
+
+    assert tag == "v0.0.1"
+    assert version == "0.0.1"
+    assert notes.strip()
+
+
+def test_manual_dispatch_cannot_publish():
+    workflow = (repo_root / ".github" / "workflows" / "release.yml").read_text()
+
+    publish_guard = (
+        "if: github.event_name == 'push' && "
+        "startsWith(github.ref, 'refs/tags/v')"
+    )
+    assert workflow.count(publish_guard) == 2
+    assert "Candidate v-prefixed tag to validate and dry-run from main" in workflow
+    assert "Manual release dry runs must be dispatched from main" in workflow
+    assert "github.event_name == 'workflow_dispatch' && github.sha" in workflow


### PR DESCRIPTION
## Summary

Harden the post-merge `v0.0.1` release path so it can be exercised safely before a tag exists.

- make manual `workflow_dispatch` a build/test-only dry run from `main`
- keep GitHub Release and PyPI publication exclusively behind an annotated `v*` tag push
- require the tagged commit to belong to `main`
- serialize runs per candidate tag without cancelling an in-flight publication
- move version/tag/changelog validation into a reusable Python 3.10+ preflight script
- add focused release-contract tests
- add an operator runbook covering pending PyPI Trusted Publishing, approvals, tagging, verification, and immutable-artifact recovery

## Safety properties

- Manual dispatch cannot execute either publishing job.
- Manual dry runs must be launched from `main`; the candidate tag need not exist.
- Production publication requires an annotated tag whose commit is on `main`.
- The `pypi` GitHub environment is configured separately with required reviewer `tfcollins` and a `v*` tag deployment policy.

## Verification

- `python .github/scripts/release_preflight.py --tag v0.0.1`
- focused release tests: 8 passed on Python 3.10
- full suite: 737 passed, 15 skipped, 4 xfailed
- Ruff: passed
- actionlint: passed
- strict Sphinx HTML: passed
- strict Sphinx linkcheck: passed
- wheel and sdist build: passed
- `twine check`: passed
- merged-main hardware rerun: all four boards passed

## Remaining external task

Configure the PyPI pending trusted publisher for project `adidt` with owner `analogdevicesinc`, repository `pyadi-dt`, workflow `release.yml`, and environment `pypi`. No tag or release is created by this PR.
