### PR TITLE
examples: pull canonical ADRV9009 profiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,13 @@ jobs:
           test/test_examples_ci_contract.py \
           --junitxml=junit-examples.xml
 
+    - name: Pull canonical ADRV9009 Talise profile
+      run: |
+        python examples/xsa/adrv9009_profile_file.py \
+          --talise-profile tx100-rx100-orx100 \
+          --download-talise-profile \
+          --output-dir "$RUNNER_TEMP/adrv9009-example"
+
     - name: Upload example JUnit XML
       if: always()
       uses: actions/upload-artifact@v7

--- a/doc/source/examples/xsa_tutorial.md
+++ b/doc/source/examples/xsa_tutorial.md
@@ -88,31 +88,62 @@ Example variations by board:
 These scripts print a final artifact summary and are a good starting point for
 platform-specific defaults.
 
-### ADRV9009 custom profile files
+### ADRV9009 board and Talise profile files
 
-The ADRV9009 profile-file example combines the checked-in
-`adrv9009_zc706` board defaults with a small user-owned JSON override file.
-Inspect the effective configuration without an XSA, network access, or Vivado:
+ADRV9009 uses two distinct kinds of profile. The built-in `adrv9009_zc706`
+JSON **board profile** supplies device-tree wiring. A Talise XML **filter
+profile** configures the running transceiver through the driver's
+`profile_config` attribute.
+
+The example retrieves all four canonical ADRV9009 filter profiles from
+[`analogdevicesinc/iio-oscilloscope`](https://github.com/analogdevicesinc/iio-oscilloscope/tree/main/filters/adrv9009).
+Downloads use a reviewed commit and SHA-256 manifest rather than mutable
+`main`, so changed or truncated hardware profiles fail closed.
+
+List the available aliases:
+
+```bash
+python examples/xsa/adrv9009_profile_file.py --list-talise-profiles
+```
+
+Download and verify one profile without an XSA, Vivado, or hardware access:
 
 ```bash
 python examples/xsa/adrv9009_profile_file.py \
-  --profile-file examples/xsa/profiles/adrv9009_zc706_custom.json \
+  --talise-profile tx200-rx200-orx200 \
+  --download-talise-profile \
+  --output-dir build/adrv9009
+```
+
+The script prints the downloaded path and explicit target-side steps for
+copying it and writing it to `profile_config`; it does not modify hardware
+automatically.
+
+The checked-in JSON override is still available to demonstrate board-profile
+merging. Inspect the effective board configuration without running SDTGen:
+
+```bash
+python examples/xsa/adrv9009_profile_file.py \
+  --board-profile-file examples/xsa/profiles/adrv9009_zc706_custom.json \
   --show-config
 ```
 
-Then use the same validated profile file for a complete XSA pipeline run:
+Run the complete XSA pipeline and retrieve the selected runtime profile in one
+command:
 
 ```bash
 python examples/xsa/adrv9009_profile_file.py \
-  --profile-file my-adrv9009.json \
+  --board-profile-file my-adrv9009-board.json \
+  --talise-profile tx200-rx200-orx200 \
   --xsa /path/to/system_top.xsa \
   --output-dir build/adrv9009
 ```
 
-The custom file only needs to contain values that differ from the built-in
-profile. Explicit custom values win; SPI assignments, GPIOs, link IDs, and
-other omitted wiring values continue to come from `adrv9009_zc706`. Profile
-keys and value types are validated before SDTGen runs.
+The custom JSON file only needs values that differ from the built-in board
+profile. Explicit custom values win; omitted SPI assignments, GPIOs, and link
+IDs continue to come from `adrv9009_zc706`. JSON keys and types are validated
+before SDTGen runs. The selected Talise file remains separate and is applied
+after the generated device tree has booted.
 
 ## Tutorial 3: Use the Python API directly
 

--- a/examples/xsa/adrv9009_profile_file.py
+++ b/examples/xsa/adrv9009_profile_file.py
@@ -1,109 +1,237 @@
-"""Generate an ADRV9009 DTS using built-in and custom JSON profile files.
+"""Generate an ADRV9009 DTS and retrieve a canonical Talise profile.
 
-The built-in ``adrv9009_zc706`` profile supplies normal board wiring.  A
-user-owned JSON profile supplies only site-specific overrides; explicit values
-from that file win while missing values continue to come from the built-in
-profile.
+Two different profile types are involved:
 
-Inspect the effective configuration without an XSA or Vivado installation::
+* The built-in ``adrv9009_zc706`` and optional JSON board profile configure
+  device-tree wiring and properties for :class:`XsaPipeline`.
+* A Talise filter profile from ``analogdevicesinc/iio-oscilloscope`` configures
+  the running ADRV9009 through the driver's ``profile_config`` attribute.
+
+Inspect the merged board configuration without XSA/Vivado::
+
+    python examples/xsa/adrv9009_profile_file.py --show-config
+
+Download and verify one canonical Talise profile without touching hardware::
 
     python examples/xsa/adrv9009_profile_file.py \
-        --profile-file examples/xsa/profiles/adrv9009_zc706_custom.json \
-        --show-config
+        --talise-profile tx200-rx200-orx200 \
+        --download-talise-profile
 
-Run the complete XSA pipeline with the same profile file::
+Run the XSA pipeline and retrieve that runtime profile::
 
     python examples/xsa/adrv9009_profile_file.py \
-        --profile-file my-adrv9009.json \
+        --talise-profile tx200-rx200-orx200 \
         --xsa /path/to/system_top.xsa \
         --output-dir build/adrv9009
 
-A custom profile has the same validated shape as a built-in profile::
-
-    {
-      "name": "my_adrv9009",
-      "defaults": {
-        "adrv9009_board": {
-          "trx_spi_max_frequency": 10000000
-        }
-      }
-    }
+The script prints explicit copy/application steps but never writes hardware.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import shlex
+import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from adidt.xsa.config.profiles import ProfileManager, merge_profile_defaults
 from adidt.xsa.pipeline import XsaPipeline
 
 HERE = Path(__file__).parent
-DEFAULT_PROFILE_FILE = HERE / "profiles" / "adrv9009_zc706_custom.json"
+DEFAULT_BOARD_PROFILE_FILE = HERE / "profiles" / "adrv9009_zc706_custom.json"
 DEFAULT_BASE_PROFILE = "adrv9009_zc706"
 DEFAULT_OUT_DIR = HERE / "output_adrv9009_profile"
+IIO_OSCILLOSCOPE_COMMIT = "c4baaaafe2f91c41c2d4c800f017655296f8a001"
+IIO_OSCILLOSCOPE_PROFILE_ROOT = (
+    "https://raw.githubusercontent.com/analogdevicesinc/iio-oscilloscope/"
+    f"{IIO_OSCILLOSCOPE_COMMIT}/filters/adrv9009"
+)
 
 
-def load_profile_file(path: Path) -> dict[str, Any]:
-    """Load and validate one JSON profile using the public profile API."""
+class TaliseProfile(NamedTuple):
+    """One reviewed profile in iio-oscilloscope's ADRV9009 filter set."""
+
+    filename: str
+    sha256: str
+
+
+TALISE_PROFILES = {
+    "tx100-rx100-orx100": TaliseProfile(
+        "Tx_BW100_IR122p88_Rx_BW100_OR122p88_ORx_BW100_OR122p88_DC245p76.txt",
+        "d1f6cf05c9f39a63d2cc3bbf18ebaf63e7d0ca4df0c8c9b29733c93386555edd",
+    ),
+    "tx200-rx100-orx200": TaliseProfile(
+        "Tx_BW200_IR245p76_Rx_BW100_OR122p88_ORx_BW200_OR245p76_DC245p76.txt",
+        "58fe2c44a69b4cced645b952d14b6d746de39e5a8e7f14e8b600d3121bf38b4b",
+    ),
+    "tx200-rx200-orx200": TaliseProfile(
+        "Tx_BW200_IR245p76_Rx_BW200_OR245p76_ORx_BW200_OR245p76_DC245p76.txt",
+        "85e93c550f7b5ca87ec15e5720551bd75eb47753f82f12bc8d740834cc8c4bb7",
+    ),
+    "tx400-rx100-orx400": TaliseProfile(
+        "Tx_BW400_IR491p52_Rx_BW100_OR122p88_ORx_BW400_OR491p52_DC245p76.txt",
+        "ad8111a7abbcde2cb4e6505c8cf6e56a81ebd1e3c454d33ccbded93f61c02087",
+    ),
+}
+DEFAULT_TALISE_PROFILE = "tx100-rx100-orx100"
+
+
+def load_board_profile_file(path: Path) -> dict[str, Any]:
+    """Load and validate one JSON board profile using the public profile API."""
     path = path.expanduser().resolve()
     return ProfileManager(profile_dir=path.parent).load(path.stem)
 
 
 def effective_config(
-    profile_file: Path, base_profile: str = DEFAULT_BASE_PROFILE
+    board_profile_file: Path, base_profile: str = DEFAULT_BASE_PROFILE
 ) -> dict[str, Any]:
-    """Merge custom values over a built-in board profile."""
-    custom = load_profile_file(profile_file)
+    """Merge custom board values over a built-in board profile."""
+    custom = load_board_profile_file(board_profile_file)
     built_in = ProfileManager().load(base_profile)
     custom_defaults = custom["defaults"]
     return merge_profile_defaults(custom_defaults, built_in)
 
 
-def main() -> None:
-    """Parse command-line arguments and inspect or run the profiled pipeline."""
+def _validate_talise_profile(body: bytes, profile: TaliseProfile) -> None:
+    digest = hashlib.sha256(body).hexdigest()
+    if digest != profile.sha256:
+        raise ValueError(
+            f"Talise profile SHA-256 mismatch for {profile.filename}: "
+            f"expected {profile.sha256}, got {digest}"
+        )
+    if not body.lstrip().startswith(b"<profile Talise "):
+        raise ValueError(f"Talise profile is not expected XML: {profile.filename}")
+
+
+def download_talise_profile(alias: str, destination: Path) -> Path:
+    """Download, verify, and cache one canonical Talise profile."""
+    try:
+        profile = TALISE_PROFILES[alias]
+    except KeyError as ex:
+        choices = ", ".join(sorted(TALISE_PROFILES))
+        raise ValueError(f"unknown Talise profile {alias!r}; choose from: {choices}") from ex
+
+    destination = destination.expanduser().resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+    output = destination / profile.filename
+    if output.exists():
+        cached = output.read_bytes()
+        try:
+            _validate_talise_profile(cached, profile)
+        except ValueError:
+            output.unlink()
+        else:
+            return output
+
+    url = f"{IIO_OSCILLOSCOPE_PROFILE_ROOT}/{profile.filename}"
+    with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+        body = response.read()
+    _validate_talise_profile(body, profile)
+    temporary = output.with_suffix(f"{output.suffix}.tmp")
+    temporary.write_bytes(body)
+    temporary.replace(output)
+    return output
+
+
+def print_talise_application(profile_path: Path) -> None:
+    """Print explicit target-side steps without modifying hardware."""
+    filename = shlex.quote(profile_path.name)
+    print(f"Canonical Talise profile: {profile_path}")
+    print("This example does not write hardware automatically.")
+    print("Copy the profile to the target, then apply it explicitly:")
+    print(f"  scp {shlex.quote(str(profile_path))} root@TARGET:/tmp/{filename}")
+    print(
+        "  PROFILE_CONFIG=$(find /sys/kernel/debug/iio /sys/bus/iio/devices "
+        "-name profile_config 2>/dev/null | head -1)"
+    )
+    print(f'  cat /tmp/{filename} > "$PROFILE_CONFIG"')
+
+
+def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "--board-profile-file",
         "--profile-file",
+        dest="board_profile_file",
         type=Path,
-        default=DEFAULT_PROFILE_FILE,
-        help="Custom JSON profile containing site-specific overrides",
+        default=DEFAULT_BOARD_PROFILE_FILE,
+        help="Validated JSON board-profile overrides (not the Talise filter profile)",
     )
     parser.add_argument(
         "--base-profile",
         default=DEFAULT_BASE_PROFILE,
         help="Built-in board profile used for unspecified values",
     )
