### PR TITLE
examples: demonstrate ADRV9009 profile files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           test/devices/test_examples_smoke.py \
           test/devices/test_examples_ad9081_parity.py \
           test/test_examples_xsa_smoke.py \
+          test/xsa/test_example_adrv9009_profile_file.py \
           test/xsa/test_example_fmcdaq2_zc706.py \
           test/test_jif_contract_examples.py \
           test/test_examples_ci_contract.py \

--- a/doc/source/examples/xsa_tutorial.md
+++ b/doc/source/examples/xsa_tutorial.md
@@ -88,6 +88,32 @@ Example variations by board:
 These scripts print a final artifact summary and are a good starting point for
 platform-specific defaults.
 
+### ADRV9009 custom profile files
+
+The ADRV9009 profile-file example combines the checked-in
+`adrv9009_zc706` board defaults with a small user-owned JSON override file.
+Inspect the effective configuration without an XSA, network access, or Vivado:
+
+```bash
+python examples/xsa/adrv9009_profile_file.py \
+  --profile-file examples/xsa/profiles/adrv9009_zc706_custom.json \
+  --show-config
+```
+
+Then use the same validated profile file for a complete XSA pipeline run:
+
+```bash
+python examples/xsa/adrv9009_profile_file.py \
+  --profile-file my-adrv9009.json \
+  --xsa /path/to/system_top.xsa \
+  --output-dir build/adrv9009
+```
+
+The custom file only needs to contain values that differ from the built-in
+profile. Explicit custom values win; SPI assignments, GPIOs, link IDs, and
+other omitted wiring values continue to come from `adrv9009_zc706`. Profile
+keys and value types are validated before SDTGen runs.
+
 ## Tutorial 3: Use the Python API directly
 
 For custom integrations (CI, scripts, internal tools), call `XsaPipeline.run()`:

