### PR TITLE
ci: add dedicated example tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,15 +63,61 @@ jobs:
         reporter: java-junit
         fail-on-error: false
 
+  examples-test:
+    name: Test examples
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install example dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install ".[test,xsa]"
+
+    - name: Run executable example tests
+      run: |
+        pytest -v \
+          test/devices/test_examples_smoke.py \
+          test/devices/test_examples_ad9081_parity.py \
+          test/test_examples_xsa_smoke.py \
+          test/xsa/test_example_fmcdaq2_zc706.py \
+          test/test_jif_contract_examples.py \
+          test/test_examples_ci_contract.py \
+          --junitxml=junit-examples.xml
+
+    - name: Upload example JUnit XML
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: junit-examples
+        path: junit-examples.xml
+        retention-days: 14
+        if-no-files-found: error
+
+    - name: Publish example results to PR
+      if: always()
+      uses: dorny/test-reporter@v3
+      with:
+        name: Example Tests
+        path: junit-examples.xml
+        reporter: java-junit
+        fail-on-error: false
+
   publish-pr-test-summary:
     name: PR Test Summary
-    needs: python-test
+    needs: [python-test, examples-test]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
         with:
-          pattern: junit-py*
+          pattern: junit-*
           path: junit
           merge-multiple: true
 
@@ -83,7 +129,7 @@ jobs:
           report_individual_runs: true
 
   build-package:
-    needs: [python-test]
+    needs: [python-test, examples-test]
     runs-on: ubuntu-latest
     name: Build Package for PyPI
     steps:

--- a/test/test_examples_ci_contract.py
+++ b/test/test_examples_ci_contract.py
@@ -1,0 +1,49 @@
+"""Contracts for the dedicated examples CI gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
+EXAMPLE_TEST_GROUPS = (
+    "test/devices/test_examples_smoke.py",
+    "test/devices/test_examples_ad9081_parity.py",
+    "test/test_examples_xsa_smoke.py",
+    "test/xsa/test_example_fmcdaq2_zc706.py",
+    "test/test_jif_contract_examples.py",
+    "test/test_examples_ci_contract.py",
+)
+
+
+def test_examples_have_a_dedicated_blocking_ci_job() -> None:
+    """Keep all example checks visible and blocking in package CI."""
+    workflow = WORKFLOW.read_text()
+
+    assert "examples-test:" in workflow
+    assert 'pip install ".[test,xsa]"' in workflow
+    for test_group in EXAMPLE_TEST_GROUPS:
+        assert test_group in workflow
+    assert "needs: [python-test, examples-test]" in workflow
+
+
+def test_every_python_example_is_discovered_by_an_example_test() -> None:
+    """Require executable or import-smoke discovery for every Python example."""
+    examples = REPO_ROOT / "examples"
+    top_level = {path.name for path in examples.glob("*.py")}
+    xsa = {path.name for path in (examples / "xsa").glob("*.py")}
+    jif_contract = {path.name for path in (examples / "jif_contract").glob("*.py")}
+
+    assert top_level
+    assert xsa
+    assert jif_contract
+
+    smoke_source = (REPO_ROOT / "test/devices/test_examples_smoke.py").read_text()
+    xsa_source = (REPO_ROOT / "test/test_examples_xsa_smoke.py").read_text()
+    contract_source = (REPO_ROOT / "test/test_jif_contract_examples.py").read_text()
+
+    assert 'EXAMPLES_DIR.glob("*.py")' in smoke_source
+    assert 'XSA_DIR.glob("*.py")' in xsa_source
+    for script in jif_contract:
+        assert script in contract_source


### PR DESCRIPTION
## Summary

- add a dedicated blocking CI job for repository examples
- install the XSA extra and run executable, parity, import-smoke, mocked-pipeline, and JIF contract checks
- publish an examples-specific JUnit artifact/check and include it in the PR summary
- add contracts ensuring every Python example is discovered and the CI gate remains present

## Validation

- dedicated examples command: 30 passed on Python 3.12
- full suite: 756 passed, 18 skipped, 4 xfailed
- Ruff: passed
- Actionlint: passed
- git diff --check: passed