### PR TITLE
feat: align AD9371 with pyadi-jif model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install ".[test,xsa]"
+        pip install -r requirements/pyadi-jif-ad9371.txt
 
     - name: Run executable example tests
       run: |
@@ -87,6 +88,7 @@ jobs:
           test/devices/test_examples_ad9081_parity.py \
           test/test_examples_xsa_smoke.py \
           test/xsa/test_example_adrv9009_profile_file.py \
+          test/xsa/test_example_adrv937x_zc706.py \
           test/xsa/test_example_fmcdaq2_zc706.py \
           test/test_jif_contract_examples.py \
           test/test_examples_ci_contract.py \

--- a/adidt/xsa/build/builders/adrv937x.py
+++ b/adidt/xsa/build/builders/adrv937x.py
@@ -266,15 +266,25 @@ class ADRV937xBuilder:
         tx_link_id = int(board_cfg.get("tx_link_id", 0))
         rx_os_link_id = int(board_cfg.get("rx_os_link_id", 2))
         tx_octets_per_frame = int(board_cfg.get("tx_octets_per_frame", 2))
-        rx_os_octets_per_frame = int(board_cfg.get("rx_os_octets_per_frame", 2))
-        rx_os_k = int(board_cfg.get("rx_os_k", 32))
-
-        # JESD framing parameters (from pipeline cfg, not board_cfg)
+        # JESD framing parameters.  Explicit pyadi-jif link data owns the
+        # electrical intent; legacy board-profile fields remain fallbacks for
+        # callers that have not migrated to the AD9371 three-link model.
         jesd_cfg = cfg.get("jesd", {})
         rx_f = int(jesd_cfg.get("rx", {}).get("F", 4))
         rx_k = int(jesd_cfg.get("rx", {}).get("K", 32))
+        tx_f = int(
+            jesd_cfg.get("tx", {}).get(
+                "F", board_cfg.get("tx_octets_per_frame", tx_octets_per_frame)
+            )
+        )
         tx_k = int(jesd_cfg.get("tx", {}).get("K", 32))
         tx_m = int(jesd_cfg.get("tx", {}).get("M", 4))
+        rx_os_f = int(
+            jesd_cfg.get("obs", {}).get(
+                "F", board_cfg.get("rx_os_octets_per_frame", 2)
+            )
+        )
+        rx_os_k = int(jesd_cfg.get("obs", {}).get("K", 32))
 
         # --- Clock chip (AD9528_1, single-chip path only) ---
         clock_chip_label = "clk0_ad9528"
@@ -439,7 +449,7 @@ class ADRV937xBuilder:
             ),
             clock_names_str='"s_axi_aclk", "device_clk", "lane_clk"',
             clock_output_name="jesd_tx_lane_clk",
-            f=tx_octets_per_frame,
+            f=tx_f,
             k=tx_k,
             jesd204_inputs=f"{tx_xcvr_label} 0 {tx_link_id}",
             converter_resolution=14,
@@ -462,7 +472,7 @@ class ADRV937xBuilder:
                 ),
                 clock_names_str='"s_axi_aclk", "device_clk", "lane_clk"',
                 clock_output_name="jesd_rx_os_lane_clk",
-                f=rx_os_octets_per_frame,
+                f=rx_os_f,
                 k=rx_os_k,
                 jesd204_inputs=f"{rx_os_xcvr_label} 0 {rx_os_link_id}",
             )

--- a/doc/source/examples/xsa_tutorial.md
+++ b/doc/source/examples/xsa_tutorial.md
@@ -145,6 +145,45 @@ IDs continue to come from `adrv9009_zc706`. JSON keys and types are validated
 before SDTGen runs. The selected Talise file remains separate and is applied
 after the generated device tree has booted.
 
