### PR TITLE
ci: add serialized release artifact checksums

### DIFF
--- a/.github/scripts/release_manifest.py
+++ b/.github/scripts/release_manifest.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Release artifact manifest and upsert helper for adidt.
+
+Provides deterministic SHA-256 manifest generation, verification, and idempotent
+GitHub Release asset upsert across Python and Debian workflows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+MANIFEST_NAME = "SHA256SUMS"
+
+
+def compute_sha256(file_path: Path) -> str:
+    """Compute SHA-256 hex digest for a given file."""
+    hasher = hashlib.sha256()
+    with file_path.open("rb") as f:
+        while chunk := f.read(65536):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def generate_manifest(
+    files_or_dir: Path | list[Path],
+    output_file: Path | None = None,
+    exclude_names: set[str] | None = None,
+) -> str:
+    """Generate deterministic SHA-256 manifest string.
+
+    Format per line: `<sha256>  <filename>` sorted alphabetically by filename.
+    """
+    if exclude_names is None:
+        exclude_names = {MANIFEST_NAME, "release-notes.md"}
+    else:
+        exclude_names = set(exclude_names) | {MANIFEST_NAME}
+
+    target_files: list[Path] = []
+    if isinstance(files_or_dir, Path) and files_or_dir.is_dir():
+        for item in files_or_dir.iterdir():
+            if item.is_file() and item.name not in exclude_names:
+                target_files.append(item)
+    elif isinstance(files_or_dir, list):
+        for item in files_or_dir:
+            p = Path(item)
+            if p.is_file() and p.name not in exclude_names:
+                target_files.append(p)
+    elif isinstance(files_or_dir, Path) and files_or_dir.is_file():
+        if files_or_dir.name not in exclude_names:
+            target_files.append(files_or_dir)
+
+    target_files.sort(key=lambda p: p.name)
+
+    lines = []
+    for file_path in target_files:
+        digest = compute_sha256(file_path)
+        lines.append(f"{digest}  {file_path.name}")
+
+    manifest_text = "\n".join(lines) + ("\n" if lines else "")
+
+    if output_file is not None:
+        output_file.write_text(manifest_text, encoding="utf-8")
+
+    return manifest_text
+
+
+def verify_manifest(manifest_path: Path, directory: Path) -> tuple[bool, list[str]]:
+    """Verify files in directory against a SHA256SUMS manifest file."""
+    if not manifest_path.exists():
+        return False, [f"Manifest file not found: {manifest_path}"]
+
+    errors: list[str] = []
+    lines = manifest_path.read_text(encoding="utf-8").splitlines()
+
+    for line_num, line in enumerate(lines, 1):
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            errors.append(f"Line {line_num}: invalid manifest format: {line!r}")
+            continue
+        expected_hash, filename = parts[0], parts[1].lstrip(" *")
+        file_path = directory / filename
+        if not file_path.exists():
+            errors.append(f"Missing file: {filename}")
+            continue
+        actual_hash = compute_sha256(file_path)
+        if actual_hash.lower() != expected_hash.lower():
+            errors.append(
+                f"Checksum mismatch for {filename}: expected {expected_hash}, got {actual_hash}"
+            )
+
+    return len(errors) == 0, errors
+
+
+def run_cmd(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run shell command with string output."""
+    return subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=check,
+    )
+
+
+def upsert_github_release(
+    tag: str,
+    files_to_upload: list[Path],
+    notes_file: Path | None = None,
+    title: str | None = None,
+    runner_func=run_cmd,
+) -> None:
+    """Robustly create/update GitHub Release, upload files, and update SHA256SUMS."""
+    rel_title = title or tag
+
+    view_proc = runner_func(["gh", "release", "view", tag], check=False)
+    release_exists = view_proc.returncode == 0
+
+    if not release_exists:
+        create_cmd = ["gh", "release", "create", tag, "--verify-tag", "--title", rel_title]
+        if notes_file and notes_file.exists():
+            create_cmd.extend(["--notes-file", str(notes_file)])
+        else:
+            create_cmd.extend(["--notes", f"Release {tag}"])
+
+        create_proc = runner_func(create_cmd, check=False)
+        if create_proc.returncode != 0:
+            view_proc2 = runner_func(["gh", "release", "view", tag], check=False)
+            if view_proc2.returncode != 0:
+                sys.stderr.write(f"Failed to create release {tag}: {create_proc.stderr}\n")
+                sys.exit(create_proc.returncode)
+
+    if release_exists and notes_file and notes_file.exists():
+        edit_cmd = [
+            "gh",
+            "release",
+            "edit",
+            tag,
+            "--title",
+            rel_title,
+            "--notes-file",
+            str(notes_file),
+        ]
+        edit_proc = runner_func(edit_cmd, check=False)
+        if edit_proc.returncode != 0:
+            sys.stderr.write(f"Warning: Failed to edit release notes: {edit_proc.stderr}\n")
+
+    valid_files = [p for p in files_to_upload if p.exists()]
+    if valid_files:
+        upload_cmd = ["gh", "release", "upload", tag] + [str(p) for p in valid_files] + ["--clobber"]
+        runner_func(upload_cmd, check=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        dl_proc = runner_func(
+            ["gh", "release", "download", tag, "-D", str(tmp_path), "--clobber"],
+            check=False,
+        )
+        if dl_proc.returncode == 0:
+            manifest_file = tmp_path / MANIFEST_NAME
+            generate_manifest(tmp_path, output_file=manifest_file)
+            runner_func(
+                ["gh", "release", "upload", tag, str(manifest_file), "--clobber"],
+                check=True,
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Release artifact manifest helper")
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+
+    # generate
+    gen_parser = subparsers.add_parser("generate", help="Generate SHA256SUMS manifest")
+    gen_parser.add_argument("--dir", type=Path, help="Directory containing files")
+    gen_parser.add_argument("--files", type=Path, nargs="*", help="List of files")
+    gen_parser.add_argument("--output", type=Path, help="Output manifest file path")
+
+    # verify
+    ver_parser = subparsers.add_parser("verify", help="Verify files against manifest")
+    ver_parser.add_argument("--manifest", type=Path, required=True, help="Manifest file path")
+    ver_parser.add_argument("--dir", type=Path, required=True, help="Directory with files")
+
+    # upsert-release
+    upsert_parser = subparsers.add_parser("upsert-release", help="Upsert GitHub release & manifest")
+    upsert_parser.add_argument("--tag", required=True, help="Release tag (e.g. v0.1.0)")
+    upsert_parser.add_argument("--files", type=Path, nargs="*", default=[], help="Files to upload")
+    upsert_parser.add_argument("--notes-file", type=Path, help="Path to release notes file")
+    upsert_parser.add_argument("--title", help="Release title")
+
+    args = parser.parse_args(argv)
+
+    if args.subcommand == "generate":
+        if args.dir:
+            target = args.dir.resolve()
+        elif args.files:
+            target = [f.resolve() for f in args.files]
+        else:
+            print("ERROR: Must provide --dir or --files", file=sys.stderr)
+            return 1
+
+        manifest = generate_manifest(target, output_file=args.output)
+        if not args.output:
+            sys.stdout.write(manifest)
+        return 0
+
+    if args.subcommand == "verify":
+        ok, errors = verify_manifest(args.manifest.resolve(), args.dir.resolve())
+        if not ok:
+            print("ERROR: Manifest verification failed:", file=sys.stderr)
+            for err in errors:
+                print(f"  - {err}", file=sys.stderr)
+            return 1
+        print(f"Manifest verification SUCCESS for {args.manifest}")
+        return 0
+
+    if args.subcommand == "upsert-release":
+        files = [f.resolve() for f in args.files]
+        notes_file = args.notes_file.resolve() if args.notes_file else None
+        upsert_github_release(args.tag, files, notes_file=notes_file, title=args.title)
+        print(f"Release {args.tag} upserted successfully.")
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build_debian.yaml
+++ b/.github/workflows/build_debian.yaml
@@ -1,7 +1,13 @@
 name: Build and Deploy adidt (debian)
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  # Match release.yml on tag pushes so Python and Debian assets cannot race
+  # while creating the release or replacing its checksum manifest.
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
 
 env:
   APP_NAME: adidt
@@ -114,20 +120,6 @@ jobs:
         path: python3-${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{matrix.architecture}}.deb
         if-no-files-found: error
 
-    - name: Attach .deb to tagged GitHub release
-      if: github.ref_type == 'tag'
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        for attempt in {1..30}; do
-          gh release view "${{ github.ref_name }}" >/dev/null 2>&1 && break
-          if [[ "$attempt" == 30 ]]; then echo "Release was not created in time" >&2; exit 1; fi
-          sleep 10
-        done
-        gh release upload "${{ github.ref_name }}" \
-          python3-${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{matrix.architecture}}.deb \
-          --clobber
-
   build_and_deploy_for_ubuntu:
     runs-on: ubuntu-latest
     needs: identify_version
@@ -163,16 +155,36 @@ jobs:
         path: ${{env.APP_NAME}}/python3-${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb
         if-no-files-found: error
 
-    - name: Attach .deb to tagged GitHub release
-      if: github.ref_type == 'tag'
+  attach_debian_release_assets:
+    name: Attach verified Debian artifacts to release
+    if: github.ref_type == 'tag'
+    needs: [identify_version, build_and_deploy_for_kuiper, build_and_deploy_for_ubuntu]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout release helper
+      uses: actions/checkout@v7
+      with:
+        path: source
+    - name: Download all Debian artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: adidt-*
+        path: release-assets
+        merge-multiple: true
+    - name: Validate and attach Debian assets
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        for attempt in {1..30}; do
-          gh release view "${{ github.ref_name }}" >/dev/null 2>&1 && break
-          if [[ "$attempt" == 30 ]]; then echo "Release was not created in time" >&2; exit 1; fi
-          sleep 10
-        done
-        gh release upload "${{ github.ref_name }}" \
-          ${{env.APP_NAME}}/python3-${{env.APP_NAME}}_${{needs.identify_version.outputs.app-version}}-1_${{env.architecture}}.deb \
-          --clobber
+        set -euo pipefail
+        shopt -s nullglob
+        artifacts=(release-assets/*.deb)
+        if [[ "${#artifacts[@]}" -ne 3 ]]; then
+          echo "Expected three Debian artifacts, found ${#artifacts[@]}" >&2
+          printf '  %s\n' "${artifacts[@]}" >&2
+          exit 1
+        fi
+        python3 source/.github/scripts/release_manifest.py upsert-release \
+          --tag "${{ github.ref_name }}" \
+          --files "${artifacts[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
       - run: python -m pip install build twine
       - run: python -m build
       - run: twine check dist/*
+      - name: Generate and verify SHA-256 distribution manifest
+        run: |
+          python .github/scripts/release_manifest.py generate --dir dist --output dist/SHA256SUMS
+          python .github/scripts/release_manifest.py verify --manifest dist/SHA256SUMS --dir dist
       - name: Verify wheel in a clean environment
         run: |
           python -m venv /tmp/adidt-release-smoke
@@ -120,6 +124,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.validate.outputs.tag }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - uses: actions/download-artifact@v8
         with:
           name: python-distributions
@@ -129,17 +136,16 @@ jobs:
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
           python .github/scripts/release_preflight.py --tag "$RELEASE_TAG" --notes-output release-notes.md
-      - name: Create release and attach Python artifacts
+      - name: Upsert release, attach Python artifacts, and update manifest
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" dist/* --clobber
-          else
-            gh release create "$RELEASE_TAG" dist/* \
-              --verify-tag --title "$RELEASE_TAG" --notes-file release-notes.md
-          fi
+          python .github/scripts/release_manifest.py upsert-release \
+            --tag "$RELEASE_TAG" \
+            --files dist/* \
+            --notes-file release-notes.md \
+            --title "$RELEASE_TAG"
 
   pypi:
     name: Publish to PyPI

--- a/doc/source/developer/release_runbook.md
+++ b/doc/source/developer/release_runbook.md
@@ -84,8 +84,17 @@ are correct.
 2. Confirm the Debian workflow completed for the same tag and attached its
    `.deb` artifacts to the GitHub Release.
 3. Verify the GitHub Release contains the wheel, source distribution, release
-   notes, and Debian artifacts.
-4. Verify PyPI and smoke-test the immutable published package:
+   notes, Debian artifacts, and `SHA256SUMS` manifest file.
+4. Verify checksum manifest integrity:
+
+   ```bash
+   gh release download vX.Y.Z -D /tmp/adidt-verify-assets
+   cd /tmp/adidt-verify-assets
+   sha256sum -c SHA256SUMS
+   python .github/scripts/release_manifest.py verify --manifest SHA256SUMS --dir .
+   ```
+
+5. Verify PyPI and smoke-test the immutable published package:
 
    ```bash
    python -m venv /tmp/adidt-release-verify
@@ -95,7 +104,7 @@ are correct.
    /tmp/adidt-release-verify/bin/adidtc --help
    ```
 
-5. Verify the public documentation still serves successfully.
+6. Verify the public documentation still serves successfully.
 
 ## Recover from partial failure
 
@@ -110,9 +119,14 @@ artifact for it has been accepted by PyPI.
   Do not rebuild different bytes for the same version.
 - **GitHub Release failed after PyPI succeeded:** rerun the failed job. The
   workflow creates a missing release or uploads artifacts to an existing one
-  with `--clobber`.
+  with `--clobber` and updates `SHA256SUMS`.
 - **Debian attachment failed:** rerun the Debian workflow for the original tag;
   do not retag.
+- **Checksum manifest out of sync:** re-sync the release manifest using the
+  helper script:
+  ```bash
+  python .github/scripts/release_manifest.py upsert-release --tag vX.Y.Z
+  ```
 - **A bad package was fully published:** keep the tag and release as an audit
   record, document the problem, bump to a new version, and publish a corrective
   release. PyPI versions cannot be replaced safely.

--- a/test/test_release_manifest.py
+++ b/test/test_release_manifest.py
@@ -1,0 +1,171 @@
+"""Tests for release artifact manifest and release upsert helper script."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+repo_root = Path(__file__).parent.parent
+sys.path.insert(0, str(repo_root / ".github" / "scripts"))
+
+from release_manifest import (
+    compute_sha256,
+    generate_manifest,
+    main,
+    upsert_github_release,
+    verify_manifest,
+)
+
+
+def test_compute_sha256(tmp_path):
+    file1 = tmp_path / "test.txt"
+    file1.write_bytes(b"hello world\n")
+    # sha256 of "hello world\n"
+    # echo "hello world" | sha256sum -> d2a842e44ec75078f08d66653347917e6e522502693892787729227f272e505a
+    expected = hashlib_sha256(b"hello world\n")
+    assert compute_sha256(file1) == expected
+
+
+def hashlib_sha256(data: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def test_generate_manifest_deterministic(tmp_path):
+    (tmp_path / "z_file.whl").write_bytes(b"content z")
+    (tmp_path / "a_file.tar.gz").write_bytes(b"content a")
+    (tmp_path / "SHA256SUMS").write_text("old manifest")
+
+    manifest = generate_manifest(tmp_path)
+    lines = manifest.strip().splitlines()
+
+    assert len(lines) == 2
+    # Verify sorted order (a_file before z_file)
+    assert lines[0].endswith("a_file.tar.gz")
+    assert lines[1].endswith("z_file.whl")
+
+    # Verify standard sha256sum format: hash + two spaces + filename
+    h_a = hashlib_sha256(b"content a")
+    h_z = hashlib_sha256(b"content z")
+    assert lines[0] == f"{h_a}  a_file.tar.gz"
+    assert lines[1] == f"{h_z}  z_file.whl"
+
+    # Test writing output file
+    out_file = tmp_path / "OUTPUT_MANIFEST"
+    generate_manifest(tmp_path, output_file=out_file)
+    assert out_file.read_text(encoding="utf-8") == manifest
+
+
+def test_verify_manifest(tmp_path):
+    (tmp_path / "pkg.whl").write_bytes(b"package content")
+    manifest_file = tmp_path / "SHA256SUMS"
+    generate_manifest(tmp_path, output_file=manifest_file)
+
+    # Valid verification
+    ok, errors = verify_manifest(manifest_file, tmp_path)
+    assert ok
+    assert not errors
+
+    # Corrupt file
+    (tmp_path / "pkg.whl").write_bytes(b"corrupted content")
+    ok, errors = verify_manifest(manifest_file, tmp_path)
+    assert not ok
+    assert any("Checksum mismatch" in e for e in errors)
+
+    # Missing file
+    (tmp_path / "pkg.whl").unlink()
+    ok, errors = verify_manifest(manifest_file, tmp_path)
+    assert not ok
+    assert any("Missing file" in e for e in errors)
+
+
+def test_sha256sum_cli_compatibility(tmp_path):
+    """Verify standard sha256sum CLI utility accepts generated SHA256SUMS file."""
+    (tmp_path / "dist1.whl").write_bytes(b"data 1")
+    (tmp_path / "dist2.tar.gz").write_bytes(b"data 2")
+    manifest_file = tmp_path / "SHA256SUMS"
+    generate_manifest(tmp_path, output_file=manifest_file)
+
+    proc = subprocess.run(
+        ["sha256sum", "-c", "SHA256SUMS"],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "dist1.whl: OK" in proc.stdout
+    assert "dist2.tar.gz: OK" in proc.stdout
+
+
+def test_upsert_release_creates_new(tmp_path):
+    tag = "v1.0.0"
+    file1 = tmp_path / "adidt-1.0.0.whl"
+    file1.write_bytes(b"wheel content")
+    notes_file = tmp_path / "notes.md"
+    notes_file.write_text("- Release notes v1.0.0")
+
+    executed_cmds = []
+
+    def mock_runner(cmd: list[str], check: bool = True):
+        executed_cmds.append(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = ""
+        proc.stderr = ""
+        # Simulate initial view failing (release does not exist yet)
+        if cmd[:3] == ["gh", "release", "view"]:
+            if len([c for c in executed_cmds if c[:3] == ["gh", "release", "view"]]) == 1:
+                proc.returncode = 1
+        return proc
+
+    upsert_github_release(tag, [file1], notes_file=notes_file, runner_func=mock_runner)
+
+    cmd_heads = [c[:3] for c in executed_cmds]
+    assert ["gh", "release", "view"] in cmd_heads
+    assert ["gh", "release", "create"] in cmd_heads
+    assert ["gh", "release", "upload"] in cmd_heads
+    assert ["gh", "release", "download"] in cmd_heads
+
+
+def test_upsert_release_edits_existing(tmp_path):
+    tag = "v1.0.0"
+    file1 = tmp_path / "adidt-1.0.0.whl"
+    file1.write_bytes(b"wheel content")
+    notes_file = tmp_path / "notes.md"
+    notes_file.write_text("- Release notes v1.0.0")
+
+    executed_cmds = []
+
+    def mock_runner(cmd: list[str], check: bool = True):
+        executed_cmds.append(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        return proc
+
+    upsert_github_release(tag, [file1], notes_file=notes_file, runner_func=mock_runner)
+
+    cmd_heads = [c[:3] for c in executed_cmds]
+    assert ["gh", "release", "view"] in cmd_heads
+    assert ["gh", "release", "create"] not in cmd_heads
+    assert ["gh", "release", "edit"] in cmd_heads
+    assert ["gh", "release", "upload"] in cmd_heads
+
+
+def test_cli_subcommands(tmp_path):
+    (tmp_path / "test.txt").write_bytes(b"content")
+    out_manifest = tmp_path / "SHA256SUMS"
+
+    # test generate
+    ret = main(["generate", "--dir", str(tmp_path), "--output", str(out_manifest)])
+    assert ret == 0
+    assert out_manifest.exists()
+
+    # test verify
+    ret = main(["verify", "--manifest", str(out_manifest), "--dir", str(tmp_path)])
+    assert ret == 0

--- a/test/test_release_preflight.py
+++ b/test/test_release_preflight.py
@@ -126,3 +126,20 @@ def test_manual_dispatch_cannot_publish():
     assert "Candidate v-prefixed tag to validate and dry-run from main" in workflow
     assert "Manual release dry runs must be dispatched from main" in workflow
     assert "github.event_name == 'workflow_dispatch' && github.sha" in workflow
+
+
+def test_workflows_use_release_manifest_without_sleep_loops():
+    release_wf = (repo_root / ".github" / "workflows" / "release.yml").read_text()
+    debian_wf = (repo_root / ".github" / "workflows" / "build_debian.yaml").read_text()
+
+    assert "release_manifest.py generate" in release_wf
+    assert "release_manifest.py verify" in release_wf
+    assert "release_manifest.py upsert-release" in release_wf
+
+    assert debian_wf.count("release_manifest.py upsert-release") == 1
+    assert "needs: [identify_version, build_and_deploy_for_kuiper, build_and_deploy_for_ubuntu]" in debian_wf
+    assert "Expected three Debian artifacts" in debian_wf
+    assert "group: release-${{ github.ref_name }}" in debian_wf
+    assert "group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}" in release_wf
+    assert "sleep 10" not in debian_wf
+    assert "for attempt in {1..30}" not in debian_wf


### PR DESCRIPTION
## Summary

Add deterministic checksums and serialize tag-triggered Python/Debian release updates.

- generate and verify a standard `SHA256SUMS` manifest for wheel/sdist artifacts
- attach one checksum manifest covering the exact assets downloaded from the GitHub Release
- replace per-matrix Debian release uploads with one post-matrix attachment job
- share a per-tag concurrency group with the Python release workflow so release creation, asset upserts, and checksum replacement cannot race across workflows
- retain idempotent reruns through `--clobber` and regenerated checksums
- document checksum verification and partial-failure recovery

## Important ordering

This PR is stacked on #87 and targets `release/post-merge-hardening`. Merge #87 first, then this PR can be retargeted or merged into `main`.

## Verification

- actionlint: passed
- focused release tests: 16 passed
- full suite: 742 passed, 18 skipped, 4 xfailed
- Ruff: passed
- strict Sphinx HTML: passed
- strict Sphinx linkcheck: passed
- wheel and sdist build: passed
- `twine check`: passed
- helper manifest verification: passed
- GNU `sha256sum -c`: passed

No tag, GitHub Release, or package publication is performed by this PR.
