### PR TITLE
test: close AD9371 hardware coverage gaps

### DIFF
--- a/.github/scripts/install-adidt-venv.sh
+++ b/.github/scripts/install-adidt-venv.sh
@@ -19,6 +19,8 @@ if [[ ! -x "$VENV/bin/python" ]]; then
 fi
 
 uv pip install --quiet --python "$VENV/bin/python" -e ".[dev]"
+uv pip install --quiet --python "$VENV/bin/python" \
+    -r requirements/pyadi-jif-ad9371.txt
 
 # ``sdtgen`` ships with Vivado rather than the Python ``lopper`` package.
 # Publish the host installation inside the persistent venv so the dynamic test
@@ -44,4 +46,4 @@ if [[ ! -x "$VENV/bin/sdtgen" ]]; then
     exit 1
 fi
 "$VENV/bin/sdtgen" -help >/dev/null
-"$VENV/bin/python" -c "import adi_lg_plugins, lopper"
+"$VENV/bin/python" -c "import adi_lg_plugins, adijif, lopper; assert hasattr(adijif, 'ad9371')"

--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -38,13 +38,15 @@ jobs:
       venv_install_cmd: 'bash .github/scripts/install-adidt-venv.sh'
       venv_dir: $HOME/.cache/adidt-ci/adidt-venv
       # Dynamic mode exports $BOARD + $CARRIER (no manifest test list). Select
-      # this place's HW tests by filename convention test/hw/*<board>*<carrier>*_hw.py
-      # (e.g. daq3 matches fmcdaq3_vcu118), excluding the slow petalinux builds.
+      # this place's full-DTB and runtime-overlay tests by filename convention
+      # (e.g. daq3 matches fmcdaq3_vcu118), excluding slow PetaLinux builds.
       # The labgrid pytest plugin reads LG_ENV / LG_COORDINATOR from the env.
       pytest_cmd_template: >-
         set -euo pipefail;
         source .github/scripts/prepare-hardware-env.sh;
