### PR TITLE
docs: reference adidtc agent skill in Sphinx

### DIFF
--- a/doc/source/ai_skill.rst
+++ b/doc/source/ai_skill.rst
@@ -1,0 +1,81 @@
+AI Agent CLI Skill
+==================
+
+pyadi-dt includes a reusable `Agent Skill <https://agentskills.io/>`_ that
+teaches compatible AI coding agents how to use the ``adidtc`` command-line
+interface. The skill routes agents across all public commands, provides runnable
+recipes, and adds safety rules for operations that can modify remote hardware or
+SD-card contents.
+
+Use the skill when asking an agent to:
+
+- generate DTS output from a Vivado XSA or board configuration;
+- inspect local DTBs or live device trees;
+- analyze DTS include dependencies;
+- discover supported Kuiper boards and XSA profiles; or
+- stage boot files on a remote board.
+
+The source is maintained in
+`skills/pyadi-dt-cli/SKILL.md <https://github.com/analogdevicesinc/pyadi-dt/blob/main/skills/pyadi-dt-cli/SKILL.md>`_.
+Detailed command recipes live in
+`skills/pyadi-dt-cli/reference/commands.md <https://github.com/analogdevicesinc/pyadi-dt/blob/main/skills/pyadi-dt-cli/reference/commands.md>`_.
+
+Install the skill
+-----------------
+
+Clone pyadi-dt, then run the bundled installer from the repository root:
+
+.. code-block:: bash
+
+   git clone https://github.com/analogdevicesinc/pyadi-dt.git
+   cd pyadi-dt
+   ./skills/pyadi-dt-cli/scripts/install.sh
+
+The default ``all`` target creates symlinks in both of these Agent
+Skills-compatible locations:
+
+- ``~/.agents/skills/pyadi-dt-cli``
+- ``~/.claude/skills/pyadi-dt-cli``
+
+Install only one integration by passing its target explicitly:
+
+.. code-block:: bash
+
+   ./skills/pyadi-dt-cli/scripts/install.sh agents
+   ./skills/pyadi-dt-cli/scripts/install.sh claude
+
+The installer is idempotent when the destination already points to this
+checkout. Start a new agent session after installation so the agent discovers
+the skill.
+
+How agents use it
+-----------------
+
+A compatible agent loads the skill when a request involves pyadi-dt, ``adidtc``,
+XSA-to-DTS generation, device-tree inspection, Kuiper board discovery, or
+SD-card deployment. It first inspects the installed CLI with
+``adidtc --help`` and ``adidtc <command> --help`` rather than assuming flags.
+
+The skill defaults to read-only contexts and requires a preview before changing
+hardware. In particular, agents must run ``sd-move`` and ``sd-remote-copy`` with
+``--dry-run --show`` and obtain explicit approval before the real operation.
+Credentials must not be placed in commands, committed files, or reports.
+
+For the human-oriented command reference and examples, see :doc:`cli`. For an
+API integration that exposes pyadi-dt tools directly to AI assistants, see
+:doc:`mcp_server`.
+
+Example prompts
+---------------
+
+After restarting the agent, prompts can focus on the desired outcome rather
+than reproducing CLI syntax:
+
+- ``Generate and lint a DTS from design.xsa using the ad9081_zcu102 profile.``
+- ``List the built-in XSA profiles and explain which one matches my carrier.``
+- ``Inspect this DTB for nodes compatible with adi,ad9081 without modifying it.``
+- ``Show a dry-run plan to copy BOOT.BIN and system.dtb to 192.168.2.1.``
+
+The agent should report the exact commands executed, exit status, artifact
+paths, validation performed, and whether hardware was only staged or actually
+boot-tested.

--- a/doc/source/cli.rst
+++ b/doc/source/cli.rst
@@ -5,6 +5,9 @@ Command Line Interface
 trees on live hardware, generating device tree source files from Vivado XSA
 designs or board class configurations, and managing boot files on remote boards.
 
+AI coding agents can use the bundled :doc:`ai_skill`, which adds task routing,
+runnable recipes, and dry-run safeguards around this command surface.
+
 .. code-block:: bash
 
    pip install adidt          # core commands

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,6 +83,8 @@ Where to start
   walkthrough of Vivado XSA-based generation.
 - **PetaLinux?** See :doc:`petalinux` for generating ``system-user.dtsi``
   files from XSA archives.
+- **Using pyadi-dt through an AI coding agent?** See :doc:`ai_skill` for
+  installing the bundled ``adidtc`` Agent Skill and its hardware-safety rules.
 - **Adding a new device class?** See :doc:`developer/authoring_devices`
   for the end-to-end walkthrough — class design, rendering pipeline,
   and cookbook recipes for clocks, converters, and eval / FPGA boards.
@@ -123,5 +125,6 @@ Table of contents
    :caption: Reference
 
    cli
+   ai_skill
    mcp_server
    api/index

--- a/test/test_ai_skill.py
+++ b/test/test_ai_skill.py
@@ -12,6 +12,9 @@ SKILL_ROOT = ROOT / "skills" / "pyadi-dt-cli"
 SKILL = SKILL_ROOT / "SKILL.md"
 COMMANDS = SKILL_ROOT / "reference" / "commands.md"
 INSTALLER = SKILL_ROOT / "scripts" / "install.sh"
+SPHINX_INDEX = ROOT / "doc" / "source" / "index.rst"
+SPHINX_CLI = ROOT / "doc" / "source" / "cli.rst"
+SPHINX_SKILL = ROOT / "doc" / "source" / "ai_skill.rst"
 
 PUBLIC_COMMANDS = {
     "deps",
@@ -87,3 +90,17 @@ def test_installer_supports_agents_claude_and_is_idempotent(tmp_path):
         installed = tmp_path / parent / "skills" / "pyadi-dt-cli"
         assert installed.is_symlink()
         assert installed.resolve() == SKILL_ROOT.resolve()
+
+
+def test_sphinx_documents_and_links_the_skill():
+    index = SPHINX_INDEX.read_text()
+    cli_docs = SPHINX_CLI.read_text()
+    skill_docs = SPHINX_SKILL.read_text()
+
+    assert "   ai_skill" in index
+    assert ":doc:`ai_skill`" in index
+    assert ":doc:`ai_skill`" in cli_docs
+    assert "skills/pyadi-dt-cli/SKILL.md" in skill_docs
+    assert "./skills/pyadi-dt-cli/scripts/install.sh" in skill_docs
+    assert "--dry-run --show" in skill_docs
+    assert "explicit approval" in skill_docs


### PR DESCRIPTION
## Summary

Add the bundled `adidtc` Agent Skill to the published Sphinx documentation.

- add a dedicated AI Agent CLI Skill reference page
- document installation for `.agents/skills` and `.claude/skills`
- explain task routing, read-only defaults, dry-run/approval safeguards, and example prompts
- link the page from the main reference toctree, getting-started routes, and CLI page
- add a regression test for Sphinx discoverability and safety guidance

## Verification

- `pytest -q test/test_ai_skill.py` — 6 passed
- full `pytest -q` — 753 passed, 15 skipped, 4 xfailed
- `ruff check test/test_ai_skill.py` — passed
- strict Sphinx HTML build — passed
- strict Sphinx linkcheck — passed
- rendered `ai_skill.html` inspected for navigation, installer commands, dry-run, and explicit-approval guidance
- `git diff --check` — passed