+### AD9371 profiles with the corrected pyadi-jif model
+
+The `adrv937x_zc706.py` example sends the same canonical Mykonos profile to
+both tools: pyadi-jif derives and validates the primary RX, observation RX, TX,
+FPGA, and shared-SYSREF intent, while pyadi-dt renders the complete profile
+coefficients and places the links on the ZC706/AD9528 hardware.
+
+Until the AD9371 model is included in a pyadi-jif release, install the reviewed
+upstream revision used by CI:
+
+```bash
+pip install -r requirements/pyadi-jif-ad9371.txt
+```
+
+Inspect the profile-derived settings without an XSA, Vivado, network, or
+hardware access:
+
+```bash
+python examples/xsa/adrv937x_zc706.py \
+  --ad9371-profile \
+    examples/xsa/profiles/ad9371_5/profile_TxBW200_ORxBW200_RxBW100.txt \
+  --show-jif-config
+```
+
+The output includes the corrected Mykonos framing (`RX M=4/L=2/F=4`,
+`OBS M=2/L=2/F=2`, and `TX M=4/L=4/F=2`), 14-bit converter resolution with
+two control bits, profile sample rates, and the 78.125 kHz pulsed-SYSREF limit.
+Add `--solve-adijif` to run the full CPLEX AD9528/FPGA solve and verify that all
+three links use a common SYSREF.
+
+Generate the DTS from an XSA using that electrical intent:
+
+```bash
+python examples/xsa/adrv937x_zc706.py \
+  --ad9371-profile path/to/profile.txt \
+  --xsa path/to/system_top.xsa \
+  --output-dir build/adrv937x
+```
+
 ## Tutorial 3: Use the Python API directly
 
 For custom integrations (CI, scripts, internal tools), call `XsaPipeline.run()`:

--- a/examples/xsa/adrv937x_zc706.py
+++ b/examples/xsa/adrv937x_zc706.py
@@ -1,9 +1,17 @@
-"""ADRV937x + ZC706: full XSA -> DTS generation example."""
+"""ADRV937x + ZC706: profile-driven XSA -> DTS generation.
+
+The canonical AD9371 profile drives both the Linux Mykonos properties and the
+corrected three-link ``pyadi-jif`` model.  pyadi-jif owns the RX, observation-RX,
+TX, FPGA, and shared-SYSREF electrical intent; pyadi-dt owns physical ZC706 and
+AD9528 placement in the generated device tree.
+"""
 
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
+from typing import Any
 
 from adidt.xsa.parse.kuiper import download_kuiper_xsa
 from adidt.xsa.pipeline import XsaPipeline
@@ -12,26 +20,120 @@ HERE = Path(__file__).parent
 DEFAULT_OUT_DIR = HERE / "output_adrv937x_zc706"
 DEFAULT_KUIPER_RELEASE = "2023_r2"
 DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv937x"
