### PR TITLE
docs: add adidtc AI agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,28 @@ adidtc -c remote_sysfs -i 192.168.2.1 prop -cp adi,ad9361 clock-output-names
 - [Visualization & Diagnostics](https://analogdevicesinc.github.io/pyadi-dt/visualization.html)
 - [Developer Guide](https://analogdevicesinc.github.io/pyadi-dt/xsa_developer.html)
 
+## AI agent skill
+
+The repository includes an [Agent Skill](skills/pyadi-dt-cli/SKILL.md) that
+teaches compatible coding agents to discover and use `adidtc`, select the least
+invasive device-tree access context, generate and validate XSA outputs, and
+handle hardware-changing commands safely.
+
+Install it for Agent Skills-compatible tools and Claude Code:
+
+```bash
+./skills/pyadi-dt-cli/scripts/install.sh
+```
+
+Install for only one skill directory with `agents` or `claude`, for example:
+
+```bash
+./skills/pyadi-dt-cli/scripts/install.sh agents
+```
+
+The installer creates a symlink, so the installed skill follows the checked-out
+version. Start a new agent session after installation.
+
 ## Development
 
 ```bash

--- a/skills/pyadi-dt-cli/SKILL.md
+++ b/skills/pyadi-dt-cli/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: pyadi-dt-cli
+description: Use the pyadi-dt adidtc CLI to inspect, generate, validate, and safely deploy Analog Devices Linux device trees. Trigger for Vivado XSA-to-DTS generation, built-in board profiles, Kuiper support discovery, DTS include analysis, local DTB inspection, live-board property reads, SD-card updates, or pyadi-jif clock updates.
+---
+
+# pyadi-dt CLI
+
+Use `adidtc` to inspect, generate, validate, and deploy Linux device trees for
+Analog Devices hardware. Prefer discovery and read-only commands first. Treat SD
+card writes, property writes, and reboots as hardware-changing operations.
+
+## Start here
+
+1. Confirm the executable and inspect the current command surface:
+
+   ```bash
+   command -v adidtc
+   adidtc --help
+   ```
+
+2. If it is unavailable, from the pyadi-dt repository create an isolated
+   environment instead of modifying the system Python:
+
+   ```bash
+   python3 -m venv .venv
+   .venv/bin/pip install -e .
+   .venv/bin/adidtc --help
+   ```
+
+   For XSA generation, install the XSA extra and ensure `sdtgen` is available:
+
+   ```bash
+   .venv/bin/pip install -e '.[xsa]'
+   command -v sdtgen
+   ```
+
+3. Ask for or discover the input path, board/profile, desired output, and whether
+   hardware mutation is allowed. Do not guess a board, IP address, credential,
+   PetaLinux project, or output path.
+
+4. Run the narrow command's `--help` before composing an unfamiliar invocation.
+
+## Route the task
+
+| Goal | Command | Safe first action |
+|---|---|---|
+| Discover supported Kuiper designs | `kuiper-boards` | `adidtc kuiper-boards --json-output` |
+| Discover XSA profiles | `xsa-profiles`, `xsa-profile-show` | List, then inspect one profile |
+| Generate from Vivado XSA | `xsa2dt` | Validate XSA/config/profile and write to a new directory |
+| Generate without Vivado/XSA | `gen-dts` | Write a new `.dts`; add `--compile` only when `dtc` exists |
+| Analyze DTS includes | `deps` | Use tree or JSON output; do not modify source files |
+| Inspect one node/property | `prop` | Use `local_file`, `local_sysfs`, or `remote_sysfs` |
+| Navigate nested nodes | `props` | Read without `--value` first |
+| Apply pyadi-jif clocks | `jif`, then `jif clock` | Inspect its help and inputs before writing |
+| Switch an SD reference design | `sd-move` | Always run `--dry-run --show` first |
+| Copy boot files to an SD card | `sd-remote-copy` | Always run `--dry-run --show` first |
+
+See `reference/commands.md` for copy/pasteable recipes and output checks.
+
+## XSA-to-DTS workflow
+
+1. Verify inputs exist and preserve them unchanged:
+
+   ```bash
+   test -f design.xsa
+   test -f cfg.json
+   python -m json.tool cfg.json >/dev/null
+   adidtc xsa-profiles
+   adidtc xsa-profile-show ad9081_zcu102
+   ```
+
+2. Use a fresh output directory. Prefer linting, and use strict validation for a
+   release or hardware-bound artifact:
+
+   ```bash
+   adidtc xsa2dt \
+     -x design.xsa \
+     -c cfg.json \
+     --profile ad9081_zcu102 \
+     -o generated/ad9081-zcu102 \
+     --strict-lint
+   ```
+
+3. When a trusted DTS exists, request parity evidence:
+
+   ```bash
+   adidtc xsa2dt \
+     -x design.xsa \
+     -c cfg.json \
+     --profile ad9081_zcu102 \
+     --reference-dts reference.dts \
+     --strict-parity \
+     --strict-lint \
+     -o generated/ad9081-zcu102
+   ```
+
+4. Verify the command exited successfully and inspect every reported artifact.
+   Expected outputs can include a generated overlay (`.dtso`), merged source
+   (`.dts`), HTML report, map/coverage reports, and PetaLinux files when that
+   format is selected. Do not claim the tree boots until it has actually been
+   compiled and tested on the intended hardware.
+
+5. Use `--format petalinux` without `--petalinux-project` to review generated
+   integration files first. Copy into a real project only when the user supplied
+   and approved its path.
+
+## Inspection workflow
+
+Choose the least invasive context:
+
+- `local_file`: read a supplied `.dts` or `.dtb`; no hardware access.
+- `local_sysfs`: inspect `/proc/device-tree` on the current target.
+- `remote_sysfs`: inspect a running board over SSH; read-only.
+- `local_sd` / `remote_sd`: persistent boot media; writes are possible.
+
+Examples:
+
+```bash
+adidtc -c local_file -f system.dtb prop -cp adi,ad9081 clock-output-names
+adidtc -c remote_sysfs -i BOARD_IP prop -cp adi,ad9361 clock-output-names
+adidtc -c local_file -f system.dtb props amba spi0
+```
+
+Replace `BOARD_IP` with a user-provided or independently discovered address.
+Keep global options before the subcommand. First identify nodes, then read the
+property, then propose any change.
+
+## Hardware mutation guardrails
+
+- Do not write a property, alter SD contents, or reboot unless the user explicitly
+  requested that side effect and identified the target.
+- Never place passwords, tokens, or private keys in files, command history,
+  reports, or the skill. Prefer existing SSH configuration or an interactive
+  credential mechanism. Do not print secrets.
+- Before `sd-move` or `sd-remote-copy`, run the identical operation with
+  `--dry-run --show`, review source files and destination target, then run the
+  real command only after explicit approval.
+- Omit `--reboot` on the first real write unless reboot was explicitly requested.
+- Preserve original XSA, DTS/DTB, boot files, and configs. Generate into a new
+  path and report it.
+- A successful generation is not hardware validation. A successful copy is not
+  proof of a successful boot. Verify each stage separately.
+
+## Failure handling
+
+- `adidtc: command not found`: use the repository venv or install in a fresh venv.
+- Missing `sdtgen`: install lopper/XSA dependencies or source the correct
+  Vivado/Vitis environment; do not substitute a fabricated base DTS.
+- Missing `dtc`: generation may still produce DTS, but `--compile` cannot be
+  claimed successful.
+- Unknown profile: run `adidtc xsa-profiles`; do not invent profile names.
+- Invalid config or parity/lint failure: preserve the output and report the exact
+  diagnostic. Do not disable strict checks merely to get a green command.
+- Remote connection failure: distinguish address/authentication/network failures
+  from device-tree errors before changing the invocation.
+
+## Completion checklist
+
+- [ ] Used an isolated environment and the actual `adidtc --help` surface.
+- [ ] Confirmed input files, target/profile, and output path.
+- [ ] Preserved source artifacts and wrote generated files to a new path.
+- [ ] Used read-only context or dry-run before hardware-changing operations.
+- [ ] Ran applicable lint, parity, JSON, DTS/DTB, or hardware validation.
+- [ ] Reported the executed command, exit status, artifact paths, and limitations.

--- a/skills/pyadi-dt-cli/reference/commands.md
+++ b/skills/pyadi-dt-cli/reference/commands.md
@@ -1,0 +1,144 @@
+# Command recipes
+
+These recipes match the current `adidtc` Click command surface. Run
+`adidtc <command> --help` before using newer installations.
+
+## Discovery
+
+```bash
+# Machine-readable support inventory
+adidtc kuiper-boards --json-output
+
+# Narrow to fully supported designs
+adidtc kuiper-boards --status full
+
+# Discover and inspect XSA profiles
+adidtc xsa-profiles
+adidtc xsa-profile-show ad9081_zcu102
+```
+
+Use the reported board/profile names exactly. `profile_only` means an XSA profile
+exists but a complete board-class workflow may not.
+
+## Generate without an XSA
+
+```bash
+printf '{}\n' > cfg.json
+adidtc gen-dts \
+  --board ad9081_fmc \
+  --platform zcu102 \
+  --config cfg.json \
+  --output generated/ad9081-zcu102.dts
+```
+
+Supported pairs are reported by `adidtc gen-dts --help`. To produce a DTB, first
+check `command -v dtc`, then add `--compile`. Confirm the `.dts` and, when
+requested, `.dtb` exist and are non-empty.
+
+## Generate from a Vivado XSA
+
+```bash
+adidtc xsa2dt \
+  --xsa design.xsa \
+  --config cfg.json \
+  --profile ad9081_zcu102 \
+  --output generated/ad9081-zcu102 \
+  --strict-lint
+```
+
+For comparison with a trusted design:
+
+```bash
+adidtc xsa2dt \
+  --xsa design.xsa \
+  --config cfg.json \
+  --profile ad9081_zcu102 \
+  --reference-dts reference.dts \
+  --strict-parity \
+  --strict-lint \
+  --output generated/ad9081-zcu102
+```
+
+For PetaLinux, first generate reviewable files without modifying a project:
+
+```bash
+adidtc xsa2dt \
+  --xsa design.xsa \
+  --config cfg.json \
+  --profile ad9081_zcu102 \
+  --format petalinux \
+  --output generated/petalinux
+```
+
+Only after reviewing them, add `--petalinux-project /approved/project/path`.
+
+## Analyze include dependencies
+
+```bash
+adidtc deps system.dts
+adidtc deps system.dts --format json --output dependencies.json
+adidtc deps system.dts --format dot --output dependencies.dot
+```
+
+A DOT file is not a PNG. Render only when Graphviz is installed:
+
+```bash
+dot -Tpng dependencies.dot -o dependencies.png
+```
+
+## Read a local tree
+
+```bash
+# List compatible IDs
+adidtc -c local_file -f system.dtb prop --compat
+
+# Read one property by compatible ID
+adidtc -c local_file -f system.dtb \
+  prop --compat adi,ad9081 clock-output-names
+
+# Navigate nested nodes
+adidtc -c local_file -f system.dtb props amba spi0
+```
+
+`local_file` is read-only. Use it to inspect generated artifacts before touching
+hardware.
+
+## Read a live tree
+
+```bash
+adidtc -c remote_sysfs -i BOARD_IP \
+  prop --compat adi,ad9361 clock-output-names
+```
+
+Use an existing SSH setup. Do not put passwords in documentation or shell
+transcripts.
+
+## Persistent SD-card changes
+
+Preview switching a reference design:
+
+```bash
+adidtc -c remote_sd -i BOARD_IP \
+  sd-move DESIGN_NAME --dry-run --show
+```
+
+Preview copying boot artifacts:
+
+```bash
+adidtc -c remote_sd -i BOARD_IP \
+  sd-remote-copy BOOT.BIN,system.dtb,image.ub --dry-run --show
+```
+
+After explicit approval, remove `--dry-run`; retain `--show` for evidence. Add
+`--reboot` only when requested. Confirm target identity before and boot health
+afterward.
+
+## Exit and artifact checks
+
+A responsible completion report includes:
+
+1. Exact command with secrets omitted.
+2. Exit code.
+3. Generated or modified paths.
+4. Lint/parity/compile result.
+5. Whether hardware was merely copied, rebooted, or actually boot-tested.

--- a/skills/pyadi-dt-cli/scripts/install.sh
+++ b/skills/pyadi-dt-cli/scripts/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Install the pyadi-dt CLI skill for Agent Skills-compatible tools.
+set -euo pipefail
+
+SKILL_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${1:-all}"
+
+install_skill() {
+  local dest_dir="$1"
+  local dest="${dest_dir}/pyadi-dt-cli"
+  mkdir -p "${dest_dir}"
+
+  if [[ -L "${dest}" ]]; then
+    if [[ "$(readlink "${dest}")" == "${SKILL_SRC}" ]]; then
+      echo "Already installed: ${dest} -> ${SKILL_SRC}"
+      return
+    fi
+    echo "Updating symlink: ${dest}"
+    rm "${dest}"
+  elif [[ -e "${dest}" ]]; then
+    echo "Error: ${dest} exists and is not a symlink; move it aside first." >&2
+    return 1
+  fi
+
+  ln -s "${SKILL_SRC}" "${dest}"
+  echo "Installed: ${dest} -> ${SKILL_SRC}"
+}
+
+case "${TARGET}" in
+  all)
+    install_skill "${HOME}/.agents/skills"
+    install_skill "${HOME}/.claude/skills"
+    ;;
+  agents)
+    install_skill "${HOME}/.agents/skills"
+    ;;
+  claude)
+    install_skill "${HOME}/.claude/skills"
+    ;;
+  *)
+    echo "Usage: $0 [all|agents|claude]" >&2
+    exit 2
+    ;;
+esac
+
+echo "Start a new agent session to load the skill."

--- a/test/test_ai_skill.py
+++ b/test/test_ai_skill.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 from pathlib import Path
 
-import yaml
 from click.testing import CliRunner
 
 from adidt.cli.main import cli
@@ -29,9 +28,10 @@ PUBLIC_COMMANDS = {
 }
 
 
-def _frontmatter(text: str) -> dict:
+def _frontmatter(text: str) -> dict[str, str]:
     assert text.startswith("---\n")
-    return yaml.safe_load(text.split("---\n", 2)[1])
+    block = text.split("---\n", 2)[1]
+    return dict(line.split(": ", 1) for line in block.splitlines())
 
 
 def test_skill_has_valid_frontmatter_and_linked_files():

--- a/test/test_ai_skill.py
+++ b/test/test_ai_skill.py
@@ -1,0 +1,89 @@
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from adidt.cli.main import cli
+
+
+ROOT = Path(__file__).parents[1]
+SKILL_ROOT = ROOT / "skills" / "pyadi-dt-cli"
+SKILL = SKILL_ROOT / "SKILL.md"
+COMMANDS = SKILL_ROOT / "reference" / "commands.md"
+INSTALLER = SKILL_ROOT / "scripts" / "install.sh"
+
+PUBLIC_COMMANDS = {
+    "deps",
+    "gen-dts",
+    "jif",
+    "kuiper-boards",
+    "prop",
+    "props",
+    "sd-move",
+    "sd-remote-copy",
+    "xsa-profile-show",
+    "xsa-profiles",
+    "xsa2dt",
+}
+
+
+def _frontmatter(text: str) -> dict:
+    assert text.startswith("---\n")
+    return yaml.safe_load(text.split("---\n", 2)[1])
+
+
+def test_skill_has_valid_frontmatter_and_linked_files():
+    text = SKILL.read_text()
+    metadata = _frontmatter(text)
+    assert metadata["name"] == "pyadi-dt-cli"
+    assert "adidtc" in metadata["description"]
+    assert "reference/commands.md" in text
+    assert COMMANDS.is_file()
+    assert INSTALLER.is_file()
+
+
+def test_skill_routes_every_public_cli_command():
+    text = f"{SKILL.read_text()}\n{COMMANDS.read_text()}"
+    assert set(cli.commands) == PUBLIC_COMMANDS
+    for command in PUBLIC_COMMANDS:
+        assert f"`{command}`" in text or f"adidtc {command}" in text
+
+
+def test_skill_keeps_hardware_changes_behind_dry_run_and_approval():
+    text = SKILL.read_text().lower()
+    recipes = COMMANDS.read_text().lower()
+    for command in ("sd-move", "sd-remote-copy"):
+        assert f"{command}` | always run `--dry-run --show` first" in text
+        assert f"{command} " in recipes
+    assert "explicit approval" in text
+    assert "do not put passwords" in recipes
+    assert "successful copy is not" in text
+
+
+def test_documented_discovery_commands_execute():
+    runner = CliRunner()
+
+    profiles = runner.invoke(cli, ["xsa-profiles"])
+    assert profiles.exit_code == 0, profiles.output
+    assert "ad9081_zcu102" in profiles.output
+
+    profile = runner.invoke(cli, ["xsa-profile-show", "ad9081_zcu102"])
+    assert profile.exit_code == 0, profile.output
+    assert '"name": "ad9081_zcu102"' in profile.output
+
+    boards = runner.invoke(cli, ["kuiper-boards", "--json-output"])
+    assert boards.exit_code == 0, boards.output
+    assert '"status"' in boards.output
+
+
+def test_installer_supports_agents_claude_and_is_idempotent(tmp_path):
+    env = {**os.environ, "HOME": str(tmp_path)}
+    subprocess.run(["bash", str(INSTALLER), "all"], check=True, env=env)
+    subprocess.run(["bash", str(INSTALLER), "all"], check=True, env=env)
+
+    for parent in (".agents", ".claude"):
+        installed = tmp_path / parent / "skills" / "pyadi-dt-cli"
+        assert installed.is_symlink()
+        assert installed.resolve() == SKILL_ROOT.resolve()


### PR DESCRIPTION
## Summary

Add a reusable in-repository Agent Skill for operating the `adidtc` CLI.

- route agents across all 11 public CLI commands
- provide runnable discovery, XSA generation, local inspection, dependency, and SD-card recipes
- default to read-only contexts and require dry-run plus explicit approval for hardware-changing operations
- install by symlink into `.agents/skills` and/or `.claude/skills`
- document skill installation in the project README
- contract-test front matter, command coverage, safety guidance, safe discovery commands, and installer idempotency

## Verification

- `pytest -q test/test_ai_skill.py` — 5 passed
- full `pytest -q` — 747 passed, 18 skipped, 4 xfailed
- `ruff check .` — passed
- `ty check adidt/xsa/build/builders/` — passed
- strict Sphinx HTML build — passed
- `bash -n skills/pyadi-dt-cli/scripts/install.sh` — passed
- real installer smoke test for both `.agents/skills` and `.claude/skills`, including a second idempotent run — passed
- `git diff --check` — passed

## Note

A fresh `nox -s ty` environment could not fetch the private `pyadi-build` Git dependency over unauthenticated HTTPS. The exact underlying strict `ty` target was run directly and passed; hosted CI will exercise the repository's configured authentication path.
