### PR TITLE
Fix native packaging workflow isolation

### DIFF
--- a/.github/scripts/create_system_package.sh
+++ b/.github/scripts/create_system_package.sh
@@ -57,6 +57,30 @@ subprocess.run([sys.executable, "-m", "pip", "install", *dependencies], check=Tr
 PY
 
 mkdir -p "$(dirname "$output_file")"
+output_dir=$(cd "$(dirname "$output_file")" && pwd)
+output_file="$output_dir/$(basename "$output_file")"
+
+# fpm's Python source adapter runs setuptools and writes egg-info into its input
+# tree. Build from a disposable copy so container jobs (which run as root) never
+# leave root-owned generated files in the checked-out source tree.
+package_source=$(mktemp -d "${RUNNER_TEMP:-/tmp}/adidt-package-source.XXXXXX")
+trap 'rm -rf "$package_source"' EXIT
+PACKAGE_SOURCE="$package_source" python3 - <<'PY'
+import os
+import shutil
+from pathlib import Path
+
+ignored = shutil.ignore_patterns(
+    ".git", ".pytest_cache", ".ruff_cache", ".venv", "__pycache__",
+    "*.egg-info", "build", "dist",
+)
+shutil.copytree(
+    Path.cwd(),
+    os.environ["PACKAGE_SOURCE"],
+    dirs_exist_ok=True,
+    ignore=ignored,
+)
+PY
 
 extra_args=()
 if [[ "$package_type" == "osxpkg" ]]; then
@@ -72,22 +96,25 @@ if [[ "$package_type" == "osxpkg" ]]; then
     export PATH="$pkgbuild_shim:$PATH"
 fi
 
-fpm -s python -t "$package_type" \
-    --force \
-    --architecture "$architecture" \
-    --name python3-adidt \
-    --package "$output_file" \
-    --url "https://github.com/analogdevicesinc/pyadi-dt" \
-    --version "$version" \
-    --iteration 1 \
-    --maintainer "EngineerZone <https://ez.analog.com/sw-interface-tools>" \
-    --license "EPL-2.0" \
-    --no-auto-depends \
-    --python-bin python3 \
-    --python-package-name-prefix python3 \
-    --description "Device tree management tools for ADI hardware ($distro build)" \
-    "${extra_args[@]}" \
-    .
+(
+    cd "$package_source"
+    fpm -s python -t "$package_type" \
+        --force \
+        --architecture "$architecture" \
+        --name python3-adidt \
+        --package "$output_file" \
+        --url "https://github.com/analogdevicesinc/pyadi-dt" \
+        --version "$version" \
+        --iteration 1 \
+        --maintainer "EngineerZone <https://ez.analog.com/sw-interface-tools>" \
+        --license "EPL-2.0" \
+        --no-auto-depends \
+        --python-bin python3 \
+        --python-package-name-prefix python3 \
+        --description "Device tree management tools for ADI hardware ($distro build)" \
+        "${extra_args[@]}" \
+        .
+)
 
 test -s "$output_file"
 printf 'created %s\n' "$output_file"

--- a/.github/workflows/build_debian.yaml
+++ b/.github/workflows/build_debian.yaml
@@ -4,9 +4,9 @@ permissions:
   contents: read
 
 concurrency:
-  # Match release.yml on tag pushes so Python and Debian assets cannot race
-  # while creating the release or replacing its checksum manifest.
-  group: release-${{ github.ref_name }}
+  # Match release.yml only on tag pushes. Branch and PR runs stay isolated by
+  # workflow so this job and native-system packaging can both reach execution.
+  group: ${{ github.ref_type == 'tag' && format('release-{0}', github.ref_name) || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/build_system_packages.yml
+++ b/.github/workflows/build_system_packages.yml
@@ -18,9 +18,10 @@ permissions:
   contents: read
 
 concurrency:
-  # Serialize every tag-triggered release finalizer with release.yml and the
-  # Kuiper/Ubuntu Debian workflow while they update one checksum manifest.
-  group: release-${{ github.ref_name }}
+  # Tag runs serialize with release.yml and build_debian.yaml while they update
+  # one release manifest. Branch and PR runs stay isolated by workflow so one
+  # packaging workflow cannot cancel another workflow while it is still queued.
+  group: ${{ github.ref_type == 'tag' && format('release-{0}', github.ref_name) || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: false
 
 jobs:

--- a/test/test_release_preflight.py
+++ b/test/test_release_preflight.py
@@ -142,13 +142,18 @@ def test_workflows_use_release_manifest_without_sleep_loops():
     assert debian_wf.count("release_manifest.py upsert-release") == 1
     assert "needs: [identify_version, build_and_deploy_for_kuiper, build_and_deploy_for_ubuntu]" in debian_wf
     assert "Expected three Debian artifacts" in debian_wf
-    assert "group: release-${{ github.ref_name }}" in debian_wf
+    concurrency_group = (
+        "group: ${{ github.ref_type == 'tag' && "
+        "format('release-{0}', github.ref_name) || "
+        "format('{0}-{1}', github.workflow, github.ref) }}"
+    )
+    assert concurrency_group in debian_wf
     assert "group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}" in release_wf
     assert "sleep 10" not in debian_wf
     assert "for attempt in {1..30}" not in debian_wf
 
     assert system_wf.count("release_manifest.py upsert-release") == 1
-    assert "group: release-${{ github.ref_name }}" in system_wf
+    assert concurrency_group in system_wf
     assert "Expected three native system packages" in system_wf
     assert "sleep 10" not in system_wf
 
@@ -174,6 +179,8 @@ def test_native_system_package_ci_contract():
     assert 'fpm -s python -t "$package_type"' in builder
     assert '--package "$output_file"' in builder
     assert "--no-auto-depends" in builder
+    assert 'cd "$package_source"' in builder
+    assert '"*.egg-info", "build", "dist"' in builder
     assert "dpkg -L python3-adidt" in verifier
     assert "rpm -ql python3-adidt" in verifier
     assert "--osxpkg-identifier-prefix com.analogdevices" in builder


### PR DESCRIPTION
Follow-up to #98.

The shared release concurrency group was also applied to pull-request and branch runs. GitHub keeps only one pending run per concurrency group, so the Debian workflow was cancelled while the native-system workflow ran. This keeps the shared group for tag finalizers but isolates non-tag runs by workflow and ref.

It also builds fpm packages from a disposable source copy so root-running Linux containers cannot leave generated, root-owned egg-info in the checkout.

Verification:
- `pytest -q test/test_release_preflight.py` (9 passed)
- Bash syntax and workflow YAML parsing
- #98 hosted native build/install/smoke jobs passed on Debian 12, Fedora 42, and macOS 14; this PR reruns those jobs with the isolation fix.