### PR TITLE
CI: build native Debian, Fedora, and macOS packages

### DIFF
--- a/.github/scripts/create_system_package.sh
+++ b/.github/scripts/create_system_package.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+    echo "usage: $0 <deb|rpm|osxpkg> <version> <architecture> <distro> <output-file>" >&2
+    exit 2
+fi
+
+package_type=$1
+version=$2
+architecture=$3
+distro=$4
+output_file=$5
+
+case "$package_type" in
+    deb)
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential libffi-dev python3-dev python3-pip python3-venv ruby ruby-dev
+        ;;
+    rpm)
+        dnf install -y \
+            gcc libffi-devel make python3-devel python3-pip python3-rpm-generators \
+            python3-virtualenv rpm-build ruby ruby-devel
+        ;;
+    osxpkg)
+        if [[ "$(uname -s)" != "Darwin" ]]; then
+            echo "osxpkg packages must be built on macOS" >&2
+            exit 1
+        fi
+        ;;
+    *)
+        echo "unsupported package type: $package_type" >&2
+        exit 2
+        ;;
+esac
+
+gem install --no-document fpm
+
+# Keep a dependency-complete environment outside the package source tree for the
+# installed-package smoke test. System packages intentionally contain adidt
+# itself; Python dependencies remain managed by the target Python environment,
+# as with the existing Kuiper package.
+package_test_venv="${RUNNER_TEMP:-/tmp}/adidt-package-test-venv"
+rm -rf "$package_test_venv"
+python3 -m venv --system-site-packages "$package_test_venv"
+package_test_python="$package_test_venv/bin/python"
+"$package_test_python" -m pip install --upgrade pip
+"$package_test_python" - <<'PY'
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+dependencies = tomllib.loads(Path("pyproject.toml").read_text())["project"]["dependencies"]
+subprocess.run([sys.executable, "-m", "pip", "install", *dependencies], check=True)
+PY
+
+mkdir -p "$(dirname "$output_file")"
+
+extra_args=()
+if [[ "$package_type" == "osxpkg" ]]; then
+    extra_args+=(--identifier com.analogdevices.adidt)
+fi
+
+fpm -s python -t "$package_type" \
+    --force \
+    --architecture "$architecture" \
+    --name python3-adidt \
+    --package "$output_file" \
+    --url "https://github.com/analogdevicesinc/pyadi-dt" \
+    --version "$version" \
+    --iteration 1 \
+    --maintainer "EngineerZone <https://ez.analog.com/sw-interface-tools>" \
+    --license "EPL-2.0" \
+    --no-auto-depends \
+    --python-bin python3 \
+    --python-package-name-prefix python3 \
+    --description "Device tree management tools for ADI hardware ($distro build)" \
+    "${extra_args[@]}" \
+    .
+
+test -s "$output_file"
+printf 'created %s\n' "$output_file"

--- a/.github/scripts/create_system_package.sh
+++ b/.github/scripts/create_system_package.sh
@@ -61,6 +61,15 @@ mkdir -p "$(dirname "$output_file")"
 extra_args=()
 if [[ "$package_type" == "osxpkg" ]]; then
     extra_args+=(--osxpkg-identifier-prefix com.analogdevices)
+
+    # setup-python's toolcache can place another `pkgbuild` executable ahead of
+    # Apple's packaging utility. fpm resolves pkgbuild through PATH, so provide
+    # a private shim that unambiguously invokes the native macOS tool.
+    pkgbuild_shim="${RUNNER_TEMP:-/tmp}/adidt-package-tools"
+    rm -rf "$pkgbuild_shim"
+    mkdir -p "$pkgbuild_shim"
+    ln -s /usr/bin/pkgbuild "$pkgbuild_shim/pkgbuild"
+    export PATH="$pkgbuild_shim:$PATH"
 fi
 
 fpm -s python -t "$package_type" \

--- a/.github/scripts/create_system_package.sh
+++ b/.github/scripts/create_system_package.sh
@@ -60,7 +60,7 @@ mkdir -p "$(dirname "$output_file")"
 
 extra_args=()
 if [[ "$package_type" == "osxpkg" ]]; then
-    extra_args+=(--identifier com.analogdevices.adidt)
+    extra_args+=(--osxpkg-identifier-prefix com.analogdevices)
 fi
 
 fpm -s python -t "$package_type" \

