### PR TITLE
ci: fail broken hardware prerequisites

### DIFF
--- a/.github/scripts/install-adidt-venv.sh
+++ b/.github/scripts/install-adidt-venv.sh
@@ -19,3 +19,29 @@ if [[ ! -x "$VENV/bin/python" ]]; then
 fi
 
 uv pip install --quiet --python "$VENV/bin/python" -e ".[dev]"
+
+# ``sdtgen`` ships with Vivado rather than the Python ``lopper`` package.
+# Publish the host installation inside the persistent venv so the dynamic test
+# command has one stable PATH contract on every hardware runner.
+rm -f "$VENV/bin/sdtgen"
+for candidate in \
+    /tools/Xilinx/2025.1/Vivado/bin/sdtgen \
+    /opt/Xilinx/2025.1/Vivado/bin/sdtgen; do
+    if [[ -x "$candidate" ]]; then
+        # Vivado's launcher resolves setupEnv.sh relative to $0, so a symlink
+        # from the venv is invalid. Use a tiny wrapper that runs from bin/.
+        printf '#!/usr/bin/env bash\nset -e\ncd %q\nexec ./sdtgen "$@"\n' \
+            "$(dirname "$candidate")" > "$VENV/bin/sdtgen"
+        chmod +x "$VENV/bin/sdtgen"
+        break
+    fi
+done
+
+# Fail setup before place acquisition if the persistent runner is incomplete;
+# otherwise pytest can turn infrastructure defects into skip-only green jobs.
+if [[ ! -x "$VENV/bin/sdtgen" ]]; then
+    echo "sdtgen not found in the venv or a supported Vivado 2025.1 path" >&2
+    exit 1
+fi
+"$VENV/bin/sdtgen" -help >/dev/null
+"$VENV/bin/python" -c "import adi_lg_plugins, lopper"

--- a/.github/scripts/prepare-hardware-env.sh
+++ b/.github/scripts/prepare-hardware-env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Prepare a deterministic PATH for pyadi-dt hardware tests.
+#
+# GitHub self-hosted runners inherit the PATH captured when their listener
+# starts. User-level tools can therefore shadow toolchain binaries (notably an
+# agent CLI named `as`, which breaks Linux kernel builds expecting GNU as).
+
+set -euo pipefail
+
+: "${VENV_DIR:?VENV_DIR must point at the persistent hardware venv}"
+
+filtered_path=""
+IFS=: read -r -a path_entries <<< "${PATH:-}"
+for entry in "${path_entries[@]}"; do
+    [[ -n "$entry" ]] || continue
+    [[ "$entry" == "$HOME/.local/bin" ]] && continue
+    case ":$filtered_path:" in
+        *":$entry:"*) ;;
+        *) filtered_path="${filtered_path:+$filtered_path:}$entry" ;;
+    esac
+done
+
+export PATH="$VENV_DIR/bin:/usr/bin${filtered_path:+:$filtered_path}"
+
+for tool in as labgrid-client pytest sdtgen; do
+    resolved=$(command -v "$tool") || {
+        echo "required hardware tool not found on sanitized PATH: $tool" >&2
+        return 1 2>/dev/null || exit 1
+    }
+    printf '%s=%s\n' "$tool" "$resolved" >&2
+done
+
+if [[ "$(command -v as)" != "/usr/bin/as" ]]; then
+    echo "GNU assembler shadowed after PATH sanitization: $(command -v as)" >&2
+    return 1 2>/dev/null || exit 1
+fi

--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -43,7 +43,7 @@ jobs:
       # The labgrid pytest plugin reads LG_ENV / LG_COORDINATOR from the env.
       pytest_cmd_template: >-
         set -euo pipefail;