+    parser.add_argument(
+        "--talise-profile",
+        choices=sorted(TALISE_PROFILES),
+        default=DEFAULT_TALISE_PROFILE,
+        help="Canonical iio-oscilloscope ADRV9009 filter profile alias",
+    )
+    parser.add_argument(
+        "--list-talise-profiles",
+        action="store_true",
+        help="List canonical profile aliases and filenames, then exit",
+    )
+    parser.add_argument(
+        "--download-talise-profile",
+        action="store_true",
+        help="Download and verify the selected Talise profile without running SDTGen",
+    )
     parser.add_argument("--xsa", type=Path, help="Path to the Vivado XSA")
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument(
         "--show-config",
         action="store_true",
-        help="Print the validated merged config and exit without running SDTGen",
+        help="Print the validated board config and exit without running SDTGen",
     )
-    args = parser.parse_args()
+    return parser
 
-    cfg = effective_config(args.profile_file, args.base_profile)
+
+def main() -> None:
+    """Inspect profiles, retrieve Talise XML, or run the profiled pipeline."""
+    args = _parser().parse_args()
+
+    if args.list_talise_profiles:
+        for alias, profile in TALISE_PROFILES.items():
+            print(f"{alias}: {profile.filename}")
+        return
+
+    cfg = effective_config(args.board_profile_file, args.base_profile)
     if args.show_config:
         print(json.dumps(cfg, indent=2, sort_keys=True))
         return
 