--- a/.github/scripts/verify_system_package.sh
+++ b/.github/scripts/verify_system_package.sh
@@ -20,7 +20,7 @@ case "$package_type" in
         ;;
     osxpkg)
         sudo installer -pkg "$package_file" -target /
-        package_files=$(pkgutil --files com.analogdevices.adidt)
+        package_files=$(pkgutil --files com.analogdevices.python3-adidt)
         ;;
     *)
         echo "unsupported package type: $package_type" >&2

--- a/.github/scripts/verify_system_package.sh
+++ b/.github/scripts/verify_system_package.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <deb|rpm|osxpkg> <package-file>" >&2
+    exit 2
+fi
+
+package_type=$1
+package_file=$2
+
+case "$package_type" in
+    deb)
+        dpkg -i "$package_file"
+        package_files=$(dpkg -L python3-adidt)
+        ;;
+    rpm)
+        rpm -i "$package_file"
+        package_files=$(rpm -ql python3-adidt)
+        ;;
+    osxpkg)
+        sudo installer -pkg "$package_file" -target /
+        package_files=$(pkgutil --files com.analogdevices.adidt)
+        ;;
+    *)
+        echo "unsupported package type: $package_type" >&2
+        exit 2
+        ;;
+esac
+
+package_init=$(printf '%s\n' "$package_files" | grep -E '/?adidt/__init__\.py$' | head -1)
+package_cli=$(printf '%s\n' "$package_files" | grep -E '/?bin/adidtc$' | head -1)
+[[ "$package_init" == /* ]] || package_init="/$package_init"
+[[ "$package_cli" == /* ]] || package_cli="/$package_cli"
+test -f "$package_init"
+test -f "$package_cli"
+
+package_site=$(dirname "$(dirname "$package_init")")
+package_test_venv="${RUNNER_TEMP:-/tmp}/adidt-package-test-venv"
+package_test_python="$package_test_venv/bin/python"
+test -x "$package_test_python"
+(
+    cd /tmp
+    PYTHONPATH="$package_site" "$package_test_python" - <<'PY'
+import importlib.metadata as metadata
+from pathlib import Path
+
+import adidt
+
+assert metadata.version("adidt") == adidt.__version__
+assert Path(adidt.__file__).is_file()
+print(f"verified adidt {adidt.__version__} from {adidt.__file__}")
+PY
+    PYTHONPATH="$package_site" "$package_test_python" "$package_cli" --help >/dev/null
+)

--- a/.github/workflows/build_system_packages.yml
+++ b/.github/workflows/build_system_packages.yml
@@ -1,0 +1,157 @@
+name: Build native system packages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - '20[1-9][0-9]_R[1-9]'
+      - staging/*
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+      - '20[1-9][0-9]_R[1-9]'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize every tag-triggered release finalizer with release.yml and the
+  # Kuiper/Ubuntu Debian workflow while they update one checksum manifest.
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  identify_version:
+    runs-on: ubuntu-latest
+    outputs:
+      app-version: ${{ steps.set_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set package version
+        id: set_version
+        run: |
+          set -euo pipefail
+          package_version=$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+          print(tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"])
+          PY
+          )
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            app_version="${{ github.ref_name }}"
+            app_version="${app_version#v}"
+            [[ "$app_version" == "$package_version" ]] || {
+              echo "Tag version $app_version does not match package version $package_version" >&2
+              exit 1
+            }
+          else
+            app_version="${package_version}+${GITHUB_SHA}"
+          fi
+          echo "version=$app_version" >> "$GITHUB_OUTPUT"
+
+  linux-packages:
+    name: ${{ matrix.distro }} ${{ matrix.package_type }}
+    needs: identify_version
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: debian12
+            container: debian:12
+            package_type: "deb"
+            architecture: amd64
+            extension: deb
+          - distro: fedora42
+            container: fedora:42
+            package_type: "rpm"
+            architecture: x86_64
+            extension: rpm
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build native package
+        env:
+          VERSION: ${{ needs.identify_version.outputs.app-version }}
+        run: |
+          output="dist/system/python3-adidt-${VERSION}-1-${{ matrix.distro }}-${{ matrix.architecture }}.${{ matrix.extension }}"
+          .github/scripts/create_system_package.sh \
+            "${{ matrix.package_type }}" "$VERSION" "${{ matrix.architecture }}" \
+            "${{ matrix.distro }}" "$output"
+      - name: Install and verify package
+        env:
+          VERSION: ${{ needs.identify_version.outputs.app-version }}
+        run: |
+          package="dist/system/python3-adidt-${VERSION}-1-${{ matrix.distro }}-${{ matrix.architecture }}.${{ matrix.extension }}"
+          .github/scripts/verify_system_package.sh "${{ matrix.package_type }}" "$package"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: adidt-system-${{ matrix.distro }}-${{ matrix.architecture }}
+          path: dist/system/*.${{ matrix.extension }}
+          if-no-files-found: error
+
+  macos-package:
+    name: macOS 14 installer package
+    needs: identify_version
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Build native package
+        env:
+          VERSION: ${{ needs.identify_version.outputs.app-version }}
+        run: |
+          architecture=$(uname -m)
+          output="dist/system/python3-adidt-${VERSION}-1-macos14-${architecture}.pkg"
+          .github/scripts/create_system_package.sh osxpkg "$VERSION" "$architecture" macos14 "$output"
+      - name: Install and verify package
+        env:
+          VERSION: ${{ needs.identify_version.outputs.app-version }}
+        run: |
+          architecture=$(uname -m)
+          package="dist/system/python3-adidt-${VERSION}-1-macos14-${architecture}.pkg"
+          .github/scripts/verify_system_package.sh osxpkg "$package"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: adidt-system-macos14
+          path: dist/system/*.pkg
+          if-no-files-found: error
+
+  attach_system_release_assets:
+    name: Attach verified native packages to release
+    if: github.ref_type == 'tag'
+    needs: [identify_version, linux-packages, macos-package]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release helper
+        uses: actions/checkout@v7
+        with:
+          path: source
+      - name: Download all native system packages
+        uses: actions/download-artifact@v8
+        with:
+          pattern: adidt-system-*
+          path: release-assets
+          merge-multiple: true
+      - name: Validate and attach native system packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          artifacts=(release-assets/*.deb release-assets/*.rpm release-assets/*.pkg)
+          if [[ "${#artifacts[@]}" -ne 3 ]]; then
+            echo "Expected three native system packages, found ${#artifacts[@]}" >&2
+            printf '  %s\n' "${artifacts[@]}" >&2
+            exit 1
+          fi
+          python3 source/.github/scripts/release_manifest.py upsert-release \
+            --tag "${{ github.ref_name }}" \
+            --files "${artifacts[@]}"

--- a/doc/source/developer/release_runbook.md
+++ b/doc/source/developer/release_runbook.md
@@ -55,8 +55,10 @@ this environment; no PyPI API token is required.
 
    Confirm the validation, Python 3.10–3.13, build, wheel-install, and CLI
    smoke-test jobs pass. The GitHub Release and PyPI jobs must be skipped.
-4. Confirm all required `main` workflows—including hardware and Debian—are
-   green for the exact commit to be tagged.
+4. Confirm all required `main` workflows—including hardware, Kuiper/Ubuntu
+   Debian packaging, and native system packaging—are green for the exact commit
+   to be tagged. The native workflow builds on Debian 12, Fedora 42, and macOS
+   14 rather than cross-packaging those artifacts on Ubuntu.
 
 ## Tag and publish
 
@@ -81,10 +83,12 @@ are correct.
 ## Verify the published release
 
 1. Confirm **Publish Release** completed successfully for the tagged SHA.
-2. Confirm the Debian workflow completed for the same tag and attached its
-   `.deb` artifacts to the GitHub Release.
+2. Confirm both packaging workflows completed for the same tag. The release
+   must contain Kuiper/Ubuntu `.deb` files plus the Debian 12 `.deb`, Fedora 42
+   `.rpm`, and macOS 14 `.pkg` artifacts. Each job installs and smoke-tests its
+   package before upload.
 3. Verify the GitHub Release contains the wheel, source distribution, release
-   notes, Debian artifacts, and `SHA256SUMS` manifest file.
+   notes, all native system packages, and the `SHA256SUMS` manifest file.
 4. Verify checksum manifest integrity:
 
    ```bash
@@ -120,8 +124,8 @@ artifact for it has been accepted by PyPI.
 - **GitHub Release failed after PyPI succeeded:** rerun the failed job. The
   workflow creates a missing release or uploads artifacts to an existing one
   with `--clobber` and updates `SHA256SUMS`.
-- **Debian attachment failed:** rerun the Debian workflow for the original tag;
-  do not retag.
+- **System-package attachment failed:** rerun the failed Debian or native-system
+  package workflow for the original tag; do not retag.
 - **Checksum manifest out of sync:** re-sync the release manifest using the
   helper script:
   ```bash

--- a/test/test_release_preflight.py
+++ b/test/test_release_preflight.py
@@ -177,5 +177,6 @@ def test_native_system_package_ci_contract():
     assert "dpkg -L python3-adidt" in verifier
     assert "rpm -ql python3-adidt" in verifier
     assert "--osxpkg-identifier-prefix com.analogdevices" in builder
+    assert 'ln -s /usr/bin/pkgbuild "$pkgbuild_shim/pkgbuild"' in builder
     assert "pkgutil --files com.analogdevices.python3-adidt" in verifier
     assert '"$package_test_python" "$package_cli" --help' in verifier

--- a/test/test_release_preflight.py
+++ b/test/test_release_preflight.py
@@ -176,5 +176,6 @@ def test_native_system_package_ci_contract():
     assert "--no-auto-depends" in builder
     assert "dpkg -L python3-adidt" in verifier
     assert "rpm -ql python3-adidt" in verifier
-    assert "pkgutil --files com.analogdevices.adidt" in verifier
+    assert "--osxpkg-identifier-prefix com.analogdevices" in builder
+    assert "pkgutil --files com.analogdevices.python3-adidt" in verifier
     assert '"$package_test_python" "$package_cli" --help' in verifier

--- a/test/test_release_preflight.py
+++ b/test/test_release_preflight.py
@@ -131,6 +131,9 @@ def test_manual_dispatch_cannot_publish():
 def test_workflows_use_release_manifest_without_sleep_loops():
     release_wf = (repo_root / ".github" / "workflows" / "release.yml").read_text()
     debian_wf = (repo_root / ".github" / "workflows" / "build_debian.yaml").read_text()
+    system_wf = (
+        repo_root / ".github" / "workflows" / "build_system_packages.yml"
+    ).read_text()
 
     assert "release_manifest.py generate" in release_wf
     assert "release_manifest.py verify" in release_wf
@@ -143,3 +146,35 @@ def test_workflows_use_release_manifest_without_sleep_loops():
     assert "group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}" in release_wf
     assert "sleep 10" not in debian_wf
     assert "for attempt in {1..30}" not in debian_wf
+
+    assert system_wf.count("release_manifest.py upsert-release") == 1
+    assert "group: release-${{ github.ref_name }}" in system_wf
+    assert "Expected three native system packages" in system_wf
+    assert "sleep 10" not in system_wf
+
+
+def test_native_system_package_ci_contract():
+    """Build each package in its native OS or distribution and smoke-test it."""
+    workflow = (
+        repo_root / ".github" / "workflows" / "build_system_packages.yml"
+    ).read_text()
+    builder = (repo_root / ".github" / "scripts" / "create_system_package.sh").read_text()
+    verifier = (repo_root / ".github" / "scripts" / "verify_system_package.sh").read_text()
+
+    assert "debian:12" in workflow
+    assert "fedora:42" in workflow
+    assert "runs-on: macos-14" in workflow
+    assert 'package_type: "deb"' in workflow
+    assert 'package_type: "rpm"' in workflow
+    assert "create_system_package.sh osxpkg" in workflow
+    assert workflow.count("actions/upload-artifact@v7") == 2
+    assert "Install and verify package" in workflow
+    assert "if-no-files-found: error" in workflow
+
+    assert 'fpm -s python -t "$package_type"' in builder
+    assert '--package "$output_file"' in builder
+    assert "--no-auto-depends" in builder
+    assert "dpkg -L python3-adidt" in verifier
+    assert "rpm -ql python3-adidt" in verifier
+    assert "pkgutil --files com.analogdevices.adidt" in verifier
+    assert '"$package_test_python" "$package_cli" --help' in verifier


### PR DESCRIPTION
## Summary

- build a Debian 12 `.deb`, Fedora 42 `.rpm`, and real macOS 14 `.pkg` on their native platforms
- install and smoke-test every package before artifact upload
- attach exactly three verified assets to tag releases through the shared checksum-manifest helper
- document native package release and recovery checks

## Verification

- Debian 12 package built, installed, imported, and ran `adidtc --help` in a clean container
- Fedora 42 package built, installed, imported, and ran `adidtc --help` in a clean container
- `pytest test/test_release_preflight.py -q` (9 passed)
- actionlint and shellcheck pass for the new workflow/scripts

Hosted macOS packaging is exercised by this PR.