--- a/examples/xsa/adrv9009_profile_file.py
+++ b/examples/xsa/adrv9009_profile_file.py
@@ -1,0 +1,110 @@
+"""Generate an ADRV9009 DTS using built-in and custom JSON profile files.
+
+The built-in ``adrv9009_zc706`` profile supplies normal board wiring.  A
+user-owned JSON profile supplies only site-specific overrides; explicit values
+from that file win while missing values continue to come from the built-in
+profile.
+
+Inspect the effective configuration without an XSA or Vivado installation::
+
+    python examples/xsa/adrv9009_profile_file.py \
+        --profile-file examples/xsa/profiles/adrv9009_zc706_custom.json \
+        --show-config
+
+Run the complete XSA pipeline with the same profile file::
+
+    python examples/xsa/adrv9009_profile_file.py \
+        --profile-file my-adrv9009.json \
+        --xsa /path/to/system_top.xsa \
+        --output-dir build/adrv9009
+
+A custom profile has the same validated shape as a built-in profile::
+
+    {
+      "name": "my_adrv9009",
+      "defaults": {
+        "adrv9009_board": {
+          "trx_spi_max_frequency": 10000000
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from adidt.xsa.config.profiles import ProfileManager, merge_profile_defaults
+from adidt.xsa.pipeline import XsaPipeline
+
+HERE = Path(__file__).parent
+DEFAULT_PROFILE_FILE = HERE / "profiles" / "adrv9009_zc706_custom.json"
+DEFAULT_BASE_PROFILE = "adrv9009_zc706"
+DEFAULT_OUT_DIR = HERE / "output_adrv9009_profile"
+
+
+def load_profile_file(path: Path) -> dict[str, Any]:
+    """Load and validate one JSON profile using the public profile API."""
+    path = path.expanduser().resolve()
+    return ProfileManager(profile_dir=path.parent).load(path.stem)
+
+
+def effective_config(
+    profile_file: Path, base_profile: str = DEFAULT_BASE_PROFILE
+) -> dict[str, Any]:
+    """Merge custom values over a built-in board profile."""
+    custom = load_profile_file(profile_file)
+    built_in = ProfileManager().load(base_profile)
+    custom_defaults = custom["defaults"]
+    return merge_profile_defaults(custom_defaults, built_in)
+
+
+def main() -> None:
+    """Parse command-line arguments and inspect or run the profiled pipeline."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile-file",
+        type=Path,
+        default=DEFAULT_PROFILE_FILE,
+        help="Custom JSON profile containing site-specific overrides",
+    )
+    parser.add_argument(
+        "--base-profile",
+        default=DEFAULT_BASE_PROFILE,
+        help="Built-in board profile used for unspecified values",
+    )
+    parser.add_argument("--xsa", type=Path, help="Path to the Vivado XSA")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument(
+        "--show-config",
+        action="store_true",
+        help="Print the validated merged config and exit without running SDTGen",
+    )
+    args = parser.parse_args()
+
+    cfg = effective_config(args.profile_file, args.base_profile)
+    if args.show_config:
+        print(json.dumps(cfg, indent=2, sort_keys=True))
+        return
+
+    if args.xsa is None:
+        raise SystemExit("Provide --xsa, or use --show-config to inspect the merge")
+
+    result = XsaPipeline().run(
+        xsa_path=args.xsa.expanduser().resolve(),
+        cfg=cfg,
+        output_dir=args.output_dir.expanduser().resolve(),
+        profile=args.base_profile,
+    )
+    print(f"Loaded custom profile: {args.profile_file}")
+    print(f"Built-in base profile: {args.base_profile}")
+    print("Generated artifacts:")
+    for name, path in result.items():
+        print(f"  {name}: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/xsa/profiles/adrv9009_zc706_custom.json
+++ b/examples/xsa/profiles/adrv9009_zc706_custom.json
@@ -1,0 +1,8 @@
+{
+  "name": "adrv9009_zc706_custom",
+  "defaults": {
+    "adrv9009_board": {
+      "trx_spi_max_frequency": 10000000
+    }
+  }
+}

--- a/test/test_examples_ci_contract.py
+++ b/test/test_examples_ci_contract.py
@@ -11,6 +11,7 @@ EXAMPLE_TEST_GROUPS = (
     "test/devices/test_examples_smoke.py",
     "test/devices/test_examples_ad9081_parity.py",
     "test/test_examples_xsa_smoke.py",
+    "test/xsa/test_example_adrv9009_profile_file.py",
     "test/xsa/test_example_fmcdaq2_zc706.py",
     "test/test_jif_contract_examples.py",
     "test/test_examples_ci_contract.py",

--- a/test/xsa/test_example_adrv9009_profile_file.py
+++ b/test/xsa/test_example_adrv9009_profile_file.py
@@ -1,0 +1,92 @@
+"""Tests for the ADRV9009 JSON profile-file example."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE = REPO_ROOT / "examples" / "xsa" / "adrv9009_profile_file.py"
+PROFILE = (
+    REPO_ROOT
+    / "examples"
+    / "xsa"
+    / "profiles"
+    / "adrv9009_zc706_custom.json"
+)
+TUTORIAL = REPO_ROOT / "doc" / "source" / "examples" / "xsa_tutorial.md"
+
+
+def _load_example_module():
+    spec = importlib.util.spec_from_file_location("adrv9009_profile_file", EXAMPLE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_show_config_executes_with_checked_in_profile() -> None:
+    """The documented no-hardware path must validate and merge both profiles."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(EXAMPLE),
+            "--profile-file",
+            str(PROFILE),
+            "--show-config",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    config = json.loads(result.stdout)
+
+    board = config["adrv9009_board"]
+    assert board["spi_bus"] == "spi0"  # inherited from the built-in profile
+    assert board["trx_spi_max_frequency"] == 10_000_000  # file override
+    assert board["trx_reset_gpio"] == 130  # inherited built-in wiring
+
+
+def test_pipeline_receives_profile_file_overrides(monkeypatch, tmp_path) -> None:
+    """Custom profile values must remain explicit when the pipeline adds defaults."""
+    module = _load_example_module()
+    fake_xsa = tmp_path / "system_top.xsa"
+    fake_xsa.write_text("xsa")
+    runner = MagicMock()
+    runner.run.return_value = {"merged": tmp_path / "adrv9009_zc706.dts"}
+    monkeypatch.setattr(module, "XsaPipeline", lambda: runner)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "adrv9009_profile_file.py",
+            "--profile-file",
+            str(PROFILE),
+            "--xsa",
+            str(fake_xsa),
+            "--output-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    module.main()
+
+    kwargs = runner.run.call_args.kwargs
+    assert kwargs["profile"] == "adrv9009_zc706"
+    assert kwargs["cfg"]["adrv9009_board"]["trx_spi_max_frequency"] == 10_000_000
+    assert kwargs["cfg"]["adrv9009_board"]["trx_reset_gpio"] == 130
+
+
+def test_profile_file_example_is_documented() -> None:
+    """Keep the runnable profile-file commands discoverable in Sphinx docs."""
+    tutorial = TUTORIAL.read_text()
+    assert "ADRV9009 custom profile files" in tutorial
+    assert "examples/xsa/adrv9009_profile_file.py" in tutorial
+    assert "examples/xsa/profiles/adrv9009_zc706_custom.json" in tutorial
+    assert "--show-config" in tutorial


### PR DESCRIPTION
## Summary
- add an executable ADRV9009 example that merges a validated custom JSON profile over the built-in ZC706 profile
- include a checked-in override profile and a safe `--show-config` path requiring no XSA, network, or Vivado
- document complete profile inspection and XSA-generation commands
- run the example behavior in the dedicated blocking examples CI job

## Verification
- 34 dedicated example tests passed on Python 3.12
- full pytest: 760 passed, 18 skipped, 4 xfailed
- strict Sphinx HTML build passed
- Ruff, ty, Actionlint, and `git diff --check` passed