-    if args.xsa is None:
-        raise SystemExit("Provide --xsa, or use --show-config to inspect the merge")
+    output_dir = args.output_dir.expanduser().resolve()
+    if args.download_talise_profile:
+        profile_path = download_talise_profile(
+            args.talise_profile, output_dir / "profiles"
+        )
+        print_talise_application(profile_path)
+        return
 
+    if args.xsa is None:
+        raise SystemExit(
+            "Provide --xsa, --download-talise-profile, --list-talise-profiles, "
+            "or --show-config"
+        )
+
+    profile_path = download_talise_profile(args.talise_profile, output_dir / "profiles")
     result = XsaPipeline().run(
         xsa_path=args.xsa.expanduser().resolve(),
         cfg=cfg,
-        output_dir=args.output_dir.expanduser().resolve(),
+        output_dir=output_dir,
         profile=args.base_profile,
     )
-    print(f"Loaded custom profile: {args.profile_file}")
+    print(f"Loaded JSON board profile: {args.board_profile_file}")
     print(f"Built-in base profile: {args.base_profile}")
     print("Generated artifacts:")
     for name, path in result.items():
         print(f"  {name}: {path}")
+    print_talise_application(profile_path)
 
 
 if __name__ == "__main__":

--- a/test/test_examples_ci_contract.py
+++ b/test/test_examples_ci_contract.py
@@ -24,6 +24,8 @@ def test_examples_have_a_dedicated_blocking_ci_job() -> None:
 
     assert "examples-test:" in workflow
     assert 'pip install ".[test,xsa]"' in workflow