-        TESTS=$(ls test/hw/*"$BOARD"*"$CARRIER"*_hw.py 2>/dev/null | grep -v petalinux | tr '\n' ' ');
+        TESTS=$( { find test/hw -maxdepth 1 -type f -name "*${BOARD}*${CARRIER}*_hw.py";
+        find test/hw/xsa -maxdepth 1 -type f -name "test_*${BOARD}*${CARRIER}*_overlay.py"; }
+        | grep -v petalinux | sort -u | tr '\n' ' ');
         if [ -z "$TESTS" ]; then echo "::warning::no pyadi-dt HW tests for board=$BOARD carrier=$CARRIER"; exit 0; fi;
         echo "Selected: $TESTS" >&2;
         "$VENV_DIR/bin/pytest" -p no:genalyzer -v -s $TESTS --junitxml="$JUNIT"

--- a/adidt/profiles/__init__.py
+++ b/adidt/profiles/__init__.py
@@ -1,5 +1,6 @@
 """External device-profile parsers."""
 
 from .ad9371 import AD9371Profile, parse_ad9371_profile
+from .ad9371_jif import resolve_ad9371_jif_config
 
-__all__ = ["AD9371Profile", "parse_ad9371_profile"]
+__all__ = ["AD9371Profile", "parse_ad9371_profile", "resolve_ad9371_jif_config"]

--- a/adidt/profiles/ad9371_jif.py
+++ b/adidt/profiles/ad9371_jif.py
@@ -1,0 +1,102 @@
+"""Build pyadi-dt configuration from the corrected pyadi-jif AD9371 model."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+_RX_JESD = {"M": 4, "L": 2, "S": 1, "Np": 16}
+_OBS_JESD = {"M": 2, "L": 2, "S": 1, "Np": 16}
+_TX_JESD = {"M": 4, "L": 4, "S": 1, "Np": 16}
+_JESD_FIELDS = ("F", "K", "M", "L", "N", "Np", "S", "CS")
+
+
+def _jesd_config(path: Any) -> dict[str, int]:
+    return {key: int(getattr(path, key)) for key in _JESD_FIELDS}
+
+
+def resolve_ad9371_jif_config(
+    profile_path: str | Path, *, solve: bool = False
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Apply a canonical AD9371 profile to pyadi-jif's three-link model.
+
+    The returned configuration is accepted directly by :class:`XsaPipeline`.
+    When ``solve`` is true, the solved JESD and FPGA settings replace quick-mode
+    values and the summary includes the AD9528 output-clock solution.
+    """
+    adijif = importlib.import_module("adijif")
+
+    if not hasattr(adijif, "ad9371"):
+        raise RuntimeError(
+            "Installed pyadi-jif does not provide the AD9371 profile model. "
+            "Install the AD9371-capable revision documented for this example."
+        )
+
+    resolved_profile = Path(profile_path).expanduser().resolve()
+    if not resolved_profile.is_file():
+        raise FileNotFoundError(f"AD9371 profile file not found: {resolved_profile}")
+
+    system = adijif.system("ad9371", "ad9528", "xilinx", 122_880_000)
+    system.converter.apply_profile_settings(
+        str(resolved_profile),
+        rx_jesd=_RX_JESD,
+        obs_jesd=_OBS_JESD,
+        tx_jesd=_TX_JESD,
+    )
+    system.fpga.setup_by_dev_kit_name("zc706")
+    system.fpga.force_qpll = True
+
+    converter = system.converter
+    metadata = converter.get_config()
+    cfg: dict[str, Any] = {
+        "jesd": {
+            "rx": _jesd_config(converter.adc),
+            "obs": _jesd_config(converter.obs),
+            "tx": _jesd_config(converter.dac),
+        },
+        "clock": {
+            "rx_device_clk_label": "clkgen",
+            "tx_device_clk_label": "clkgen",
+        },
+        "adrv9009_board": {
+            "ad9371_profile_path": str(resolved_profile),
+            "ad9528_vcxo_freq": int(metadata["device_clock"]),
+            "ad9528_jesd204_max_sysref_hz": int(
+                metadata["jesd204_max_sysref_hz"]
+            ),
+        },
+    }
+    summary: dict[str, Any] = {
+        "profile": str(resolved_profile),
+        "rates_hz": {
+            "rx": int(converter.adc.sample_clock),
+            "obs": int(converter.obs.sample_clock),
+            "tx": int(converter.dac.sample_clock),
+        },
+        "lane_rates_hz": {
+            "rx": int(converter.adc.bit_clock),
+            "obs": int(converter.obs.bit_clock),
+            "tx": int(converter.dac.bit_clock),
+        },
+        "solver_attempted": solve,
+        "solver_succeeded": False,
+        "clock_output_clocks": None,
+    }
+
+    if solve:
+        solved = system.solve()
+        summary["solver_succeeded"] = True
+        summary["clock_output_clocks"] = solved["clock"]["output_clocks"]
+        for cfg_name, solved_name in (
+            ("rx", "adc"),
+            ("obs", "obs"),
+            ("tx", "dac"),
+        ):
+            solved_jesd = solved[f"jesd_{solved_name}"]
+            for key in _JESD_FIELDS:
+                if key in solved_jesd:
+                    cfg["jesd"][cfg_name][key] = int(solved_jesd[key])
+            cfg[f"fpga_{solved_name}"] = solved[f"fpga_{solved_name}"]
+
+    return cfg, summary

--- a/examples/xsa/adrv937x_zc706.py
+++ b/examples/xsa/adrv937x_zc706.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any
 
+from adidt.profiles import resolve_ad9371_jif_config
 from adidt.xsa.parse.kuiper import download_kuiper_xsa
 from adidt.xsa.pipeline import XsaPipeline
 
@@ -26,115 +26,6 @@ DEFAULT_AD9371_PROFILE = (
     / "ad9371_5"
     / "profile_TxBW200_ORxBW200_RxBW100.txt"
 )
-
-# The profile contains datapath rates and interpolation/decimation but not JESD
-# transport framing.  These are ADI's standard Mykonos transport modes.  The
-# corrected pyadi-jif AD9371 model validates them and supplies F/N/CS details.
-_RX_JESD = {"M": 4, "L": 2, "S": 1, "Np": 16}
-_OBS_JESD = {"M": 2, "L": 2, "S": 1, "Np": 16}
-_TX_JESD = {"M": 4, "L": 4, "S": 1, "Np": 16}
-
-
-def _jesd_config(path: Any) -> dict[str, int]:
-    """Return pyadi-dt framing fields from one configured pyadi-jif path."""
-    return {
-        key: int(getattr(path, key))
-        for key in ("F", "K", "M", "L", "N", "Np", "S", "CS")
-    }
-
-
-def _resolve_config_from_adijif(
-    profile_path: Path, *, solve: bool = False
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Apply an AD9371 profile to the corrected pyadi-jif Mykonos model.
-
-    Args:
-        profile_path: Canonical AD9371 profile-wizard text file.
-        solve: Run the full AD9528 + FPGA CPLEX solve when true.  Profile and
-            quick-mode validation do not require a solver.
-
-    Returns:
-        A pyadi-dt pipeline configuration and a human-readable solver summary.
-
-    Raises:
-        RuntimeError: If the installed pyadi-jif predates AD9371 support.
-    """
-    import adijif
-
-    if not hasattr(adijif, "ad9371"):
-        raise RuntimeError(
-            "Installed pyadi-jif does not provide the AD9371 profile model. "
-            "Install the AD9371-capable revision documented for this example."
-        )
-
-    resolved_profile = profile_path.expanduser().resolve()
-    if not resolved_profile.is_file():
-        raise FileNotFoundError(f"AD9371 profile file not found: {resolved_profile}")
-
-    system = adijif.system("ad9371", "ad9528", "xilinx", 122_880_000)
-    system.converter.apply_profile_settings(
-        str(resolved_profile),
-        rx_jesd=_RX_JESD,
-        obs_jesd=_OBS_JESD,
-        tx_jesd=_TX_JESD,
-    )
-    system.fpga.setup_by_dev_kit_name("zc706")
-    system.fpga.force_qpll = True
-
-    converter = system.converter
-    metadata = converter.get_config()
-    cfg: dict[str, Any] = {
-        "jesd": {
-            "rx": _jesd_config(converter.adc),
-            "obs": _jesd_config(converter.obs),
-            "tx": _jesd_config(converter.dac),
-        },
-        "clock": {
-            "rx_device_clk_label": "clkgen",
-            "tx_device_clk_label": "clkgen",
-        },
-        "adrv9009_board": {
-            "ad9371_profile_path": str(resolved_profile),
-            "ad9528_vcxo_freq": int(metadata["device_clock"]),
-            "ad9528_jesd204_max_sysref_hz": int(
-                metadata["jesd204_max_sysref_hz"]
-            ),
-        },
-    }
-    summary: dict[str, Any] = {
-        "profile": str(resolved_profile),
-        "rates_hz": {
-            "rx": int(converter.adc.sample_clock),
-            "obs": int(converter.obs.sample_clock),
-            "tx": int(converter.dac.sample_clock),
-        },
-        "lane_rates_hz": {
-            "rx": int(converter.adc.bit_clock),
-            "obs": int(converter.obs.bit_clock),
-            "tx": int(converter.dac.bit_clock),
-        },
-        "solver_attempted": solve,
-        "solver_succeeded": False,
-        "clock_output_clocks": None,
-    }
-
-    if solve:
-        solved = system.solve()
-        summary["solver_succeeded"] = True
-        summary["clock_output_clocks"] = solved["clock"]["output_clocks"]
-        for cfg_name, solved_name in (
-            ("rx", "adc"),
-            ("obs", "obs"),
-            ("tx", "dac"),
-        ):
-            solved_jesd = solved[f"jesd_{solved_name}"]
-            for key in ("F", "K", "M", "L", "N", "Np", "S", "CS"):
-                if key in solved_jesd:
-                    cfg["jesd"][cfg_name][key] = int(solved_jesd[key])
-            cfg[f"fpga_{solved_name}"] = solved[f"fpga_{solved_name}"]
-
-    return cfg, summary
-
 
 def _download_kuiper_xsa(
     release: str, project: str, cache_dir: Path, out_dir: Path
@@ -178,7 +69,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    cfg, summary = _resolve_config_from_adijif(
+    cfg, summary = resolve_ad9371_jif_config(
         args.ad9371_profile, solve=args.solve_adijif
     )
     if args.show_jif_config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ test = [
 ]
 dev = [
     "adidt[test,xsa]",
-    "labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git",
+    "labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/labgrid-plugins.git@d21e5a94b4eebd3bedeb7cd16cd12504b11b5aba",
     "pyadi-build @ git+https://github.com/tfcollins/pyadi-build.git",
     "usbsdmux",
 ]

--- a/test/hw/README.md
+++ b/test/hw/README.md
@@ -293,5 +293,7 @@ The TFTP-boot boards (`nemo`, `bq`) don't need ssh access to the exporter host (
 | `iio_required_any_groups` | `()` | Tuple of groups; each inner tuple is "any of these names must be present".  Express multiple independent any-of asserts (e.g. RX frontend group + TX frontend group). |
 | `jesd_rx_glob` | default | sysfs glob for the RX JESD platform device.  `None` uses a permissive default. |
 | `jesd_tx_glob` | default | Same for TX. |
+| `expected_rx_jesd_links` | `1` | Number of RX cores that must independently report `Link status: DATA`; AD9371 uses `2` for primary + observation RX. |
+| `expected_tx_jesd_links` | `1` | Number of TX cores that must independently report `Link status: DATA`. |
 | `dmesg_filter` | identity | `(text) -> text` to strip benign noise before `assert_no_probe_errors`. |
 | `rx_capture_target_names` | `()` | Tuple of IIO device names to try for the RX capture smoke test; empty skips the capture. |

--- a/test/hw/_system_base.py
+++ b/test/hw/_system_base.py
@@ -132,6 +132,8 @@ class BoardSystemProfile:
 
     jesd_rx_glob: Optional[str] = None
     jesd_tx_glob: Optional[str] = None
+    expected_rx_jesd_links: int = 1
+    expected_tx_jesd_links: int = 1
 
     dmesg_filter: DmesgFilter = _identity
 
@@ -235,6 +237,8 @@ def boot_and_verify_from_dtb(
         context=spec.out_label,
         rx_glob=rx_glob,
         tx_glob=tx_glob,
+        expected_rx_links=spec.expected_rx_jesd_links,
+        expected_tx_links=spec.expected_tx_jesd_links,
     )
     print(f"$ cat .../{rx_glob}/status\n{rx_status}")
     print(f"$ cat .../{tx_glob}/status\n{tx_status}")

--- a/test/hw/hw_helpers.py
+++ b/test/hw/hw_helpers.py
@@ -670,13 +670,15 @@ def read_jesd_status(
     """Return ``(rx_status, tx_status)`` from the platform-device sysfs nodes."""
     rx_status = shell_out(
         shell,
-        f"cat /sys/bus/platform/devices/{rx_glob}/status 2>/dev/null "
-        "| head -n 20 || true",
+        f"for f in /sys/bus/platform/devices/{rx_glob}/status; do "
+        '  [ -f "$f" ] || continue; echo "=== $f ==="; cat "$f"; '
+        "done 2>/dev/null || true",
     )
     tx_status = shell_out(
         shell,
-        f"cat /sys/bus/platform/devices/{tx_glob}/status 2>/dev/null "
-        "| head -n 20 || true",
+        f"for f in /sys/bus/platform/devices/{tx_glob}/status; do "
+        '  [ -f "$f" ] || continue; echo "=== $f ==="; cat "$f"; '
+        "done 2>/dev/null || true",
     )
     return rx_status, tx_status
 

--- a/test/hw/hw_helpers.py
+++ b/test/hw/hw_helpers.py
@@ -300,6 +300,7 @@ def hardware_prereq_unavailable(message: str) -> NoReturn:
     if os.environ.get("LG_COORDINATOR"):
         pytest.fail(message)
     pytest.skip(message)
+    raise AssertionError("pytest.skip returned unexpectedly")  # pragma: no cover
 
 
 def require_hw_prereqs() -> None:
@@ -543,7 +544,7 @@ def check_jesd_framing_plausibility(jesd_cfg: dict) -> list[str]:
     fast with a clear message.
     """
     warnings: list[str] = []
-    for side in ("rx", "tx"):
+    for side in ("rx", "obs", "tx"):
         sub = jesd_cfg.get(side)
         if not isinstance(sub, dict):
             continue
@@ -685,15 +686,21 @@ def assert_jesd_links_data(
     context: str = "",
     rx_glob: str = "*.axi[_-]jesd204[_-]rx",
     tx_glob: str = "*.axi[_-]jesd204[_-]tx",
+    expected_rx_links: int = 1,
+    expected_tx_links: int = 1,
 ) -> tuple[str, str]:
-    """Read RX + TX JESD status and assert both show ``Link status: DATA``."""
+    """Assert every expected RX/TX JESD core reports ``Link status: DATA``."""
     rx_status, tx_status = read_jesd_status(shell, rx_glob, tx_glob)
     suffix = f" ({context})" if context else ""
-    assert "Link status: DATA" in rx_status, (
-        f"RX JESD link not in DATA{suffix}:\n{rx_status}"
+    rx_data = rx_status.count("Link status: DATA")
+    tx_data = tx_status.count("Link status: DATA")
+    assert rx_data >= expected_rx_links, (
+        f"Expected {expected_rx_links} RX JESD link(s) in DATA{suffix}, "
+        f"found {rx_data}:\n{rx_status}"
     )
-    assert "Link status: DATA" in tx_status, (
-        f"TX JESD link not in DATA{suffix}:\n{tx_status}"
+    assert tx_data >= expected_tx_links, (
+        f"Expected {expected_tx_links} TX JESD link(s) in DATA{suffix}, "
+        f"found {tx_data}:\n{tx_status}"
     )
     return rx_status, tx_status
 

--- a/test/hw/test_adrv9371_zc706_hw.py
+++ b/test/hw/test_adrv9371_zc706_hw.py
@@ -19,11 +19,14 @@ LG_ENV: lg_adrv9371_zc706_tftp.yaml.
 
 from __future__ import annotations
 
+import copy
+from functools import cache
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from adidt.profiles import resolve_ad9371_jif_config
 from test.hw._system_base import (
     BoardSystemProfile,
     acquire_or_local_xsa,
@@ -34,22 +37,24 @@ from test.hw._system_base import (
 
 DEFAULT_KUIPER_RELEASE = "2023_R2_P1"
 DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv937x"
-DEFAULT_VCXO_HZ = 122_880_000
 PROFILE_PATH = (
     Path(__file__).parents[2]
     / "examples/xsa/profiles/ad9371_5/profile_TxBW200_ORxBW200_RxBW100.txt"
 )
 
 
-def _adrv9371_cfg() -> dict[str, Any]:
-    """ADRV9371+ZC706 XSA pipeline cfg.
+@cache
+def _solved_ad9371_config() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Solve the canonical profile once for this hardware-test process."""
+    return resolve_ad9371_jif_config(PROFILE_PATH, solve=True)
 
-    JESD framing matches the Kuiper reference
-    ``zynq-zc706-adv7511-adrv937x``: RX = M=4 L=2 S=1 → F=4;
-    TX = M=4 L=4 S=1 → F=2.
-    """
-    return {
-        "adrv9009_board": {
+
+def _adrv9371_cfg() -> dict[str, Any]:
+    """Return the real solved pyadi-jif configuration plus board wiring."""
+    cfg, _summary = _solved_ad9371_config()
+    cfg = copy.deepcopy(cfg)
+    cfg["adrv9009_board"].update(
+        {
             "misc_clk_hz": 122_880_000,
             "spi_bus": "spi0",
             "clk_cs": 0,
@@ -57,19 +62,12 @@ def _adrv9371_cfg() -> dict[str, Any]:
             "trx_reset_gpio": 106,
             "trx_sysref_req_gpio": 112,
             "ad9528_reset_gpio": 113,
-            "ad9528_vcxo_freq": DEFAULT_VCXO_HZ,
             "rx_link_id": 1,
+            "rx_os_link_id": 2,
             "tx_link_id": 0,
-            # Override the built-in hand-transcribed property list with the
-            # canonical profile parser under test.
-            "trx_profile_props": None,
-            "ad9371_profile_path": str(PROFILE_PATH),
-        },
-        "jesd": {
-            "rx": {"F": 4, "K": 32, "M": 4, "L": 2},
-            "tx": {"F": 2, "K": 32, "M": 4, "L": 4},
-        },
-    }
+        }
+    )
+    return cfg
 
 
 def _topology_assert(topology) -> None:
@@ -90,10 +88,15 @@ SPEC = BoardSystemProfile(
     kernel_fixture_name="built_kernel_image_zynq",
     out_label="adrv9371_xsa",
     dmesg_grep_pattern="ad9371|ad9528|jesd204|mykonos|probe|failed|error",
-    merged_dts_must_contain=('compatible = "adi,ad9371"',),
+    merged_dts_must_contain=(
+        'compatible = "adi,ad9371"',
+        'compatible = "adi,axi-ad9371-obs-1.0"',
+    ),
     probe_signature_any=("ad9371", "mykonos"),
     probe_signature_message="AD9371 driver probe signature not found in dmesg",
     iio_required_all=("ad9371-phy", "ad9528-1"),
+    expected_rx_jesd_links=2,
+    rx_capture_target_names=("axi-ad9371-rx-hpc", "ad_ip_jesd204_tpl_adc"),
 )
 
 
@@ -108,6 +111,16 @@ def test_adrv9371_zc706_xsa_hw(board, tmp_path, request):
         read_jesd_status,
         shell_out,
     )
+
+    cfg, solver_summary = _solved_ad9371_config()
+    assert solver_summary["solver_succeeded"] is True
+    clocks = solver_summary["clock_output_clocks"]
+    assert clocks["adc_sysref"]["rate"] == clocks["obs_sysref"]["rate"]
+    assert clocks["obs_sysref"]["rate"] == clocks["dac_sysref"]["rate"]
+    assert {cfg[name]["type"] for name in ("fpga_adc", "fpga_obs", "fpga_dac")} == {
+        "qpll"
+    }
+    print(f"pyadi-jif solved clock outputs: {clocks}")
 
     shell, _ctx, dmesg_txt = run_xsa_boot_and_verify(
         SPEC, board=board, request=request, tmp_path=tmp_path
@@ -126,7 +139,9 @@ def test_adrv9371_zc706_xsa_hw(board, tmp_path, request):
         for name in ilas_report.fields:
             print(f"  mismatched: {name}")
     assert_ilas_aligned(dmesg_txt, context="adrv9371_xsa")
-    assert_jesd_links_data(shell, context="adrv9371_xsa")
+    assert_jesd_links_data(
+        shell, context="adrv9371_xsa", expected_rx_links=2
+    )
 
     # HDL compile-time framing — TPL descriptor registers.
     # Descriptor 1 @ +0x240: [31:24]=F, [23:16]=S, [15:8]=L, [7:0]=M

--- a/test/hw/xsa/_overlay_base.py
+++ b/test/hw/xsa/_overlay_base.py
@@ -283,7 +283,12 @@ def test_load_overlay(overlay_spec, booted_board, tmp_path):
     ctx, _ = open_iio_context(shell)
     _assert_iio_devices_present(spec, ctx, context="after overlay load")
 
-    rx_status, tx_status = assert_jesd_links_data(shell, context="after overlay load")
+    rx_status, tx_status = assert_jesd_links_data(
+        shell,
+        context="after overlay load",
+        expected_rx_links=spec.expected_rx_jesd_links,
+        expected_tx_links=spec.expected_tx_jesd_links,
+    )
     print(f"$ cat .../*.axi?jesd204?rx/status\n{rx_status}")
     print(f"$ cat .../*.axi?jesd204?tx/status\n{tx_status}")
 
@@ -311,7 +316,12 @@ def test_dma_loopback(overlay_spec, booted_board, tmp_path):
     if spec.pre_capture_hook is not None:
         did_something = spec.pre_capture_hook(shell, tmp_path)
         if did_something:
-            assert_jesd_links_data(shell, context="after pre-capture hook")
+            assert_jesd_links_data(
+                shell,
+                context="after pre-capture hook",
+                expected_rx_links=spec.expected_rx_jesd_links,
+                expected_tx_links=spec.expected_tx_jesd_links,
+            )
         else:
             print(
                 f"{spec.skip_reason_label}: pre-capture hook found nothing to "
@@ -391,4 +401,9 @@ def test_reload_overlay(overlay_spec, booted_board):
     _apply_and_wait(shell, spec)
     ctx, _ = open_iio_context(shell)
     _assert_iio_devices_present(spec, ctx, context="after overlay reload")
-    assert_jesd_links_data(shell, context="after overlay reload")
+    assert_jesd_links_data(
+        shell,
+        context="after overlay reload",
+        expected_rx_links=spec.expected_rx_jesd_links,
+        expected_tx_links=spec.expected_tx_jesd_links,
+    )

--- a/test/hw/xsa/_overlay_spec.py
+++ b/test/hw/xsa/_overlay_spec.py
@@ -90,6 +90,8 @@ class BoardOverlayProfile:
     iio_required_all: tuple[str, ...] = ()
     iio_required_any: tuple[str, ...] = ()
     iio_frontend_label: str = "RX frontend"
+    expected_rx_jesd_links: int = 1
+    expected_tx_jesd_links: int = 1
 
     dmesg_filter: DmesgFilter = _identity
 
@@ -134,6 +136,7 @@ def local_xsa_or_skip(*candidate_filenames: str) -> XsaResolver:
             for parent in (here, here / "ref_data")
         )
         pytest.skip(f"XSA fixture missing — looked at: {searched}")
+        raise AssertionError("pytest.skip returned unexpectedly")  # pragma: no cover
 
     return _resolver
 

--- a/test/hw/xsa/test_adrv9371_zc706_overlay.py
+++ b/test/hw/xsa/test_adrv9371_zc706_overlay.py
@@ -35,10 +35,14 @@ LG_ENV: fetch the coordinator-generated env for place ``bq`` (e.g.
 
 from __future__ import annotations
 
+import copy
+from functools import cache
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+from adidt.profiles import resolve_ad9371_jif_config
 from test.hw.hw_helpers import check_jesd_framing_plausibility, shell_out
 from test.hw.xsa._overlay_base import (  # noqa: F401 — pytest collects these
     booted_board,
@@ -56,7 +60,15 @@ from test.hw.xsa._overlay_spec import BoardOverlayProfile, acquire_or_local_xsa
 
 DEFAULT_KUIPER_RELEASE = "2023_R2_P1"
 DEFAULT_KUIPER_PROJECT = "zynq-zc706-adv7511-adrv937x"
-DEFAULT_VCXO_HZ = 122_880_000
+PROFILE_PATH = (
+    Path(__file__).parents[3]
+    / "examples/xsa/profiles/ad9371_5/profile_TxBW200_ORxBW200_RxBW100.txt"
+)
+
+
+@cache
+def _solved_ad9371_config() -> tuple[dict[str, Any], dict[str, Any]]:
+    return resolve_ad9371_jif_config(PROFILE_PATH, solve=True)
 
 
 def _adrv9371_cfg() -> dict[str, Any]:
@@ -72,8 +84,10 @@ def _adrv9371_cfg() -> dict[str, Any]:
     TX = M=4 L=4 S=1 → F=2.  Mykonos profile properties come from
     ``adidt/xsa/config/profiles/adrv937x_zc706.json``.
     """
-    cfg: dict[str, Any] = {
-        "adrv9009_board": {
+    cfg, _summary = _solved_ad9371_config()
+    cfg = copy.deepcopy(cfg)
+    cfg["adrv9009_board"].update(
+        {
             "misc_clk_hz": 122_880_000,
             "spi_bus": "spi0",
             "clk_cs": 0,
@@ -81,15 +95,11 @@ def _adrv9371_cfg() -> dict[str, Any]:
             "trx_reset_gpio": 106,
             "trx_sysref_req_gpio": 112,
             "ad9528_reset_gpio": 113,
-            "ad9528_vcxo_freq": DEFAULT_VCXO_HZ,
             "rx_link_id": 1,
+            "rx_os_link_id": 2,
             "tx_link_id": 0,
-        },
-        "jesd": {
-            "rx": {"F": 4, "K": 32, "M": 4, "L": 2},
-            "tx": {"F": 2, "K": 32, "M": 4, "L": 4},
-        },
-    }
+        }
+    )
     framing_warnings = check_jesd_framing_plausibility(cfg["jesd"])
     assert not framing_warnings, (
         "JESD cfg is structurally inconsistent (will fail ILAS):\n  "
@@ -164,6 +174,7 @@ SPEC = BoardOverlayProfile(
     iio_required_all=("ad9528-1", "ad9371-phy"),
     iio_required_any=("axi-ad9371-rx-hpc", "ad_ip_jesd204_tpl_adc"),
     iio_frontend_label="AD9371 RX frontend",
+    expected_rx_jesd_links=2,
     fft_mode="optional",
     capture_target_names=("axi-ad9371-rx-hpc", "ad_ip_jesd204_tpl_adc"),
     pyadi_class_name="adrv9371",

--- a/test/test_hardware_ci_contract.py
+++ b/test/test_hardware_ci_contract.py
@@ -21,10 +21,23 @@ def test_hardware_venv_installs_and_exposes_sdtgen():
     assert "hasattr(adijif, 'ad9371')" in installer
     assert "/tools/Xilinx/2025.1/Vivado/bin/sdtgen" in installer
     assert "source .github/scripts/prepare-hardware-env.sh" in workflow
-    assert 'test/hw/xsa -maxdepth 1 -type f -name "test_*${BOARD}*${CARRIER}*_overlay.py"' in workflow
+    assert (
+        'test/hw/xsa -maxdepth 1 -type f -name '
+        '"test_*${BOARD}*${CARRIER}*_overlay.py"' in workflow
+    )
     assert '[[ "$entry" == "$HOME/.local/bin" ]] && continue' in environment
     assert 'export PATH="$VENV_DIR/bin:/usr/bin' in environment
     assert '"$(command -v as)" != "/usr/bin/as"' in environment
+
+
+def test_labgrid_plugins_dependency_is_immutable() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text()
+
+    assert (
+        "labgrid-plugins[kuiper] @ git+https://github.com/tfcollins/"
+        "labgrid-plugins.git@d21e5a94b4eebd3bedeb7cd16cd12504b11b5aba"
+        in pyproject
+    )
 
 
 def test_missing_hardware_prerequisite_fails_in_coordinator_mode(monkeypatch):

--- a/test/test_hardware_ci_contract.py
+++ b/test/test_hardware_ci_contract.py
@@ -17,8 +17,11 @@ def test_hardware_venv_installs_and_exposes_sdtgen():
 
     assert '"adidt[test,xsa]"' in pyproject
     assert '"$VENV/bin/sdtgen" -help' in installer
+    assert "requirements/pyadi-jif-ad9371.txt" in installer
+    assert "hasattr(adijif, 'ad9371')" in installer
     assert "/tools/Xilinx/2025.1/Vivado/bin/sdtgen" in installer
     assert "source .github/scripts/prepare-hardware-env.sh" in workflow
+    assert 'test/hw/xsa -maxdepth 1 -type f -name "test_*${BOARD}*${CARRIER}*_overlay.py"' in workflow
     assert '[[ "$entry" == "$HOME/.local/bin" ]] && continue' in environment
     assert 'export PATH="$VENV_DIR/bin:/usr/bin' in environment
     assert '"$(command -v as)" != "/usr/bin/as"' in environment

--- a/test/test_hw_helpers.py
+++ b/test/test_hw_helpers.py
@@ -16,9 +16,11 @@ import pytest
 # Ensure a skip-gating env var doesn't fire accidentally here.
 os.environ.setdefault("LG_ENV", "unit-test-noop")
 
+import test.hw.hw_helpers as hw_helpers  # noqa: E402
 from test.hw.hw_helpers import (  # noqa: E402
     IlasMismatch,
     assert_ilas_aligned,
+    assert_jesd_links_data,
     check_jesd_framing_plausibility,
     parse_ilas_status,
 )
@@ -109,9 +111,10 @@ def test_assert_ilas_aligned_raises_on_mismatch():
 
 
 def test_check_jesd_framing_plausibility_adrv9371_hdl_defaults():
-    # Documented HDL default: RX M=4 L=2 F=4, TX M=4 L=4 F=2, Np=16.
+    # Documented HDL defaults include the independent observation path.
     cfg = {
         "rx": {"F": 4, "K": 32, "M": 4, "L": 2},
+        "obs": {"F": 2, "K": 32, "M": 2, "L": 2},
         "tx": {"F": 2, "K": 32, "M": 4, "L": 4},
     }
     assert check_jesd_framing_plausibility(cfg) == []
@@ -125,6 +128,13 @@ def test_check_jesd_framing_plausibility_detects_typo():
     assert "jesd.tx" in warnings[0]
     assert "F=1" in warnings[0]
     assert "= 2" in warnings[0]
+
+
+def test_check_jesd_framing_plausibility_checks_observation_path():
+    cfg = {"obs": {"F": 4, "K": 32, "M": 2, "L": 2}}
+    warnings = check_jesd_framing_plausibility(cfg)
+    assert len(warnings) == 1
+    assert "jesd.obs" in warnings[0]
 
 
 def test_check_jesd_framing_plausibility_skips_missing_fields():
@@ -145,3 +155,30 @@ def test_ilas_mismatch_summary_omits_none_fields():
     assert "fields=[x]" in report.summary()
     assert "deframerStatus" not in report.summary()
     assert "mask" not in report.summary()
+
+
+def test_assert_jesd_links_data_requires_every_expected_rx(monkeypatch):
+    monkeypatch.setattr(
+        hw_helpers,
+        "read_jesd_status",
+        lambda *_args, **_kwargs: (
+            "Link status: DATA\nLink status: disabled\n",
+            "Link status: DATA\n",
+        ),
+    )
+
+    with pytest.raises(AssertionError, match="Expected 2 RX JESD link"):
+        assert_jesd_links_data(object(), expected_rx_links=2)
+
+
+def test_assert_jesd_links_data_accepts_primary_and_observation_rx(monkeypatch):
+    monkeypatch.setattr(
+        hw_helpers,
+        "read_jesd_status",
+        lambda *_args, **_kwargs: (
+            "Link status: DATA\nLink status: DATA\n",
+            "Link status: DATA\n",
+        ),
+    )
+
+    assert_jesd_links_data(object(), expected_rx_links=2)

--- a/test/test_hw_helpers.py
+++ b/test/test_hw_helpers.py
@@ -23,6 +23,7 @@ from test.hw.hw_helpers import (  # noqa: E402
     assert_jesd_links_data,
     check_jesd_framing_plausibility,
     parse_ilas_status,
+    read_jesd_status,
 )
 
 
@@ -182,3 +183,20 @@ def test_assert_jesd_links_data_accepts_primary_and_observation_rx(monkeypatch):
     )
 
     assert_jesd_links_data(object(), expected_rx_links=2)
+
+
+def test_read_jesd_status_does_not_truncate_multi_link_output():
+    class FakeShell:
+        def __init__(self):
+            self.commands = []
+
+        def run(self, command):
+            self.commands.append(command)
+            return (["Link status: DATA", "Link status: DATA"], [], 0)
+
+    shell = FakeShell()
+    rx_status, _tx_status = read_jesd_status(shell)
+
+    assert rx_status.count("Link status: DATA") == 2
+    assert all("head -n" not in command for command in shell.commands)
+    assert all('echo "=== $f ==="' in command for command in shell.commands)

--- a/test/xsa/test_example_adrv937x_zc706.py
+++ b/test/xsa/test_example_adrv937x_zc706.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+from adidt.profiles import resolve_ad9371_jif_config
 
 ROOT = Path(__file__).parents[2]
 EXAMPLE = ROOT / "examples" / "xsa" / "adrv937x_zc706.py"
@@ -22,14 +23,6 @@ PROFILE = (
 )
 
 
-def _load_example():
-    spec = importlib.util.spec_from_file_location("adrv937x_zc706_example", EXAMPLE)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
 def _require_new_adijif() -> None:
     import adijif
 
@@ -40,9 +33,7 @@ def _require_new_adijif() -> None:
 def test_ad9371_profile_drives_all_mykonos_links() -> None:
     """The new pyadi-jif model must replace the old hard-coded framing."""
     _require_new_adijif()
-    module = _load_example()
-
-    cfg, summary = module._resolve_config_from_adijif(PROFILE, solve=False)
+    cfg, summary = resolve_ad9371_jif_config(PROFILE, solve=False)
 
     assert cfg["jesd"]["rx"] == {
         "F": 4,
@@ -88,9 +79,8 @@ def test_ad9371_profile_drives_all_mykonos_links() -> None:
 def test_ad9371_profile_can_be_solved_with_shared_sysref() -> None:
     """Exercise the corrected three-link solver result when CPLEX is available."""
     _require_new_adijif()
-    module = _load_example()
     try:
-        cfg, summary = module._resolve_config_from_adijif(PROFILE, solve=True)
+        cfg, summary = resolve_ad9371_jif_config(PROFILE, solve=True)
     except Exception as exc:
         if "CPLEX" in str(exc) or "docplex" in str(exc):
             pytest.skip(f"CPLEX unavailable: {exc}")


### PR DESCRIPTION
## Summary
- share the corrected AD9371 pyadi-jif resolver between the example and hardware tests
- execute the real pinned CPLEX solve in AD9371 full-DTB and runtime-overlay hardware paths
- require both primary and observation RX JESD cores in DATA and add a real buffered RX capture
- install and verify the reviewed AD9371-capable pyadi-jif revision on hardware runners
- collect existing runtime-overlay suites in the four-board hardware matrix
- validate observation-link framing in software preflight

## Local verification
- `pytest -q`: 766 passed, 19 skipped, 4 xfailed
- clean Python 3.12 pinned-dependency install + focused tests: 20 passed
- Ruff: passed
- targeted `ty`: passed
- Actionlint: passed
- Bash syntax and `git diff --check`: passed

## Hardware plan
The `hw-test` label should run all four physical places. For AD9371/ZC706, acceptance requires the real solve, generated full DT boot, both RX links + TX in DATA, nonzero varying RX capture, and the runtime overlay load/capture/unload/reload lifecycle.