+DEFAULT_AD9371_PROFILE = (
+    HERE
+    / "profiles"
+    / "ad9371_5"
+    / "profile_TxBW200_ORxBW200_RxBW100.txt"
+)
+
+# The profile contains datapath rates and interpolation/decimation but not JESD
+# transport framing.  These are ADI's standard Mykonos transport modes.  The
+# corrected pyadi-jif AD9371 model validates them and supplies F/N/CS details.
+_RX_JESD = {"M": 4, "L": 2, "S": 1, "Np": 16}
+_OBS_JESD = {"M": 2, "L": 2, "S": 1, "Np": 16}
+_TX_JESD = {"M": 4, "L": 4, "S": 1, "Np": 16}
 
 
-def _default_config(ad9371_profile: Path | None = None) -> dict:
-    config = {
+def _jesd_config(path: Any) -> dict[str, int]:
+    """Return pyadi-dt framing fields from one configured pyadi-jif path."""
+    return {
+        key: int(getattr(path, key))
+        for key in ("F", "K", "M", "L", "N", "Np", "S", "CS")
+    }
+
+
+def _resolve_config_from_adijif(
+    profile_path: Path, *, solve: bool = False
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Apply an AD9371 profile to the corrected pyadi-jif Mykonos model.
+
+    Args:
+        profile_path: Canonical AD9371 profile-wizard text file.
+        solve: Run the full AD9528 + FPGA CPLEX solve when true.  Profile and
+            quick-mode validation do not require a solver.
+
+    Returns:
+        A pyadi-dt pipeline configuration and a human-readable solver summary.
+
+    Raises:
+        RuntimeError: If the installed pyadi-jif predates AD9371 support.
+    """
+    import adijif
+
+    if not hasattr(adijif, "ad9371"):
+        raise RuntimeError(
+            "Installed pyadi-jif does not provide the AD9371 profile model. "
+            "Install the AD9371-capable revision documented for this example."
+        )
+
+    resolved_profile = profile_path.expanduser().resolve()
+    if not resolved_profile.is_file():
+        raise FileNotFoundError(f"AD9371 profile file not found: {resolved_profile}")
+
+    system = adijif.system("ad9371", "ad9528", "xilinx", 122_880_000)
+    system.converter.apply_profile_settings(
+        str(resolved_profile),
+        rx_jesd=_RX_JESD,
+        obs_jesd=_OBS_JESD,
+        tx_jesd=_TX_JESD,
+    )
+    system.fpga.setup_by_dev_kit_name("zc706")
+    system.fpga.force_qpll = True
+
+    converter = system.converter
+    metadata = converter.get_config()
+    cfg: dict[str, Any] = {
         "jesd": {
-            "rx": {"F": 4, "K": 32, "M": 4, "L": 4, "Np": 16, "S": 1},
-            "tx": {"F": 2, "K": 32, "M": 4, "L": 4, "Np": 16, "S": 1},
+            "rx": _jesd_config(converter.adc),
+            "obs": _jesd_config(converter.obs),
+            "tx": _jesd_config(converter.dac),
         },
         "clock": {
             "rx_device_clk_label": "clkgen",
             "tx_device_clk_label": "clkgen",
-            "hmc7044_rx_channel": 0,
-            "hmc7044_tx_channel": 0,
+        },
+        "adrv9009_board": {
+            "ad9371_profile_path": str(resolved_profile),
+            "ad9528_vcxo_freq": int(metadata["device_clock"]),
+            "ad9528_jesd204_max_sysref_hz": int(
+                metadata["jesd204_max_sysref_hz"]
+            ),
         },
     }
-    if ad9371_profile is not None:
-        config["adrv9009_board"] = {
-            "ad9371_profile_path": str(ad9371_profile.resolve())
-        }
-    return config
+    summary: dict[str, Any] = {
+        "profile": str(resolved_profile),
+        "rates_hz": {
+            "rx": int(converter.adc.sample_clock),
+            "obs": int(converter.obs.sample_clock),
+            "tx": int(converter.dac.sample_clock),
+        },
+        "lane_rates_hz": {
+            "rx": int(converter.adc.bit_clock),
+            "obs": int(converter.obs.bit_clock),
+            "tx": int(converter.dac.bit_clock),
+        },
+        "solver_attempted": solve,
+        "solver_succeeded": False,
+        "clock_output_clocks": None,
+    }
+
+    if solve:
+        solved = system.solve()
+        summary["solver_succeeded"] = True
+        summary["clock_output_clocks"] = solved["clock"]["output_clocks"]
+        for cfg_name, solved_name in (
+            ("rx", "adc"),
+            ("obs", "obs"),
+            ("tx", "dac"),
+        ):
+            solved_jesd = solved[f"jesd_{solved_name}"]
+            for key in ("F", "K", "M", "L", "N", "Np", "S", "CS"):
+                if key in solved_jesd:
+                    cfg["jesd"][cfg_name][key] = int(solved_jesd[key])
+            cfg[f"fpga_{solved_name}"] = solved[f"fpga_{solved_name}"]
+
+    return cfg, summary
 
 
 def _download_kuiper_xsa(
@@ -61,14 +163,30 @@ def main() -> None:
     parser.add_argument(
         "--ad9371-profile",
         type=Path,
-        default=None,
-        help="Canonical AD9371 profile-wizard text file to render into the DTS",
+        default=DEFAULT_AD9371_PROFILE,
+        help="Canonical AD9371 profile used by both pyadi-jif and the DTS renderer",
+    )
+    parser.add_argument(
+        "--solve-adijif",
+        action="store_true",
+        help="Run the full AD9528/FPGA CPLEX solve instead of profile validation only",
+    )
+    parser.add_argument(
+        "--show-jif-config",
+        action="store_true",
+        help="Print profile-derived configuration as JSON and exit without an XSA",
     )
     args = parser.parse_args()
 
+    cfg, summary = _resolve_config_from_adijif(
+        args.ad9371_profile, solve=args.solve_adijif
+    )
+    if args.show_jif_config:
+        print(json.dumps({"config": cfg, "summary": summary}, indent=2, sort_keys=True))
+        return
+
     out_dir = args.output_dir.resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
-
     if args.download_kuiper:
         xsa_path = _download_kuiper_xsa(
             release=args.release,
@@ -83,13 +201,15 @@ def main() -> None:
 
     result = XsaPipeline().run(
         xsa_path=xsa_path,
-        cfg=_default_config(args.ad9371_profile),
+        cfg=cfg,
         output_dir=out_dir,
         profile="adrv937x_zc706",
     )
     print("Generated artifacts (explicit profile=adrv937x_zc706):")
     for key, value in result.items():
         print(f"  {key}: {value}")
+    print("pyadi-jif summary:")
+    print(json.dumps(summary, indent=2, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/requirements/pyadi-jif-ad9371.txt
+++ b/requirements/pyadi-jif-ad9371.txt
@@ -1,0 +1,3 @@
+# AD9371 profile model plus corrected Mykonos link/SYSREF constraints.
+# Pin the reviewed upstream revision until these commits are in a pyadi-jif release.
+pyadi-jif[cplex,draw] @ git+https://github.com/analogdevicesinc/pyadi-jif.git@0a315f03e2325f286157f33fc4652c17095b5376

--- a/test/profiles/test_ad9371.py
+++ b/test/profiles/test_ad9371.py
@@ -52,7 +52,15 @@ def _topology() -> XsaTopology:
                 irq=106,
                 link_clk="axi_rx_clkgen_clk",
                 direction="rx",
-            )
+            ),
+            Jesd204Instance(
+                name="axi_ad9371_rx_os_jesd_rx_axi",
+                base_addr=0x44AB0000,
+                num_lanes=2,
+                irq=104,
+                link_clk="axi_rx_os_clkgen_clk",
+                direction="rx",
+            ),
         ],
         jesd204_tx=[
             Jesd204Instance(
@@ -104,6 +112,33 @@ def test_profile_path_overrides_merged_board_profile_properties():
     merged = "\n".join(nodes["converters"])
     assert "adi,test = <1>;" not in merged
     assert "adi,rx-profile-iq-rate_khz = <0x1e000>;" in merged
+
+
+def test_ad9371_builder_prefers_three_link_jif_framing():
+    cfg = {
+        "jesd": {
+            "rx": {"F": 4, "K": 32},
+            "obs": {"F": 6, "K": 16},
+            "tx": {"F": 5, "K": 24, "M": 4},
+        },
+        "adrv9009_board": {
+            "tx_octets_per_frame": 7,
+            "rx_os_octets_per_frame": 8,
+        },
+    }
+    merged = "\n".join(NodeBuilder().build(_topology(), cfg)["converters"])
+
+    obs_start = merged.index("&axi_ad9371_rx_os_jesd_rx_axi {")
+    obs_end = merged.index("\n\t};", obs_start)
+    obs = merged[obs_start:obs_end]
+    assert "adi,octets-per-frame = <6>;" in obs
+    assert "adi,frames-per-multiframe = <16>;" in obs
+
+    tx_start = merged.index("&axi_ad9371_tx_jesd_tx_axi {")
+    tx_end = merged.index("\n\t};", tx_start)
+    tx = merged[tx_start:tx_end]
+    assert "adi,octets-per-frame = <5>;" in tx
+    assert "adi,frames-per-multiframe = <24>;" in tx
 
 
 def test_board_config_rejects_empty_ad9371_profile_path():

--- a/test/test_examples_ci_contract.py
+++ b/test/test_examples_ci_contract.py
@@ -12,6 +12,7 @@ EXAMPLE_TEST_GROUPS = (
     "test/devices/test_examples_ad9081_parity.py",
     "test/test_examples_xsa_smoke.py",
     "test/xsa/test_example_adrv9009_profile_file.py",
+    "test/xsa/test_example_adrv937x_zc706.py",
     "test/xsa/test_example_fmcdaq2_zc706.py",
     "test/test_jif_contract_examples.py",
     "test/test_examples_ci_contract.py",
@@ -24,6 +25,7 @@ def test_examples_have_a_dedicated_blocking_ci_job() -> None:
 
     assert "examples-test:" in workflow
     assert 'pip install ".[test,xsa]"' in workflow
+    assert "pip install -r requirements/pyadi-jif-ad9371.txt" in workflow
     assert "Pull canonical ADRV9009 Talise profile" in workflow
     assert "--download-talise-profile" in workflow
     for test_group in EXAMPLE_TEST_GROUPS:

--- a/test/xsa/test_example_adrv937x_zc706.py
+++ b/test/xsa/test_example_adrv937x_zc706.py
@@ -1,0 +1,130 @@
+"""Tests for the AD9371 profile-driven pyadi-jif XSA example."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+EXAMPLE = ROOT / "examples" / "xsa" / "adrv937x_zc706.py"
+PROFILE = (
+    ROOT
+    / "examples"
+    / "xsa"
+    / "profiles"
+    / "ad9371_5"
+    / "profile_TxBW200_ORxBW200_RxBW100.txt"
+)
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("adrv937x_zc706_example", EXAMPLE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _require_new_adijif() -> None:
+    import adijif
+
+    if not hasattr(adijif, "ad9371"):
+        pytest.skip("requires pyadi-jif AD9371 support newer than v0.1.7")
+
+
+def test_ad9371_profile_drives_all_mykonos_links() -> None:
+    """The new pyadi-jif model must replace the old hard-coded framing."""
+    _require_new_adijif()
+    module = _load_example()
+
+    cfg, summary = module._resolve_config_from_adijif(PROFILE, solve=False)
+
+    assert cfg["jesd"]["rx"] == {
+        "F": 4,
+        "K": 32,
+        "M": 4,
+        "L": 2,
+        "N": 14,
+        "Np": 16,
+        "S": 1,
+        "CS": 2,
+    }
+    assert cfg["jesd"]["obs"] == {
+        "F": 2,
+        "K": 32,
+        "M": 2,
+        "L": 2,
+        "N": 14,
+        "Np": 16,
+        "S": 1,
+        "CS": 2,
+    }
+    assert cfg["jesd"]["tx"] == {
+        "F": 2,
+        "K": 32,
+        "M": 4,
+        "L": 4,
+        "N": 14,
+        "Np": 16,
+        "S": 1,
+        "CS": 2,
+    }
+    assert cfg["adrv9009_board"]["ad9371_profile_path"] == str(PROFILE.resolve())
+    assert cfg["adrv9009_board"]["ad9528_vcxo_freq"] == 122_880_000
+    assert cfg["adrv9009_board"]["ad9528_jesd204_max_sysref_hz"] == 78_125
+    assert summary["rates_hz"] == {
+        "rx": 122_880_000,
+        "obs": 245_760_000,
+        "tx": 245_760_000,
+    }
+    assert summary["solver_attempted"] is False
+
+
+def test_ad9371_profile_can_be_solved_with_shared_sysref() -> None:
+    """Exercise the corrected three-link solver result when CPLEX is available."""
+    _require_new_adijif()
+    module = _load_example()
+    try:
+        cfg, summary = module._resolve_config_from_adijif(PROFILE, solve=True)
+    except Exception as exc:
+        if "CPLEX" in str(exc) or "docplex" in str(exc):
+            pytest.skip(f"CPLEX unavailable: {exc}")
+        raise
+
+    assert summary["solver_succeeded"] is True
+    clocks = summary["clock_output_clocks"]
+    assert clocks["AD9371_ref_clk"]["rate"] == 122_880_000
+    assert clocks["adc_sysref"]["rate"] == clocks["obs_sysref"]["rate"]
+    assert clocks["obs_sysref"]["rate"] == clocks["dac_sysref"]["rate"]
+    assert cfg["fpga_adc"]["type"] == "qpll"
+    assert cfg["fpga_obs"]["type"] == "qpll"
+    assert cfg["fpga_dac"]["type"] == "qpll"
+
+
+def test_show_jif_config_runs_without_xsa_or_network() -> None:
+    """The profile/JIF part of the example remains executable in examples CI."""
+    _require_new_adijif()
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(EXAMPLE),
+            "--ad9371-profile",
+            str(PROFILE),
+            "--show-jif-config",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["config"]["jesd"]["rx"]["L"] == 2
+    assert payload["config"]["jesd"]["obs"]["M"] == 2
+    assert payload["config"]["jesd"]["tx"]["F"] == 2
+    assert payload["summary"]["solver_attempted"] is False


### PR DESCRIPTION
## Summary
- derive AD9371 RX, observation-RX, and TX framing from the corrected `pyadi-jif` Mykonos profile model
- pass explicit three-link framing and AD9528 SYSREF metadata into the XSA/DTS pipeline
- pin the reviewed unreleased `pyadi-jif` revision in integration CI until it is released
- add offline profile validation, real CPLEX shared-SYSREF coverage, builder precedence tests, and task-oriented documentation

## Verification
- full local suite: 782 passed, 18 skipped, 4 xfailed
- clean Python 3.12 examples suite: 40 passed
- clean install from `requirements/pyadi-jif-ad9371.txt`: passed
- real CPLEX solve: RX/OBS/TX QPLL, shared 768 kHz SYSREF
- Ruff, ty, Actionlint, strict Sphinx HTML/linkcheck: passed
- sdist/wheel build and Twine checks: passed