+    assert "Pull canonical ADRV9009 Talise profile" in workflow
+    assert "--download-talise-profile" in workflow
     for test_group in EXAMPLE_TEST_GROUPS:
         assert test_group in workflow
     assert "needs: [python-test, examples-test]" in workflow

--- a/test/xsa/test_example_adrv9009_profile_file.py
+++ b/test/xsa/test_example_adrv9009_profile_file.py
@@ -1,7 +1,8 @@
-"""Tests for the ADRV9009 JSON profile-file example."""
+"""Tests for the ADRV9009 board- and Talise-profile example."""
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import subprocess
@@ -9,10 +10,12 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE = REPO_ROOT / "examples" / "xsa" / "adrv9009_profile_file.py"
-PROFILE = (
+BOARD_PROFILE = (
     REPO_ROOT
     / "examples"
     / "xsa"
@@ -20,24 +23,43 @@ PROFILE = (
     / "adrv9009_zc706_custom.json"
 )
 TUTORIAL = REPO_ROOT / "doc" / "source" / "examples" / "xsa_tutorial.md"
+EXPECTED_TALISE_PROFILES = {
+    "tx100-rx100-orx100": (
+        "Tx_BW100_IR122p88_Rx_BW100_OR122p88_ORx_BW100_OR122p88_DC245p76.txt",
+        "d1f6cf05c9f39a63d2cc3bbf18ebaf63e7d0ca4df0c8c9b29733c93386555edd",
+    ),
+    "tx200-rx100-orx200": (
+        "Tx_BW200_IR245p76_Rx_BW100_OR122p88_ORx_BW200_OR245p76_DC245p76.txt",
+        "58fe2c44a69b4cced645b952d14b6d746de39e5a8e7f14e8b600d3121bf38b4b",
+    ),
+    "tx200-rx200-orx200": (
+        "Tx_BW200_IR245p76_Rx_BW200_OR245p76_ORx_BW200_OR245p76_DC245p76.txt",
+        "85e93c550f7b5ca87ec15e5720551bd75eb47753f82f12bc8d740834cc8c4bb7",
+    ),
+    "tx400-rx100-orx400": (
+        "Tx_BW400_IR491p52_Rx_BW100_OR122p88_ORx_BW400_OR491p52_DC245p76.txt",
+        "ad8111a7abbcde2cb4e6505c8cf6e56a81ebd1e3c454d33ccbded93f61c02087",
+    ),
+}
 
 
 def _load_example_module():
     spec = importlib.util.spec_from_file_location("adrv9009_profile_file", EXAMPLE)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 
 
-def test_show_config_executes_with_checked_in_profile() -> None:
-    """The documented no-hardware path must validate and merge both profiles."""
+def test_show_config_executes_with_checked_in_board_profile() -> None:
+    """The no-hardware path must validate and merge both board profiles."""
     result = subprocess.run(
         [
             sys.executable,
             str(EXAMPLE),
-            "--profile-file",
-            str(PROFILE),
+            "--board-profile-file",
+            str(BOARD_PROFILE),
             "--show-config",
         ],
         capture_output=True,
@@ -53,21 +75,75 @@ def test_show_config_executes_with_checked_in_profile() -> None:
     assert board["trx_reset_gpio"] == 130  # inherited built-in wiring
 
 
-def test_pipeline_receives_profile_file_overrides(monkeypatch, tmp_path) -> None:
-    """Custom profile values must remain explicit when the pipeline adds defaults."""
+def test_canonical_talise_manifest_is_pinned_and_complete() -> None:
+    """Expose all four upstream profiles with reviewed content hashes."""
+    module = _load_example_module()
+
+    assert module.IIO_OSCILLOSCOPE_COMMIT == "c4baaaafe2f91c41c2d4c800f017655296f8a001"
+    assert {
+        alias: (profile.filename, profile.sha256)
+        for alias, profile in module.TALISE_PROFILES.items()
+    } == EXPECTED_TALISE_PROFILES
+
+
+def test_download_talise_profile_verifies_source_and_caches(monkeypatch, tmp_path) -> None:
+    """A fetched profile must be XML from the pinned URL with the expected hash."""
+    module = _load_example_module()
+    body = b"<profile Talise version=1 name=test>\n</profile>\n"
+    sha256 = hashlib.sha256(body).hexdigest()
+    profile = module.TaliseProfile("fixture.txt", sha256)
+    monkeypatch.setitem(module.TALISE_PROFILES, "fixture", profile)
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = body
+    response.__exit__.return_value = False
+    urlopen = MagicMock(return_value=response)
+    monkeypatch.setattr(module.urllib.request, "urlopen", urlopen)
+
+    downloaded = module.download_talise_profile("fixture", tmp_path)
+    cached = module.download_talise_profile("fixture", tmp_path)
+
+    assert downloaded == cached == tmp_path / "fixture.txt"
+    assert downloaded.read_bytes() == body
+    assert module.IIO_OSCILLOSCOPE_COMMIT in urlopen.call_args.args[0]
+    urlopen.assert_called_once()
+
+
+def test_download_talise_profile_rejects_checksum_mismatch(monkeypatch, tmp_path) -> None:
+    """Never cache unreviewed or truncated hardware profile content."""
+    module = _load_example_module()
+    profile = module.TaliseProfile("fixture.txt", "0" * 64)
+    monkeypatch.setitem(module.TALISE_PROFILES, "fixture", profile)
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b"<profile bad>\n"
+    response.__exit__.return_value = False
+    monkeypatch.setattr(module.urllib.request, "urlopen", MagicMock(return_value=response))
+
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        module.download_talise_profile("fixture", tmp_path)
+
+    assert not (tmp_path / "fixture.txt").exists()
+
+
+def test_pipeline_downloads_selected_talise_profile(monkeypatch, tmp_path, capsys) -> None:
+    """A pipeline run must fetch and identify the runtime profile to apply."""
     module = _load_example_module()
     fake_xsa = tmp_path / "system_top.xsa"
     fake_xsa.write_text("xsa")
+    talise_path = tmp_path / "profiles" / "canonical.txt"
     runner = MagicMock()
     runner.run.return_value = {"merged": tmp_path / "adrv9009_zc706.dts"}
+    downloader = MagicMock(return_value=talise_path)
     monkeypatch.setattr(module, "XsaPipeline", lambda: runner)
+    monkeypatch.setattr(module, "download_talise_profile", downloader)
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "adrv9009_profile_file.py",
-            "--profile-file",
-            str(PROFILE),
+            "--board-profile-file",
+            str(BOARD_PROFILE),
+            "--talise-profile",
+            "tx200-rx200-orx200",
             "--xsa",
             str(fake_xsa),
             "--output-dir",
@@ -80,13 +156,18 @@ def test_pipeline_receives_profile_file_overrides(monkeypatch, tmp_path) -> None
     kwargs = runner.run.call_args.kwargs
     assert kwargs["profile"] == "adrv9009_zc706"
     assert kwargs["cfg"]["adrv9009_board"]["trx_spi_max_frequency"] == 10_000_000
-    assert kwargs["cfg"]["adrv9009_board"]["trx_reset_gpio"] == 130
+    downloader.assert_called_once_with("tx200-rx200-orx200", tmp_path / "out" / "profiles")
+    output = capsys.readouterr().out
+    assert str(talise_path) in output
+    assert "profile_config" in output
+    assert "does not write hardware automatically" in output
 
 
 def test_profile_file_example_is_documented() -> None:
-    """Keep the runnable profile-file commands discoverable in Sphinx docs."""
+    """Keep canonical retrieval and hardware application guidance discoverable."""
     tutorial = TUTORIAL.read_text()
-    assert "ADRV9009 custom profile files" in tutorial
-    assert "examples/xsa/adrv9009_profile_file.py" in tutorial
-    assert "examples/xsa/profiles/adrv9009_zc706_custom.json" in tutorial
-    assert "--show-config" in tutorial
+    assert "ADRV9009 board and Talise profile files" in tutorial
+    assert "analogdevicesinc/iio-oscilloscope" in tutorial
+    assert "--talise-profile tx200-rx200-orx200" in tutorial
+    assert "--download-talise-profile" in tutorial
+    assert "profile_config" in tutorial


### PR DESCRIPTION
## Summary
- distinguish adidt JSON board profiles from Talise runtime filter profiles
- expose all four canonical ADRV9009 profiles from analogdevicesinc/iio-oscilloscope
- pin the reviewed upstream commit and enforce SHA-256/XML validation before caching
- print explicit profile_config application steps without writing hardware automatically
- pull a real canonical profile in the blocking examples CI job
- document listing, downloading, XSA generation, and target application

## Verification
- live retrieval and SHA-256 validation of all four upstream profiles
- dedicated Python 3.12 examples suite: 37 passed
- full pytest: 763 passed, 18 skipped, 4 xfailed
- strict Sphinx HTML and linkcheck passed
- Ruff, ty, Actionlint, and git diff --check passed