-        export PATH="$HOME/.local/bin:$PATH";
+        source .github/scripts/prepare-hardware-env.sh;
         TESTS=$(ls test/hw/*"$BOARD"*"$CARRIER"*_hw.py 2>/dev/null | grep -v petalinux | tr '\n' ' ');
         if [ -z "$TESTS" ]; then echo "::warning::no pyadi-dt HW tests for board=$BOARD carrier=$CARRIER"; exit 0; fi;
         echo "Selected: $TESTS" >&2;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "requests",
 ]
 dev = [
-    "adidt[test]",
+    "adidt[test,xsa]",
     "labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git",
     "pyadi-build @ git+https://github.com/tfcollins/pyadi-build.git",
     "usbsdmux",

--- a/test/hw/hw_helpers.py
+++ b/test/hw/hw_helpers.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 
@@ -294,23 +295,30 @@ def unload_overlay(shell, name: str) -> str:
     )
 
 
+def hardware_prereq_unavailable(message: str) -> NoReturn:
+    """Skip locally, but fail coordinator CI when a prerequisite is unavailable."""
+    if os.environ.get("LG_COORDINATOR"):
+        pytest.fail(message)
+    pytest.skip(message)
+
+
 def require_hw_prereqs() -> None:
-    """Skip the current test if required system tools are missing.
+    """Stop the current test if required system tools are missing.
 
     Checks for ``sdtgen``, ``dtc``, and ``usbsdmux`` on ``PATH``.  Also
     probes the local ``venv/bin/usbsdmux`` path as a fallback before giving
     up on ``usbsdmux``.
     """
     if shutil.which("sdtgen") is None:
-        pytest.skip("sdtgen not found on PATH (Vivado tools required)")
+        hardware_prereq_unavailable("sdtgen not found on PATH (lopper required)")
     if shutil.which("dtc") is None:
-        pytest.skip("dtc not found on PATH")
+        hardware_prereq_unavailable("dtc not found on PATH")
     if shutil.which("usbsdmux") is None:
         local_usbsdmux = Path.cwd() / "venv" / "bin" / "usbsdmux"
         if local_usbsdmux.exists():
             os.environ["PATH"] = f"{local_usbsdmux.parent}:{os.environ.get('PATH', '')}"
     if shutil.which("usbsdmux") is None:
-        pytest.skip("usbsdmux not found on PATH")
+        hardware_prereq_unavailable("usbsdmux not found on PATH")
 
 
 # Known-benign ``dmesg`` lines unrelated to our ADC/DAC/JESD flow.  These

--- a/test/hw/xsa/_overlay_spec.py
+++ b/test/hw/xsa/_overlay_spec.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Literal, Optional, Sequence
 
 import pytest
 
-from test.hw.hw_helpers import acquire_xsa
+from test.hw.hw_helpers import acquire_xsa, hardware_prereq_unavailable
 
 
 BootMode = Literal["tftp", "sd", "fabric_jtag"]
@@ -169,7 +169,9 @@ def acquire_or_local_xsa(
                 project,
                 tmp_path,
             )
-        except Exception as exc:  # noqa: BLE001 — any IO/download failure → skip
-            pytest.skip(f"could not acquire XSA ({project}@{release}): {exc}")
+        except Exception as exc:  # noqa: BLE001 — preserve the concrete cause
+            hardware_prereq_unavailable(
+                f"could not acquire XSA ({project}@{release}): {exc}"
+            )
 
     return _resolver

--- a/test/test_hardware_ci_contract.py
+++ b/test/test_hardware_ci_contract.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from test.hw.hw_helpers import hardware_prereq_unavailable
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_hardware_venv_installs_and_exposes_sdtgen():
+    """Hardware CI must install the XSA extra and prepend its venv to PATH."""
+    pyproject = (ROOT / "pyproject.toml").read_text()
+    installer = (ROOT / ".github/scripts/install-adidt-venv.sh").read_text()
+    environment = (ROOT / ".github/scripts/prepare-hardware-env.sh").read_text()
+    workflow = (ROOT / ".github/workflows/hardware-test.yml").read_text()
+
+    assert '"adidt[test,xsa]"' in pyproject
+    assert '"$VENV/bin/sdtgen" -help' in installer
+    assert "/tools/Xilinx/2025.1/Vivado/bin/sdtgen" in installer
+    assert "source .github/scripts/prepare-hardware-env.sh" in workflow
+    assert '[[ "$entry" == "$HOME/.local/bin" ]] && continue' in environment
+    assert 'export PATH="$VENV_DIR/bin:/usr/bin' in environment
+    assert '"$(command -v as)" != "/usr/bin/as"' in environment
+
+
+def test_missing_hardware_prerequisite_fails_in_coordinator_mode(monkeypatch):
+    """Coordinator runs must not report skip-only green on broken tooling."""
+    monkeypatch.setenv("LG_COORDINATOR", "coordinator.example:20408")
+
+    with pytest.raises(pytest.fail.Exception, match="missing tool"):
+        hardware_prereq_unavailable("missing tool")
+
+
+def test_missing_hardware_prerequisite_skips_outside_coordinator(monkeypatch):
+    """Developer machines without lab access retain the convenient skip behavior."""
+    monkeypatch.delenv("LG_COORDINATOR", raising=False)
+
+    with pytest.raises(pytest.skip.Exception, match="missing tool"):
+        hardware_prereq_unavailable("missing tool")

--- a/test/xsa/kuiper_release.py
+++ b/test/xsa/kuiper_release.py
@@ -4,31 +4,25 @@ import io
 import tarfile
 from pathlib import Path
 
+import requests
+
 
 class KuiperXsaError(RuntimeError):
     """Raised when Kuiper release download or XSA extraction fails."""
 
 
-def _require_kuiper_plugin():
-    try:
-        from adi_lg_plugins.drivers.kuiperdldriver import Downloader, KuiperDLDriver
-    except ImportError as ex:
-        raise KuiperXsaError(
-            "adi-labgrid-plugins is required for Kuiper XSA download tests"
-        ) from ex
-    return Downloader, KuiperDLDriver
-
-
 def download_boot_partition_release(release: str, cache_dir: Path) -> Path:
     """Download (or reuse) the Kuiper boot-partition tarball for a release."""
-    Downloader, KuiperDLDriver = _require_kuiper_plugin()
     cache_dir.mkdir(parents=True, exist_ok=True)
     tarball_path = cache_dir / f"{release}_latest_boot_partition.tar.gz"
     if tarball_path.exists():
         return tarball_path
 
-    url = KuiperDLDriver.sw_downloads_template.format(release=release)
-    response = Downloader().retry_session().get(url, stream=True, timeout=120)
+    url = (
+        "https://swdownloads.analog.com/cse/boot_partition_files/"
+        f"{release}/latest_boot_partition.tar.gz"
+    )
+    response = requests.get(url, stream=True, timeout=120)
     if not response.ok:
         raise KuiperXsaError(
             f"failed to download Kuiper boot partition: release={release} "

--- a/test/xsa/test_kuiper_release_xsa.py
+++ b/test/xsa/test_kuiper_release_xsa.py
@@ -11,6 +11,7 @@ import pytest
 from adidt.xsa.pipeline import XsaPipeline
 from adidt.xsa.parse.topology import XsaParser
 from test.xsa.kuiper_release import (
+    download_boot_partition_release,
     extract_project_xsa,
     download_project_xsa,
     KuiperXsaError,
@@ -18,6 +19,38 @@ from test.xsa.kuiper_release import (
 
 
 FIXTURE_CFG = Path(__file__).parent / "fixtures" / "ad9081_config.json"
+
+
+def test_boot_partition_download_uses_current_adi_url(tmp_path, monkeypatch):
+    """The helper must not depend on removed labgrid driver class attributes."""
+    requested = {}
+
+    class Response:
+        ok = True
+        status_code = 200
+
+        @staticmethod
+        def iter_content(chunk_size):
+            assert chunk_size == 1024 * 1024
+            yield b"archive"
+
+    def fake_get(url, *, stream, timeout):
+        requested.update(url=url, stream=stream, timeout=timeout)
+        return Response()
+
+    monkeypatch.setattr("test.xsa.kuiper_release.requests.get", fake_get)
+
+    result = download_boot_partition_release("2023_r2", tmp_path)
+
+    assert requested == {
+        "url": (
+            "https://swdownloads.analog.com/cse/boot_partition_files/"
+            "2023_r2/latest_boot_partition.tar.gz"
+        ),
+        "stream": True,
+        "timeout": 120,
+    }
+    assert result.read_bytes() == b"archive"
 
 
 def _fake_sdtgen_run(xsa_path, output_dir, timeout=120):


### PR DESCRIPTION
## Summary

Make hardware CI fail on broken labgrid prerequisites instead of reporting skip-only green jobs.

- install the XSA/lopper extra in every persistent hardware venv
- prepend the persistent venv to the dynamic test `PATH` and verify `sdtgen` during setup
- replace the removed `KuiperDLDriver.sw_downloads_template` dependency with ADI's current boot-partition endpoint
- fail missing tools and XSA acquisition in coordinator runs while retaining local developer skips
- add regression tests for the persistent-vm and fail-vs-skip contracts

## Failure evidence

Manual hardware run `30131076890` was superficially green, but downloaded JUnit showed:

- AD9081/ZCU102: 1 passed, 13 skipped because `sdtgen` was absent
- ADRV9009/ZC706: 1 passed, 11 skipped because `KuiperDLDriver.sw_downloads_template` no longer exists

The ADI endpoint used by this patch returned HTTP 200 with the expected release archive before implementation.

## Local verification

- focused contracts: 7 passed, 1 opt-in network test skipped
- full pytest: 754 passed, 18 skipped, 4 xfailed
- Ruff: passed
- strict `ty`: passed
- Actionlint: passed
- shell syntax and diff checks: passed

Hardware validation is requested with the `hw-test` label. Completion requires real non-skipped tests on all four advertised board legs and no leaked labgrid acquisitions/reservations.
