### PR TITLE
ci: deduplicate feature branch checks

### DIFF
--- a/.github/workflows/binding-audit.yml
+++ b/.github/workflows/binding-audit.yml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '**'
+      - main
+      - '20[1-9][0-9]_R[1-9]'
+      - 'staging/*'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '**'
+      - main
+      - '20[1-9][0-9]_R[1-9]'
+      - 'staging/*'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '**'
+      - main
+      - '20[1-9][0-9]_R[1-9]'
+      - 'staging/*'
   pull_request:
     branches:
       - '**'

--- a/test/test_ci_workflow_triggers.py
+++ b/test/test_ci_workflow_triggers.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+DEDUPLICATED_WORKFLOWS = (
+    "binding-audit.yml",
+    "test.yml",
+    "type-check.yml",
+)
+
+
+def _push_branches(workflow: str) -> list[str]:
+    lines = (WORKFLOWS / workflow).read_text().splitlines()
+    push_index = lines.index("  push:")
+    pull_request_index = lines.index("  pull_request:", push_index)
+    push_block = lines[push_index:pull_request_index]
+    return [line.strip()[2:].strip("'\"") for line in push_block if line.strip().startswith("- ")]
+
+
+def test_feature_branches_do_not_duplicate_push_and_pull_request_runs():
+    for workflow in DEDUPLICATED_WORKFLOWS:
+        branches = _push_branches(workflow)
+        assert "main" in branches
+        assert "**" not in branches
+
+
+def test_release_maintenance_branches_keep_push_validation():
+    for workflow in DEDUPLICATED_WORKFLOWS:
+        branches = _push_branches(workflow)
+        assert "20[1-9][0-9]_R[1-9]" in branches
+        assert "staging/*" in branches


### PR DESCRIPTION
## Summary

Remove duplicate feature-branch CI runs while preserving validation for pull requests, `main`, release maintenance branches, and staging branches.

- restrict direct `push` validation in package tests, strict type checking, and ADI binding audit to `main`, `20xx_Rx`, and `staging/*`
- retain `pull_request` validation for all target branches
- add a regression test for the trigger policy

This addresses the duplicate `push` + `pull_request` workflow pairs visible on recent PR heads, which doubled test/type/audit jobs and left redundant stale failures after a corrected commit passed.

## Verification

- `pytest -q test/test_ci_workflow_triggers.py` — 2 passed
- full `pytest -q` — 749 passed, 18 skipped, 4 xfailed
- `ruff check test/test_ci_workflow_triggers.py` — passed
- strict `ty` target — passed
- `actionlint .github/workflows/*.{yml,yaml}` — passed
- `git diff --check` — passed
